### PR TITLE
Do not format text content of `<style>` and `<script>`

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/XMLFormattingOptions.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/XMLFormattingOptions.java
@@ -54,7 +54,9 @@ public class XMLFormattingOptions extends org.eclipse.lemminx.settings.LSPFormat
 			"screen", //
 			"synopsis", //
 			"pre", //
-			"xd:pre");
+			"xd:pre", //
+			"style", //
+			"script");
 
 	private boolean legacy;
 	private int maxLineWidth;

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/wtp/TestPartitionFormatterXML.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/wtp/TestPartitionFormatterXML.java
@@ -165,6 +165,12 @@ public class TestPartitionFormatterXML {
 	}
 
 	@Test
+	public void testPreserveCDATAFormat3() throws Exception {
+		// <script> is treated specially, because it likely contains formatted source code
+		formatAndAssertEquals("testfiles/xml/usecdata3.xml", "testfiles/xml/usecdata3-fmt.xml");
+	}
+
+	@Test
 	@Disabled
 	public void testSplitAttributesFormat() throws Exception {
 		// BUG113584

--- a/org.eclipse.lemminx/src/test/resources/wtp/testfiles/xml/usecdata2-fmt.xml
+++ b/org.eclipse.lemminx/src/test/resources/wtp/testfiles/xml/usecdata2-fmt.xml
@@ -1,4 +1,4 @@
-<script>
+<script-code>
 	nospacebetweenmeandcdata<![CDATA[
 function matchwo(a,b)
 {
@@ -12,4 +12,4 @@ else
    }
 }
 ]]>nospacebetweenmeandcdata
-</script>
+</script-code>

--- a/org.eclipse.lemminx/src/test/resources/wtp/testfiles/xml/usecdata3-fmt.xml
+++ b/org.eclipse.lemminx/src/test/resources/wtp/testfiles/xml/usecdata3-fmt.xml
@@ -1,4 +1,4 @@
-<script-code>
+<script>
 nospacebetweenmeandcdata<![CDATA[
 function matchwo(a,b)
 {
@@ -12,4 +12,4 @@ else
    }
 }
 ]]>nospacebetweenmeandcdata
-</script-code>
+</script>

--- a/org.eclipse.lemminx/src/test/resources/wtp/testfiles/xml/usecdata3.xml
+++ b/org.eclipse.lemminx/src/test/resources/wtp/testfiles/xml/usecdata3.xml
@@ -1,4 +1,4 @@
-<script-code>
+<script>
 nospacebetweenmeandcdata<![CDATA[
 function matchwo(a,b)
 {
@@ -12,4 +12,4 @@ else
    }
 }
 ]]>nospacebetweenmeandcdata
-</script-code>
+</script>


### PR DESCRIPTION
`<style>` is usually used for CSS, and `<script>` is usually used for JavaScript (or some other scripting language). Given the user has probably manually formatted this code, we should avoid formatting the text content by default.