### PR TITLE
Check for dynamic registration in textDocument/typeDefinition and workspace/executeCommand

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/capabilities/ClientCapabilitiesWrapper.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/capabilities/ClientCapabilitiesWrapper.java
@@ -119,6 +119,10 @@ public class ClientCapabilitiesWrapper {
 		return v3Supported && isDynamicRegistrationSupported(capabilities.getWorkspace().getDidChangeWatchedFiles());
 	}
 
+    public boolean isExecuteCommandRegistered() {
+        return v3Supported && isDynamicRegistrationSupported(capabilities.getWorkspace().getExecuteCommand());
+    }
+
 	public boolean isLinkedEditingRangeDynamicRegistered() {
 		return v3Supported && isDynamicRegistrationSupported(getTextDocument().getLinkedEditingRange());
 	}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/capabilities/XMLCapabilityManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/capabilities/XMLCapabilityManager.java
@@ -176,7 +176,7 @@ public class XMLCapabilityManager {
 		if (this.getClientCapabilities().isDefinitionDynamicRegistered()) {
 			registerCapability(DEFINITION_ID, TEXT_DOCUMENT_DEFINITION);
 		}
-		if (this.getClientCapabilities().isDefinitionDynamicRegistered()) {
+		if (this.getClientCapabilities().isTypeDefinitionDynamicRegistered()) {
 			registerCapability(TYPEDEFINITION_ID, TEXT_DOCUMENT_TYPEDEFINITION);
 		}
 		if (this.getClientCapabilities().isReferencesDynamicRegistrationSupported()) {
@@ -203,8 +203,10 @@ public class XMLCapabilityManager {
 	}
 
 	public void registerExecuteCommand(List<String> commands) {
-		registerCapability(WORKSPACE_EXECUTE_COMMAND_ID, WORKSPACE_EXECUTE_COMMAND,
-				new ExecuteCommandOptions(commands));
+    if (this.getClientCapabilities().isExecuteCommandRegistered()) {
+      registerCapability(WORKSPACE_EXECUTE_COMMAND_ID, WORKSPACE_EXECUTE_COMMAND,
+          new ExecuteCommandOptions(commands));
+    }
 	}
 
 	/**


### PR DESCRIPTION
For #1142

This might not be all the capabilities which are erroneously registered, only the ones I've seen an error for (in my limited use). 

Seems to also fix a maven test, 6 fails down to 5. Not sure which one now passes though...