### PR TITLE
Make CacheResourcesManager Constructor used for test package protected

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/uriresolver/CacheResourcesManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/uriresolver/CacheResourcesManager.java
@@ -144,7 +144,7 @@ public class CacheResourcesManager {
 		this(CacheBuilder.newBuilder().maximumSize(100).expireAfterWrite(30, TimeUnit.SECONDS).build());
 	}
 
-	public CacheResourcesManager(Cache<String, CacheResourceDownloadedException> cache) {
+	CacheResourcesManager(Cache<String, CacheResourceDownloadedException> cache) {
 		resourcesLoading = new HashMap<>();
 		protocolsForCache = new HashSet<>();
 		unavailableURICache = cache;


### PR DESCRIPTION
It looks like the CacheResourcesManager(Cache cache) constructor is oly used for test, so this is made package protected now.

This has the advantage that there is no public reference to google Cache API making it an internal implementation detail that can easily be exchanged (or embedded).