### PR TITLE
Update binary documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ socket.connect(socketPort)
 Generating a native binary:
 ---------------------------------
 To generate a native binary:
-- [Install GraalVM 20.2.0](https://www.graalvm.org/docs/getting-started/#install-graalvm)
-- In a terminal, run `gu install native-image`
+- [Install GraalVM](https://www.graalvm.org/docs/getting-started/#install-graalvm),
+  ideally with a tool that allows setting up multiple versions of Java, such as SDKMAN
 - Execute a Maven build that sets the flag `native`: `./mvnw clean package -Dnative -DskipTests`
   - On Linux, compile with `./mvnw clean package -Dnative -DskipTests -Dgraalvm.static=--static`
     in order to support distributions that don't use `glibc`, such as Alpine Linux
@@ -80,8 +80,6 @@ OS specific instructions:
   - Make sure that you have installed the static versions of the C++ standard library
     - For instance, on Fedora Linux, install `glibc-static`, `libstdc++-static`, and `zlib-static`
 - __Windows__:
-  - When installing native-image, please note that `gu` is an existing alias in PowerShell.
-  Remove the alias with `Remove-Item alias:gu -Force`, refer to `gu` with the absolute path, or use `gu` under `cmd.exe`.
   - Make sure to run the Maven wrapper in the "Native Tools Command Prompt".
   This command prompt can be obtained through installing the Windows SDK or Visual Studio, as
   mentioned in the [GraalVM installation instructions](https://www.graalvm.org/docs/getting-started-with-graalvm/windows/).


### PR DESCRIPTION
- Do not specify the version of GraalVM to use, since it's likely that the latest GraalVM works, and the lifecycle of GraalVM versions means any version we list will likely be out of date shortly.
- Remove instructions to use `gu install native-image`, because in newer versions of GraalVM, `gu` is no longer included and `native-image` is included by default

Fixes #1722