### PR TITLE
handle attribute with text equal to single quote (i.e. ")

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMNode.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMNode.java
@@ -392,7 +392,9 @@ public abstract class DOMNode implements Node, DOMRange {
 		// remove quote
 		char c = value.charAt(0);
 		if (c == '"' || c == '\'') {
-			if (value.charAt(value.length() - 1) == c) {
+			if (value.length() == 1) {
+				return value;
+			} else if (value.charAt(value.length() - 1) == c) {
 				return value.substring(1, value.length() - 1);
 			}
 			return value.substring(1, value.length());

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/dom/DOMDocumentTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/dom/DOMDocumentTest.java
@@ -252,4 +252,10 @@ public class DOMDocumentTest {
 		assertEquals("http://camel.apache.org/schema/spring", camel.getNamespaceURI());
 
 	}
+
+	@Test
+	void findElementWithSingleQuoteValue() {
+		DOMDocument document = DOMParser.getInstance().parse("<ele attr='\"'/>", "test", null);
+		assertEquals("\"", document.getChild(0).getAttribute("attr"));
+	}
 }


### PR DESCRIPTION
Attribute method is not able to handle the string with a single quote. We trim the quotes from the string without checking its length, and it's causing an issue if string has only one character. e.g. val="