### PR TITLE
Supports TextDocumentContentChangeEvent#getRangeLength with null value

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/TextDocument.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/TextDocument.java
@@ -179,7 +179,8 @@ public class TextDocument extends TextDocumentItem {
 						int length = 0;
 
 						if (range != null) {
-							length = offsetAt(range.getEnd()) - offsetAt(range.getStart());
+							Integer rangeLength = changeEvent.getRangeLength();
+							length = rangeLength != null ? rangeLength.intValue() : offsetAt(range.getEnd()) - offsetAt(range.getStart());
 						} else {
 							// range is optional and if not given, the whole file content is replaced
 							length = buffer.length();

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/TextDocument.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/TextDocument.java
@@ -179,7 +179,7 @@ public class TextDocument extends TextDocumentItem {
 						int length = 0;
 
 						if (range != null) {
-							length = changeEvent.getRangeLength().intValue();
+							length = offsetAt(range.getEnd()) - offsetAt(range.getStart());
 						} else {
 							// range is optional and if not given, the whole file content is replaced
 							length = buffer.length();

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/commons/IncrementalParsingTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/commons/IncrementalParsingTest.java
@@ -114,6 +114,55 @@ public class IncrementalParsingTest {
 	}
 
 	@Test
+	public void testRangeLengthCalculatedFromRange() {
+		String text = "<aaa>\r\n" + //
+				"  <b/>\r\n" + //
+				"</aaa>\r\n";
+
+		String expectedText = "<aaa/>\r\n";
+
+		TextDocument document = new TextDocument(text, "uri");
+		document.setIncremental(true);
+
+		Range range1 = new Range(new Position(0, 4), new Position(2, 5));
+		TextDocumentContentChangeEvent change1 = new TextDocumentContentChangeEvent(range1, 123456, "/");
+
+		ArrayList<TextDocumentContentChangeEvent> changes = new ArrayList<>();
+		changes.add(change1);
+
+		document.update(changes);
+
+		assertEquals(expectedText, document.getText());
+	}
+
+	// https://github.com/eclipse-lemminx/lemminx/issues/1674
+	@Test
+	public void testDeprecatedRangeLengthAllowsNull() {
+		String text = "<zzz>\r\n" + // /// <-- inserting 'a' in tag name
+				"  <b>\r\n" + //
+				"  </b>\r\n" + //
+				"</aaa>\r\n";
+
+		String expectedText = "<aaa>\r\n" + // /// <-- inserted 'a' in tag name
+				"  <b>\r\n" + //
+				"  </b>\r\n" + //
+				"</aaa>\r\n";
+
+		TextDocument document = new TextDocument(text, "uri");
+		document.setIncremental(true);
+
+		Range range1 = new Range(new Position(0, 1), new Position(0, 4));
+		TextDocumentContentChangeEvent change1 = new TextDocumentContentChangeEvent(range1, null, "aaa");
+
+		ArrayList<TextDocumentContentChangeEvent> changes = new ArrayList<>();
+		changes.add(change1);
+
+		document.update(changes);
+
+		assertEquals(expectedText, document.getText());
+	}
+
+	@Test
 	public void testBasicChangeMultipleChanges() {
 		String text = "<>\r\n" + // // <-- inserting 'a' in tag name
 				"  <b>\r\n" + //

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/commons/IncrementalParsingTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/commons/IncrementalParsingTest.java
@@ -114,30 +114,7 @@ public class IncrementalParsingTest {
 	}
 
 	@Test
-	public void testRangeLengthCalculatedFromRange() {
-		String text = "<aaa>\r\n" + //
-				"  <b/>\r\n" + //
-				"</aaa>\r\n";
-
-		String expectedText = "<aaa/>\r\n";
-
-		TextDocument document = new TextDocument(text, "uri");
-		document.setIncremental(true);
-
-		Range range1 = new Range(new Position(0, 4), new Position(2, 5));
-		TextDocumentContentChangeEvent change1 = new TextDocumentContentChangeEvent(range1, 123456, "/");
-
-		ArrayList<TextDocumentContentChangeEvent> changes = new ArrayList<>();
-		changes.add(change1);
-
-		document.update(changes);
-
-		assertEquals(expectedText, document.getText());
-	}
-
-	// https://github.com/eclipse-lemminx/lemminx/issues/1674
-	@Test
-	public void testDeprecatedRangeLengthAllowsNull() {
+	public void testRangeLengthPreferredOverRangeEndPosition() {
 		String text = "<zzz>\r\n" + // /// <-- inserting 'a' in tag name
 				"  <b>\r\n" + //
 				"  </b>\r\n" + //
@@ -151,8 +128,31 @@ public class IncrementalParsingTest {
 		TextDocument document = new TextDocument(text, "uri");
 		document.setIncremental(true);
 
-		Range range1 = new Range(new Position(0, 1), new Position(0, 4));
-		TextDocumentContentChangeEvent change1 = new TextDocumentContentChangeEvent(range1, null, "aaa");
+		Range range1 = new Range(new Position(0, 1), new Position(-1, -1));
+		TextDocumentContentChangeEvent change1 = new TextDocumentContentChangeEvent(range1, 3, "aaa");
+
+		ArrayList<TextDocumentContentChangeEvent> changes = new ArrayList<>();
+		changes.add(change1);
+
+		document.update(changes);
+
+		assertEquals(expectedText, document.getText());
+	}
+
+	// https://github.com/eclipse-lemminx/lemminx/issues/1674
+	@Test
+	public void testDeprecatedRangeLengthAllowsNull() {
+		String text = "<aaa>\r\n" + //
+				"  <b/>\r\n" + //
+				"</aaa>\r\n";
+
+		String expectedText = "<aaa/>\r\n";
+
+		TextDocument document = new TextDocument(text, "uri");
+		document.setIncremental(true);
+
+		Range range1 = new Range(new Position(0, 4), new Position(2, 5));
+		TextDocumentContentChangeEvent change1 = new TextDocumentContentChangeEvent(range1, null, "/");
 
 		ArrayList<TextDocumentContentChangeEvent> changes = new ArrayList<>();
 		changes.add(change1);


### PR DESCRIPTION
Fixes #1674.

Removes the usage of the deprecated `TextDocumentContentChangeEvent.rangeLength`. The length of the range is now calculated from the `TextDocumentContentChangeEvent.range` instead, which should produce the same result.

This fixes a NullPointerException that happened when the LSP client didn't set the `rangeLength` (which is allowed according to the [LSP specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentContentChangeEvent)).