### PR TITLE
Use GraalVM CPU architecture compatibility mode

### DIFF
--- a/org.eclipse.lemminx/pom.xml
+++ b/org.eclipse.lemminx/pom.xml
@@ -176,6 +176,7 @@
 							<imageName>lemminx-${os.detected.classifier}-${project.version}</imageName>
 							<buildArgs>
 								--no-fallback
+								-march=compatibility
 								--enable-http
 								--enable-https
 								${graalvm.static}


### PR DESCRIPTION
This prevents GraalVM from using CPU architecture extensions (for example, AVX and AVX2 for x86_64). This will increase the portability of the binary (i.e. it can be run on older CPUs that don't support those instructions).

Docs for the setting: https://www.graalvm.org/latest/reference-manual/native-image/overview/Options/#build-options

See https://github.com/redhat-developer/vscode-xml/issues/1055