### PR TITLE
DOCTYPE entities interfering with hover annotation display of tags / attributes

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/model/ContentModelManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/model/ContentModelManager.java
@@ -130,6 +130,7 @@ public class ContentModelManager {
 			namespaceURI = xmlDocument.getNamespaceURI();
 		}
 		Collection<CMDocument> documents = new ArrayList<>();
+		boolean findByStandardAssociation = false;
 		for (ContentModelProvider modelProvider : modelProviders) {
 			// internal grammar
 			if (withInternal) {
@@ -152,12 +153,17 @@ public class ContentModelManager {
 					CMDocument cmDocument = findCMDocument(xmlDocument.getDocumentURI(), publicId, systemId,
 							modelProvider);
 					if (cmDocument != null) {
+						findByStandardAssociation = true;
 						documents.add(cmDocument);
 					}
 				}
 			}
 		}
-		if (documents.isEmpty()) {
+		if (!findByStandardAssociation) {
+			// - find the XSD / DTD via file association from a XML file
+			// - find the XSD / DTD via XML catalog from a XML file
+			// - find the XMLSchema (xml.xsd) schema from a XSD file
+			// - find the XMLSchema (xml.xsd), xslt*.xsd schema from a XSL file
 			CMDocument cmDocument = findCMDocument(xmlDocument.getDocumentURI(), namespaceURI, null, null);
 			if (cmDocument != null) {
 				documents.add(cmDocument);

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLFileAssociationsCompletionTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLFileAssociationsCompletionTest.java
@@ -146,6 +146,24 @@ public class XMLFileAssociationsCompletionTest {
 				c("parent", "<parent></parent>", "<parent"));
 	}
 
+	@Test
+	public void completionWithXSDAndDocType() throws BadLocationException {
+		Consumer<XMLLanguageService> configuration = ls -> {
+			ContentModelManager contentModelManager = ls.getComponent(ContentModelManager.class);
+			contentModelManager.setFileAssociations(createXSDAssociationsSchemaLocationLike("src/test/resources/xsd/"));
+		};
+		// completion on <|
+		String xml = "<!DOCTYPE opt [\r\n" + //
+				"  <!ENTITY size \"short\">\r\n" + //
+				"]>\r\n" + //
+				"<project xmlns=\"http://maven.apache.org/POM/4.0.0\"\r\n>\r\n" + //
+				"	<|" + //
+				"</project>";
+		testCompletionFor(xml, "file:///test/pom.xml", configuration, //
+				c("modelVersion", te(5, 1, 5, 2, "<modelVersion></modelVersion>"), "<modelVersion"), //
+				c("parent", "<parent></parent>", "<parent"));
+	}
+
 	private static XMLFileAssociation[] createXSDAssociationsSchemaLocationLike(String baseSystemId) {
 		XMLFileAssociation maven = new XMLFileAssociation();
 		maven.setPattern("**/pom.xml");

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLFileAssociationsHoverTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLFileAssociationsHoverTest.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.contentmodel;
+
+import static org.eclipse.lemminx.XMLAssert.r;
+
+import org.apache.xerces.impl.XMLEntityManager;
+import org.apache.xerces.util.URI.MalformedURIException;
+import org.eclipse.lemminx.XMLAssert;
+import org.eclipse.lemminx.commons.BadLocationException;
+import org.eclipse.lemminx.extensions.contentmodel.settings.ContentModelSettings;
+import org.eclipse.lemminx.extensions.contentmodel.settings.XMLFileAssociation;
+import org.eclipse.lemminx.services.XMLLanguageService;
+import org.eclipse.lsp4j.Range;
+import org.junit.jupiter.api.Test;
+
+/**
+ * XML hover tests with file association.
+ *
+ */
+public class XMLFileAssociationsHoverTest {
+
+	@Test
+	public void hoverBasedOnXSDWithFileAssociation() throws BadLocationException, MalformedURIException {
+		ContentModelSettings modelSettings = new ContentModelSettings();
+		modelSettings.setFileAssociations(createXSDAssociationsSchemaLocationLike("src/test/resources/xsd/"));
+
+		String schemaURI = getXMLSchemaFileURI("maven-4.0.0.xsd");
+		String xml = "<pro|ject xmlns=\"http://maven.apache.org/POM/4.0.0\"\r\n>\r\n" + //
+				"</project>";
+		assertHover(xml, "file:///test/pom.xml", modelSettings, "3.0.0+" + //
+				System.lineSeparator() + //
+				System.lineSeparator() + //
+				"The `<project>` element is the root of the descriptor. The following table lists all of the possible child elements."
+				+ //
+				System.lineSeparator() + //
+				System.lineSeparator() + //
+				"Source: [maven-4.0.0.xsd](" + schemaURI + ")", r(0, 1, 0, 8));
+	}
+
+	@Test
+	public void hoverBasedOnXSDWithFileAssociationAndDocType() throws BadLocationException, MalformedURIException {
+		ContentModelSettings modelSettings = new ContentModelSettings();
+		modelSettings.setFileAssociations(createXSDAssociationsSchemaLocationLike("src/test/resources/xsd/"));
+
+		String schemaURI = getXMLSchemaFileURI("maven-4.0.0.xsd");
+		String xml = "<!DOCTYPE opt [\r\n" + //
+				"  <!ENTITY size \"short\">\r\n" + //
+				"]>\r\n" + //
+				"<pro|ject xmlns=\"http://maven.apache.org/POM/4.0.0\"\r\n>\r\n" + //
+				"</project>";
+		assertHover(xml, "file:///test/pom.xml", modelSettings, "3.0.0+" + //
+				System.lineSeparator() + //
+				System.lineSeparator() + //
+				"The `<project>` element is the root of the descriptor. The following table lists all of the possible child elements."
+				+ //
+				System.lineSeparator() + //
+				System.lineSeparator() + //
+				"Source: [maven-4.0.0.xsd](" + schemaURI + ")", r(3, 1, 3, 8));
+	}
+
+	private static XMLFileAssociation[] createXSDAssociationsSchemaLocationLike(String baseSystemId) {
+		XMLFileAssociation maven = new XMLFileAssociation();
+		maven.setPattern("**/pom.xml");
+		maven.setSystemId(baseSystemId + "maven-4.0.0.xsd");
+		return new XMLFileAssociation[] { maven };
+	}
+
+	private static void assertHover(String value, String fileURI, ContentModelSettings modelSettings,
+			String expectedHoverLabel, Range expectedHoverRange) throws BadLocationException {
+		XMLAssert.assertHover(new XMLLanguageService(), value, null, fileURI, expectedHoverLabel, expectedHoverRange,
+				modelSettings);
+	}
+
+	private static String getXMLSchemaFileURI(String schemaURI) throws MalformedURIException {
+		return XMLEntityManager.expandSystemId("xsd/" + schemaURI, "src/test/resources/test.xml", true).replace("///",
+				"/");
+	}
+
+}


### PR DESCRIPTION
DOCTYPE entities interfering with hover annotation display of tags / attributes.

Fixes https://github.com/redhat-developer/vscode-xml/issues/716

Signed-off-by: azerr <azerr@redhat.com>