### PR TITLE
Add basic OSGi metadata to the uber-jar

### DIFF
--- a/org.eclipse.lemminx/pom.xml
+++ b/org.eclipse.lemminx/pom.xml
@@ -78,7 +78,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>3.3.0</version>
 				<executions>
 					<execution>
 						<goals>
@@ -113,6 +112,15 @@
 						<manifest>
 							<mainClass>org.eclipse.lemminx.XMLServerLauncher</mainClass>
 						</manifest>
+						<manifestEntries>
+							<Bundle-ManifestVersion>2</Bundle-ManifestVersion>
+							<Bundle-SymbolicName>org.eclipse.lemminx.uber-jar</Bundle-SymbolicName>
+							<Bundle-ActivationPolicy>lazy</Bundle-ActivationPolicy>
+							<Bundle-Version>${parsedVersion.osgiVersion}</Bundle-Version>
+							<Bundle-Vendor>Eclipse.org</Bundle-Vendor>
+							<Bundle-Name>lemminx uber jar bundle</Bundle-Name>
+							<Service-Component>OSGI-INF/*.xml</Service-Component>
+						</manifestEntries>
 					</archive>
 				</configuration>
 				<executions>


### PR DESCRIPTION
Currently the uber-jar is a plain jar and therefore needs to be either wrapped or embedded when using inside OSGi.

This now adds very basic OSGi meta-data so it can be used inside OSGi, possible use-cases are:

- fetch it bundle location and start lemminx as a CLI process
- create fragments of the host that export packages, import additional packages or provide extensions
- create a fragment that provides a [Declarative-Service-Component](https://docs.osgi.org/specification/osgi.cmpn/7.0.0/service.component.html#d0e38069) to provide services to other parts of the system
- ...

@mickaelistria this should make it possible to extract it from WWD as a very first basic step.