### PR TITLE
changes to upgrade lsp4j.version to 1.0.0

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/CodeActionFactory.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/CodeActionFactory.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionKind;
@@ -27,6 +28,7 @@ import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ResourceOperation;
+import org.eclipse.lsp4j.SnippetTextEdit;
 import org.eclipse.lsp4j.TextDocumentEdit;
 import org.eclipse.lsp4j.TextDocumentItem;
 import org.eclipse.lsp4j.TextEdit;
@@ -96,7 +98,10 @@ public class CodeActionFactory {
 	public static TextDocumentEdit insertEdits(TextDocumentItem document, List<TextEdit> edits) {
 		VersionedTextDocumentIdentifier versionedTextDocumentIdentifier = new VersionedTextDocumentIdentifier(
 				document.getUri(), document.getVersion());
-		return new TextDocumentEdit(versionedTextDocumentIdentifier, edits);
+		List<Either<TextEdit, SnippetTextEdit>> eitherEdits = edits.stream()
+				.map(Either::<TextEdit, SnippetTextEdit>forLeft)
+				.collect(Collectors.toList());
+		return new TextDocumentEdit(versionedTextDocumentIdentifier, eitherEdits);
 	}
 
 	public static CodeAction replace(String title, Range range, String replaceText, TextDocumentItem document,
@@ -114,7 +119,10 @@ public class CodeActionFactory {
 
 		VersionedTextDocumentIdentifier versionedTextDocumentIdentifier = new VersionedTextDocumentIdentifier(
 				document.getUri(), document.getVersion());
-		TextDocumentEdit textDocumentEdit = new TextDocumentEdit(versionedTextDocumentIdentifier, replace);
+		List<Either<TextEdit, SnippetTextEdit>> eitherEdits = replace.stream()
+				.map(Either::<TextEdit, SnippetTextEdit>forLeft)
+				.collect(Collectors.toList());
+		TextDocumentEdit textDocumentEdit = new TextDocumentEdit(versionedTextDocumentIdentifier, eitherEdits);
 		WorkspaceEdit workspaceEdit = new WorkspaceEdit(Collections.singletonList(Either.forLeft(textDocumentEdit)));
 		insertContentAction.setEdit(workspaceEdit);
 		return insertContentAction;
@@ -132,8 +140,9 @@ public class CodeActionFactory {
 		TextEdit replace = new TextEdit(range, replaceText);
 		VersionedTextDocumentIdentifier versionedTextDocumentIdentifier = new VersionedTextDocumentIdentifier(
 				document.getUri(), document.getVersion());
-		TextDocumentEdit textDocumentEdit = new TextDocumentEdit(versionedTextDocumentIdentifier,
-				Collections.singletonList(replace));
+		List<Either<TextEdit, SnippetTextEdit>> eitherEdits = Collections.singletonList(
+				Either.forLeft(replace));
+		TextDocumentEdit textDocumentEdit = new TextDocumentEdit(versionedTextDocumentIdentifier, eitherEdits);
 		return new WorkspaceEdit(Collections.singletonList(Either.forLeft(textDocumentEdit)));
 	}
 
@@ -150,7 +159,10 @@ public class CodeActionFactory {
 			TextEdit edit = new TextEdit(range, replaceText);
 			edits.add(edit);
 		}
-		TextDocumentEdit textDocumentEdit = new TextDocumentEdit(versionedTextDocumentIdentifier, edits);
+		List<Either<TextEdit, SnippetTextEdit>> eitherEdits = edits.stream()
+				.map(Either::<TextEdit, SnippetTextEdit>forLeft)
+				.collect(Collectors.toList());
+		TextDocumentEdit textDocumentEdit = new TextDocumentEdit(versionedTextDocumentIdentifier, eitherEdits);
 		WorkspaceEdit workspaceEdit = new WorkspaceEdit(Collections.singletonList(Either.forLeft(textDocumentEdit)));
 
 		insertContentAction.setEdit(workspaceEdit);
@@ -192,7 +204,9 @@ public class CodeActionFactory {
 		// 2. update the created file with the given content
 		VersionedTextDocumentIdentifier identifier = new VersionedTextDocumentIdentifier(fileURI, 0);
 		TextEdit te = new TextEdit(new Range(new Position(0, 0), new Position(0, 0)), fileContent);
-		actionsToTake.add(Either.forLeft(new TextDocumentEdit(identifier, Collections.singletonList(te))));
+		List<Either<TextEdit, SnippetTextEdit>> eitherEdits = Collections.singletonList(
+				Either.forLeft(te));
+		actionsToTake.add(Either.forLeft(new TextDocumentEdit(identifier, eitherEdits)));
 
 		WorkspaceEdit createAndAddContentEdit = new WorkspaceEdit(actionsToTake);
 		return createAndAddContentEdit;

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/CodeActionFactory.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/CodeActionFactory.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.eclipse.lemminx.utils.TextEditUtils;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.Command;
@@ -98,9 +99,7 @@ public class CodeActionFactory {
 	public static TextDocumentEdit insertEdits(TextDocumentItem document, List<TextEdit> edits) {
 		VersionedTextDocumentIdentifier versionedTextDocumentIdentifier = new VersionedTextDocumentIdentifier(
 				document.getUri(), document.getVersion());
-		List<Either<TextEdit, SnippetTextEdit>> eitherEdits = edits.stream()
-				.map(Either::<TextEdit, SnippetTextEdit>forLeft)
-				.collect(Collectors.toList());
+		List<Either<TextEdit, SnippetTextEdit>> eitherEdits = TextEditUtils.toEitherTextEdits(edits);
 		return new TextDocumentEdit(versionedTextDocumentIdentifier, eitherEdits);
 	}
 
@@ -119,9 +118,7 @@ public class CodeActionFactory {
 
 		VersionedTextDocumentIdentifier versionedTextDocumentIdentifier = new VersionedTextDocumentIdentifier(
 				document.getUri(), document.getVersion());
-		List<Either<TextEdit, SnippetTextEdit>> eitherEdits = replace.stream()
-				.map(Either::<TextEdit, SnippetTextEdit>forLeft)
-				.collect(Collectors.toList());
+		List<Either<TextEdit, SnippetTextEdit>> eitherEdits = TextEditUtils.toEitherTextEdits(replace);
 		TextDocumentEdit textDocumentEdit = new TextDocumentEdit(versionedTextDocumentIdentifier, eitherEdits);
 		WorkspaceEdit workspaceEdit = new WorkspaceEdit(Collections.singletonList(Either.forLeft(textDocumentEdit)));
 		insertContentAction.setEdit(workspaceEdit);
@@ -159,9 +156,7 @@ public class CodeActionFactory {
 			TextEdit edit = new TextEdit(range, replaceText);
 			edits.add(edit);
 		}
-		List<Either<TextEdit, SnippetTextEdit>> eitherEdits = edits.stream()
-				.map(Either::<TextEdit, SnippetTextEdit>forLeft)
-				.collect(Collectors.toList());
+		List<Either<TextEdit, SnippetTextEdit>> eitherEdits = TextEditUtils.toEitherTextEdits(edits);
 		TextDocumentEdit textDocumentEdit = new TextDocumentEdit(versionedTextDocumentIdentifier, eitherEdits);
 		WorkspaceEdit workspaceEdit = new WorkspaceEdit(Collections.singletonList(Either.forLeft(textDocumentEdit)));
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/DiagnosticUtils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/DiagnosticUtils.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.commons;
+
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.MarkupContent;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+
+/**
+ * Utilities for {@link Diagnostic}.
+ * 
+ * @author Arun Venmany
+ *
+ */
+public class DiagnosticUtils {
+
+	/**
+	 * Extracts the diagnostic message as a String from Either<String, MarkupContent>.
+	 * <p>
+	 * In LSP4J 1.0.0, diagnostic messages can be either plain strings or rich MarkupContent.
+	 * This method extracts the plain text representation from either format.
+	 * </p>
+	 *
+	 * @param diagnostic the diagnostic
+	 * @return the diagnostic message as a String
+	 */
+	public static String getDiagnosticMessage(Diagnostic diagnostic) {
+		Either<String, MarkupContent> message = diagnostic.getMessage();
+		return message.isLeft() ? message.getLeft() : message.getRight().getValue();
+	}
+
+	private DiagnosticUtils() {
+		// Utility class, no instantiation
+	}
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/TextEditUtils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/TextEditUtils.java
@@ -17,6 +17,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ResourceOperation;
 import org.eclipse.lsp4j.SnippetTextEdit;
 import org.eclipse.lsp4j.TextEdit;
@@ -72,9 +74,9 @@ public class TextEditUtils {
 
 		// Insert the expected content.
 		try {
-			org.eclipse.lsp4j.Position endPos = textDocument.positionAt(to);
-			org.eclipse.lsp4j.Position startPos = to == from ? endPos : textDocument.positionAt(from);
-			org.eclipse.lsp4j.Range range = new org.eclipse.lsp4j.Range(startPos, endPos);
+			Position endPos = textDocument.positionAt(to);
+			Position startPos = to == from ? endPos : textDocument.positionAt(from);
+			Range range = new Range(startPos, endPos);
 			return new TextEdit(range, expectedContent);
 		} catch (BadLocationException e) {
 			LOGGER.log(Level.SEVERE, e.getMessage(), e);

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/TextEditUtils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/TextEditUtils.java
@@ -1,0 +1,177 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.commons;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+import org.eclipse.lsp4j.ResourceOperation;
+import org.eclipse.lsp4j.SnippetTextEdit;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+
+/**
+ * Utilities for {@link TextEdit}.
+ * 
+ * @author Angelo ZERR
+ *
+ */
+public class TextEditUtils {
+
+	private static final Logger LOGGER = Logger.getLogger(TextEditUtils.class.getName());
+
+	/**
+	 * Converts a list of TextEdit to a list of Either<TextEdit, SnippetTextEdit>.
+	 * <p>
+	 * In LSP4J 1.0.0, TextDocumentEdit requires Either wrappers to support both
+	 * regular text edits and snippet text edits with placeholders.
+	 * </p>
+	 *
+	 * @param textEdits the list of text edits
+	 * @return the list of Either wrappers containing the text edits
+	 */
+	public static List<Either<TextEdit, SnippetTextEdit>> toEitherTextEdits(List<TextEdit> textEdits) {
+		return textEdits.stream()
+				.map(Either::<TextEdit, SnippetTextEdit>forLeft)
+				.collect(Collectors.toList());
+	}
+
+	/**
+	 * Returns the {@link TextEdit} to insert the given expected content from the
+	 * given range (from, to) of the given text document and null otherwise.
+	 * 
+	 * @param from            the range from.
+	 * @param to              the range to.
+	 * @param expectedContent the expected content.
+	 * @param textDocument    the text document.
+	 * 
+	 * @return the {@link TextEdit} to insert the given expected content from the
+	 *         given range (from, to) of the given text document and null otherwise.
+	 */
+	public static TextEdit createTextEditIfNeeded(int from, int to, String expectedContent, TextDocument textDocument) {
+		String text = textDocument.getText();
+
+		// Check if content from the range [from, to] is the same than expected content
+		if (isMatchExpectedContent(from, to, expectedContent, text)) {
+			// The expected content exists, no need to create a TextEdit
+			return null;
+		}
+
+		// Insert the expected content.
+		try {
+			org.eclipse.lsp4j.Position endPos = textDocument.positionAt(to);
+			org.eclipse.lsp4j.Position startPos = to == from ? endPos : textDocument.positionAt(from);
+			org.eclipse.lsp4j.Range range = new org.eclipse.lsp4j.Range(startPos, endPos);
+			return new TextEdit(range, expectedContent);
+		} catch (BadLocationException e) {
+			LOGGER.log(Level.SEVERE, e.getMessage(), e);
+		}
+		return null;
+	}
+
+	/**
+	 * Returns true if the given content from the range [from, to] of the given text
+	 * is the same than expected content and false otherwise.
+	 * 
+	 * @param from            the from range.
+	 * @param to              the to range.
+	 * @param expectedContent the expected content.
+	 * @param text            the text document.
+	 * 
+	 * @return true if the given content from the range [from, to] of the given text
+	 *         is the same than expected content and false otherwise.
+	 */
+	private static boolean isMatchExpectedContent(int from, int to, String expectedContent, String text) {
+		if (expectedContent.length() == to - from) {
+			int j = 0;
+			for (int i = from; i < to; i++) {
+				char c = text.charAt(i);
+				if (expectedContent.charAt(j) != c) {
+					return false;
+				}
+				j++;
+			}
+		} else {
+			return false;
+		}
+		return true;
+	}
+
+	public static String applyEdits(TextDocument document, List<? extends TextEdit> edits) throws BadLocationException {
+		String text = document.getText();
+		Collections.sort(edits /* .map(getWellformedEdit) */, (a, b) -> {
+			int diff = a.getRange().getStart().getLine() - b.getRange().getStart().getLine();
+			if (diff == 0) {
+				return a.getRange().getStart().getCharacter() - b.getRange().getStart().getCharacter();
+			}
+			return diff;
+		});
+		
+		// Use StringBuilder for better memory efficiency, especially for large files
+		// Pre-allocate capacity based on original text size to minimize reallocations
+		StringBuilder result = new StringBuilder(text.length());
+		int lastModifiedOffset = 0;
+		
+		for (TextEdit e : edits) {
+			int startOffset = document.offsetAt(e.getRange().getStart());
+			if (startOffset < lastModifiedOffset) {
+				throw new Error("Overlapping edit");
+			} else if (startOffset > lastModifiedOffset) {
+				// Append unchanged text between edits
+				result.append(text, lastModifiedOffset, startOffset);
+			}
+			if (e.getNewText() != null) {
+				result.append(e.getNewText());
+			}
+			lastModifiedOffset = document.offsetAt(e.getRange().getEnd());
+		}
+		// Append remaining text after last edit
+		result.append(text, lastModifiedOffset, text.length());
+		return result.toString();
+	}
+
+	/**
+	 * Returns the offset of the first whitespace that's found in the given range
+	 * [leftLimit,to] from the left of the to, and leftLimit otherwise.
+	 * 
+	 * @param leftLimit the left limit range.
+	 * @param to        the to range.
+	 * 
+	 * @return the offset of the first whitespace that's found in the given range
+	 *         [leftLimit,to] from the left of the to, and leftLimit otherwise.
+	 */
+	public static int adjustOffsetWithLeftWhitespaces(int leftLimit, int to, String text) {
+		if (to == 0) {
+			return -1;
+		}
+		for (int i = to - 1; i >= leftLimit; i--) {
+			char c = text.charAt(i);
+			if (!Character.isWhitespace(c)) {
+				// The current character is not a whitespace, return the offset of the character
+				return i + 1;
+			}
+		}
+		return leftLimit;
+	}
+	
+	public static WorkspaceEdit createWorkspaceEdit(List<Either<org.eclipse.lsp4j.TextDocumentEdit, ResourceOperation>> documentChanges) {
+		return new WorkspaceEdit(documentChanges);
+	}
+
+	private TextEditUtils() {
+		// Utility class, no instantiation
+	}
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/EntityNotDeclaredCodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/EntityNotDeclaredCodeAction.java
@@ -23,6 +23,7 @@ import org.eclipse.lemminx.dom.DOMNode;
 import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionParticipant;
 import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionRequest;
 import org.eclipse.lemminx.settings.SharedSettings;
+import org.eclipse.lemminx.utils.MarkupContentFactory;
 import org.eclipse.lemminx.utils.XMLBuilder;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
@@ -226,9 +227,7 @@ public class EntityNotDeclaredCodeAction implements ICodeActionParticipant {
 		Range range = diagnostic.getRange();
 		String name = doc.getText().substring(doc.offsetAt(range.getStart()), doc.offsetAt(range.getEnd()));
 		String removedAmpAndSemiColon = name.substring(1, name.length() - 1);
-		// Get message as String from Either<String, MarkupContent>
-		String message = diagnostic.getMessage().isLeft() ? diagnostic.getMessage().getLeft() :
-			diagnostic.getMessage().getRight().getValue();
+		String message = MarkupContentFactory.getDiagnosticMessage(diagnostic);
 		if (!message.contains("\"" + removedAmpAndSemiColon + "\"")) {
 			return null;
 		}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/EntityNotDeclaredCodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/EntityNotDeclaredCodeAction.java
@@ -226,7 +226,10 @@ public class EntityNotDeclaredCodeAction implements ICodeActionParticipant {
 		Range range = diagnostic.getRange();
 		String name = doc.getText().substring(doc.offsetAt(range.getStart()), doc.offsetAt(range.getEnd()));
 		String removedAmpAndSemiColon = name.substring(1, name.length() - 1);
-		if (!diagnostic.getMessage().contains("\"" + removedAmpAndSemiColon + "\"")) {
+		// Get message as String from Either<String, MarkupContent>
+		String message = diagnostic.getMessage().isLeft() ? diagnostic.getMessage().getLeft() :
+			diagnostic.getMessage().getRight().getValue();
+		if (!message.contains("\"" + removedAmpAndSemiColon + "\"")) {
 			return null;
 		}
 		return removedAmpAndSemiColon;

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/EntityNotDeclaredCodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/EntityNotDeclaredCodeAction.java
@@ -15,6 +15,7 @@ import java.util.logging.Logger;
 
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.commons.CodeActionFactory;
+import org.eclipse.lemminx.commons.DiagnosticUtils;
 import org.eclipse.lemminx.commons.TextDocument;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.dom.DOMDocumentType;
@@ -23,7 +24,6 @@ import org.eclipse.lemminx.dom.DOMNode;
 import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionParticipant;
 import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionRequest;
 import org.eclipse.lemminx.settings.SharedSettings;
-import org.eclipse.lemminx.utils.MarkupContentFactory;
 import org.eclipse.lemminx.utils.XMLBuilder;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
@@ -227,7 +227,7 @@ public class EntityNotDeclaredCodeAction implements ICodeActionParticipant {
 		Range range = diagnostic.getRange();
 		String name = doc.getText().substring(doc.offsetAt(range.getStart()), doc.offsetAt(range.getEnd()));
 		String removedAmpAndSemiColon = name.substring(1, name.length() - 1);
-		String message = MarkupContentFactory.getDiagnosticMessage(diagnostic);
+		String message = DiagnosticUtils.getDiagnosticMessage(diagnostic);
 		if (!message.contains("\"" + removedAmpAndSemiColon + "\"")) {
 			return null;
 		}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/RootElementTypeMustMatchDoctypedeclCodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/RootElementTypeMustMatchDoctypedeclCodeAction.java
@@ -15,11 +15,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.lemminx.commons.CodeActionFactory;
+import org.eclipse.lemminx.commons.DiagnosticUtils;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.dom.DOMElement;
 import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionParticipant;
 import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionRequest;
-import org.eclipse.lemminx.utils.MarkupContentFactory;
 import org.eclipse.lemminx.utils.XMLPositionUtility;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
@@ -53,7 +53,7 @@ public class RootElementTypeMustMatchDoctypedeclCodeAction implements ICodeActio
 			return;
 		}
 
-		String message = MarkupContentFactory.getDiagnosticMessage(diagnostic);
+		String message = DiagnosticUtils.getDiagnosticMessage(diagnostic);
 		
 		String currentRootText = getCurrentRoot(message);
 		if (currentRootText == null || !currentRootText.equals(root.getNodeName())) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/RootElementTypeMustMatchDoctypedeclCodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/RootElementTypeMustMatchDoctypedeclCodeAction.java
@@ -52,12 +52,16 @@ public class RootElementTypeMustMatchDoctypedeclCodeAction implements ICodeActio
 			return;
 		}
 
-		String currentRootText = getCurrentRoot(diagnostic.getMessage());
+		// Get message as String from Either<String, MarkupContent>
+		String message = diagnostic.getMessage().isLeft() ? diagnostic.getMessage().getLeft() :
+			diagnostic.getMessage().getRight().getValue();
+		
+		String currentRootText = getCurrentRoot(message);
 		if (currentRootText == null || !currentRootText.equals(root.getNodeName())) {
 			return;
 		}
 
-		String doctypeRootText = getDoctypeRoot(diagnostic.getMessage());
+		String doctypeRootText = getDoctypeRoot(message);
 		if (doctypeRootText == null) {
 			return;
 		}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/RootElementTypeMustMatchDoctypedeclCodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/RootElementTypeMustMatchDoctypedeclCodeAction.java
@@ -19,6 +19,7 @@ import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.dom.DOMElement;
 import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionParticipant;
 import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionRequest;
+import org.eclipse.lemminx.utils.MarkupContentFactory;
 import org.eclipse.lemminx.utils.XMLPositionUtility;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
@@ -52,9 +53,7 @@ public class RootElementTypeMustMatchDoctypedeclCodeAction implements ICodeActio
 			return;
 		}
 
-		// Get message as String from Either<String, MarkupContent>
-		String message = diagnostic.getMessage().isLeft() ? diagnostic.getMessage().getLeft() :
-			diagnostic.getMessage().getRight().getValue();
+		String message = MarkupContentFactory.getDiagnosticMessage(diagnostic);
 		
 		String currentRootText = getCurrentRoot(message);
 		if (currentRootText == null || !currentRootText.equals(root.getNodeName())) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/TargetNamespace_1CodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/TargetNamespace_1CodeAction.java
@@ -40,7 +40,10 @@ public class TargetNamespace_1CodeAction implements ICodeActionParticipant {
 	public void doCodeAction(ICodeActionRequest request, List<CodeAction> codeActions, CancelChecker cancelChecker) {
 		Diagnostic diagnostic = request.getDiagnostic();
 		DOMDocument document = request.getDocument();
-		String namespace = extractNamespace(diagnostic.getMessage());
+		// Get message as String from Either<String, MarkupContent>
+		String message = diagnostic.getMessage().isLeft() ? diagnostic.getMessage().getLeft() :
+			diagnostic.getMessage().getRight().getValue();
+		String namespace = extractNamespace(message);
 		if (StringUtils.isEmpty(namespace)) {
 			return;
 		}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/TargetNamespace_1CodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/TargetNamespace_1CodeAction.java
@@ -17,11 +17,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.eclipse.lemminx.commons.CodeActionFactory;
+import org.eclipse.lemminx.commons.DiagnosticUtils;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionParticipant;
 import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionRequest;
 import org.eclipse.lemminx.settings.SharedSettings;
-import org.eclipse.lemminx.utils.MarkupContentFactory;
 import org.eclipse.lemminx.utils.StringUtils;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
@@ -41,7 +41,7 @@ public class TargetNamespace_1CodeAction implements ICodeActionParticipant {
 	public void doCodeAction(ICodeActionRequest request, List<CodeAction> codeActions, CancelChecker cancelChecker) {
 		Diagnostic diagnostic = request.getDiagnostic();
 		DOMDocument document = request.getDocument();
-		String message = MarkupContentFactory.getDiagnosticMessage(diagnostic);
+		String message = DiagnosticUtils.getDiagnosticMessage(diagnostic);
 		String namespace = extractNamespace(message);
 		if (StringUtils.isEmpty(namespace)) {
 			return;

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/TargetNamespace_1CodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/TargetNamespace_1CodeAction.java
@@ -21,6 +21,7 @@ import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionParticipant;
 import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionRequest;
 import org.eclipse.lemminx.settings.SharedSettings;
+import org.eclipse.lemminx.utils.MarkupContentFactory;
 import org.eclipse.lemminx.utils.StringUtils;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
@@ -40,9 +41,7 @@ public class TargetNamespace_1CodeAction implements ICodeActionParticipant {
 	public void doCodeAction(ICodeActionRequest request, List<CodeAction> codeActions, CancelChecker cancelChecker) {
 		Diagnostic diagnostic = request.getDiagnostic();
 		DOMDocument document = request.getDocument();
-		// Get message as String from Either<String, MarkupContent>
-		String message = diagnostic.getMessage().isLeft() ? diagnostic.getMessage().getLeft() :
-			diagnostic.getMessage().getRight().getValue();
+		String message = MarkupContentFactory.getDiagnosticMessage(diagnostic);
 		String namespace = extractNamespace(message);
 		if (StringUtils.isEmpty(namespace)) {
 			return;

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/TargetNamespace_2CodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/TargetNamespace_2CodeAction.java
@@ -17,12 +17,12 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.eclipse.lemminx.commons.CodeActionFactory;
+import org.eclipse.lemminx.commons.DiagnosticUtils;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.dom.DOMNode;
 import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionParticipant;
 import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionRequest;
 import org.eclipse.lemminx.settings.SharedSettings;
-import org.eclipse.lemminx.utils.MarkupContentFactory;
 import org.eclipse.lemminx.utils.StringUtils;
 import org.eclipse.lemminx.utils.XMLPositionUtility;
 import org.eclipse.lsp4j.CodeAction;
@@ -45,7 +45,7 @@ public class TargetNamespace_2CodeAction implements ICodeActionParticipant {
 	public void doCodeAction(ICodeActionRequest request, List<CodeAction> codeActions, CancelChecker cancelChecker) {
 		Diagnostic diagnostic = request.getDiagnostic();
 		DOMDocument document = request.getDocument();
-		String message = MarkupContentFactory.getDiagnosticMessage(diagnostic);
+		String message = DiagnosticUtils.getDiagnosticMessage(diagnostic);
 		String namespace = extractNamespace(message);
 		if (StringUtils.isEmpty(namespace)) {
 			return;

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/TargetNamespace_2CodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/TargetNamespace_2CodeAction.java
@@ -22,6 +22,7 @@ import org.eclipse.lemminx.dom.DOMNode;
 import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionParticipant;
 import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionRequest;
 import org.eclipse.lemminx.settings.SharedSettings;
+import org.eclipse.lemminx.utils.MarkupContentFactory;
 import org.eclipse.lemminx.utils.StringUtils;
 import org.eclipse.lemminx.utils.XMLPositionUtility;
 import org.eclipse.lsp4j.CodeAction;
@@ -44,9 +45,7 @@ public class TargetNamespace_2CodeAction implements ICodeActionParticipant {
 	public void doCodeAction(ICodeActionRequest request, List<CodeAction> codeActions, CancelChecker cancelChecker) {
 		Diagnostic diagnostic = request.getDiagnostic();
 		DOMDocument document = request.getDocument();
-		// Get message as String from Either<String, MarkupContent>
-		String message = diagnostic.getMessage().isLeft() ? diagnostic.getMessage().getLeft() :
-			diagnostic.getMessage().getRight().getValue();
+		String message = MarkupContentFactory.getDiagnosticMessage(diagnostic);
 		String namespace = extractNamespace(message);
 		if (StringUtils.isEmpty(namespace)) {
 			return;

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/TargetNamespace_2CodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/TargetNamespace_2CodeAction.java
@@ -44,7 +44,10 @@ public class TargetNamespace_2CodeAction implements ICodeActionParticipant {
 	public void doCodeAction(ICodeActionRequest request, List<CodeAction> codeActions, CancelChecker cancelChecker) {
 		Diagnostic diagnostic = request.getDiagnostic();
 		DOMDocument document = request.getDocument();
-		String namespace = extractNamespace(diagnostic.getMessage());
+		// Get message as String from Either<String, MarkupContent>
+		String message = diagnostic.getMessage().isLeft() ? diagnostic.getMessage().getLeft() :
+			diagnostic.getMessage().getRight().getValue();
+		String namespace = extractNamespace(message);
 		if (StringUtils.isEmpty(namespace)) {
 			return;
 		}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/missinggrammar/AbstractFixMissingGrammarCodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/missinggrammar/AbstractFixMissingGrammarCodeAction.java
@@ -113,7 +113,9 @@ public abstract class AbstractFixMissingGrammarCodeAction implements ICodeAction
 	 * the root element of the document is not <xsd:schema>.
 	 */
 	private String getPathFromDiagnostic(Diagnostic diagnostic) {
-		String message = diagnostic.getMessage();
+		// Get message as String from Either<String, MarkupContent>
+		String message = diagnostic.getMessage().isLeft() ? diagnostic.getMessage().getLeft() :
+			diagnostic.getMessage().getRight().getValue();
 		int startIndex = message.indexOf(FILE_SCHEME);
 		if (startIndex != -1) {
 			int endIndex = message.lastIndexOf("'");

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/missinggrammar/AbstractFixMissingGrammarCodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/missinggrammar/AbstractFixMissingGrammarCodeAction.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.lemminx.commons.CodeActionFactory;
+import org.eclipse.lemminx.commons.DiagnosticUtils;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.extensions.generators.FileContentGeneratorManager;
 import org.eclipse.lemminx.extensions.generators.FileContentGeneratorSettings;
@@ -27,7 +28,6 @@ import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionParticipant
 import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionRequest;
 import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionResolvesParticipant;
 import org.eclipse.lemminx.settings.SharedSettings;
-import org.eclipse.lemminx.utils.MarkupContentFactory;
 import org.eclipse.lemminx.utils.StringUtils;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionKind;
@@ -114,7 +114,7 @@ public abstract class AbstractFixMissingGrammarCodeAction implements ICodeAction
 	 * the root element of the document is not <xsd:schema>.
 	 */
 	private String getPathFromDiagnostic(Diagnostic diagnostic) {
-		String message = MarkupContentFactory.getDiagnosticMessage(diagnostic);
+		String message = DiagnosticUtils.getDiagnosticMessage(diagnostic);
 		int startIndex = message.indexOf(FILE_SCHEME);
 		if (startIndex != -1) {
 			int endIndex = message.lastIndexOf("'");

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/missinggrammar/AbstractFixMissingGrammarCodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/missinggrammar/AbstractFixMissingGrammarCodeAction.java
@@ -27,6 +27,7 @@ import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionParticipant
 import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionRequest;
 import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionResolvesParticipant;
 import org.eclipse.lemminx.settings.SharedSettings;
+import org.eclipse.lemminx.utils.MarkupContentFactory;
 import org.eclipse.lemminx.utils.StringUtils;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionKind;
@@ -113,9 +114,7 @@ public abstract class AbstractFixMissingGrammarCodeAction implements ICodeAction
 	 * the root element of the document is not <xsd:schema>.
 	 */
 	private String getPathFromDiagnostic(Diagnostic diagnostic) {
-		// Get message as String from Either<String, MarkupContent>
-		String message = diagnostic.getMessage().isLeft() ? diagnostic.getMessage().getLeft() :
-			diagnostic.getMessage().getRight().getValue();
+		String message = MarkupContentFactory.getDiagnosticMessage(diagnostic);
 		int startIndex = message.indexOf(FILE_SCHEME);
 		if (startIndex != -1) {
 			int endIndex = message.lastIndexOf("'");

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/RenameResponse.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/RenameResponse.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 
 import org.eclipse.lemminx.services.extensions.rename.IRenameResponse;
 import org.eclipse.lsp4j.ResourceOperation;
+import org.eclipse.lsp4j.SnippetTextEdit;
 import org.eclipse.lsp4j.TextDocumentEdit;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
@@ -39,7 +40,8 @@ class RenameResponse implements IRenameResponse {
 				.map(Either::getLeft).findFirst();
 		if(change.isPresent()) {
 			TextDocumentEdit existingTextDocumentEdit = change.get();
-			List<TextEdit> edits = new ArrayList<>();
+			// Convert Either<TextEdit, SnippetTextEdit> to TextEdit for comparison
+			List<Either<TextEdit, SnippetTextEdit>> edits = new ArrayList<>();
 			edits.addAll(existingTextDocumentEdit.getEdits());
 			textDocumentEdit.getEdits().stream().forEach(te -> {
 				if (!edits.contains(te)) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/DOMTextEditUtils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/DOMTextEditUtils.java
@@ -19,7 +19,7 @@ import org.eclipse.lsp4j.TextDocumentEdit;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
-
+import org.eclipse.lemminx.commons.TextEditUtils;
 /**
  * Utilities for {@link TextEdit} specific to DOM documents.
  * 
@@ -39,7 +39,7 @@ public class DOMTextEditUtils {
 		VersionedTextDocumentIdentifier projectVersionedTextDocumentIdentifier = new VersionedTextDocumentIdentifier(
 				document.getDocumentURI(), document.getTextDocument().getVersion());
 		// Convert List<TextEdit> to List<Either<TextEdit, SnippetTextEdit>> for LSP4J 1.0.0
-		List<Either<TextEdit, SnippetTextEdit>> edits = org.eclipse.lemminx.commons.TextEditUtils.toEitherTextEdits(textEdits);
+		List<Either<TextEdit, SnippetTextEdit>> edits = TextEditUtils.toEitherTextEdits(textEdits);
 		return new TextDocumentEdit(projectVersionedTextDocumentIdentifier, edits);
 	}
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/DOMTextEditUtils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/DOMTextEditUtils.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.utils;
+
+import java.util.List;
+
+import org.eclipse.lemminx.dom.DOMDocument;
+import org.eclipse.lsp4j.SnippetTextEdit;
+import org.eclipse.lsp4j.TextDocumentEdit;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+
+/**
+ * Utilities for {@link TextEdit} specific to DOM documents.
+ * 
+ * @author Arun Venmany
+ *
+ */
+public class DOMTextEditUtils {
+
+	/**
+	 * Creates a TextDocumentEdit object for the specified document and list of text edits
+	 *
+	 * @param document Document to be changed
+	 * @param textEdits a list of text edit changes
+	 * @return A Text Document Edit object
+	 */
+	public static TextDocumentEdit creatTextDocumentEdit(DOMDocument document, List<TextEdit> textEdits) {
+		VersionedTextDocumentIdentifier projectVersionedTextDocumentIdentifier = new VersionedTextDocumentIdentifier(
+				document.getDocumentURI(), document.getTextDocument().getVersion());
+		// Convert List<TextEdit> to List<Either<TextEdit, SnippetTextEdit>> for LSP4J 1.0.0
+		List<Either<TextEdit, SnippetTextEdit>> edits = org.eclipse.lemminx.commons.TextEditUtils.toEitherTextEdits(textEdits);
+		return new TextDocumentEdit(projectVersionedTextDocumentIdentifier, edits);
+	}
+
+	private DOMTextEditUtils() {
+		// Utility class, no instantiation
+	}
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/MarkupContentFactory.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/MarkupContentFactory.java
@@ -14,12 +14,10 @@ package org.eclipse.lemminx.utils;
 import java.util.List;
 
 import org.eclipse.lemminx.services.extensions.ISharedSettingsRequest;
-import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.MarkupContent;
 import org.eclipse.lsp4j.MarkupKind;
 import org.eclipse.lsp4j.Range;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 /**
  * Factory to create LSP4J {@link MarkupContent}
@@ -30,21 +28,6 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 public class MarkupContentFactory {
 
 	public static final String MARKDOWN_SEPARATOR = "___";
-
-	/**
-	 * Extracts the diagnostic message as a String from Either<String, MarkupContent>.
-	 * <p>
-	 * In LSP4J 1.0.0, diagnostic messages can be either plain strings or rich MarkupContent.
-	 * This method extracts the plain text representation from either format.
-	 * </p>
-	 *
-	 * @param diagnostic the diagnostic
-	 * @return the diagnostic message as a String
-	 */
-	public static String getDiagnosticMessage(Diagnostic diagnostic) {
-		Either<String, MarkupContent> message = diagnostic.getMessage();
-		return message.isLeft() ? message.getLeft() : message.getRight().getValue();
-	}
 
 	/**
 	 * Create the markup content according the given markup kind and the capability

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/MarkupContentFactory.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/MarkupContentFactory.java
@@ -14,10 +14,12 @@ package org.eclipse.lemminx.utils;
 import java.util.List;
 
 import org.eclipse.lemminx.services.extensions.ISharedSettingsRequest;
+import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.MarkupContent;
 import org.eclipse.lsp4j.MarkupKind;
 import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 /**
  * Factory to create LSP4J {@link MarkupContent}
@@ -28,6 +30,21 @@ import org.eclipse.lsp4j.Range;
 public class MarkupContentFactory {
 
 	public static final String MARKDOWN_SEPARATOR = "___";
+
+	/**
+	 * Extracts the diagnostic message as a String from Either<String, MarkupContent>.
+	 * <p>
+	 * In LSP4J 1.0.0, diagnostic messages can be either plain strings or rich MarkupContent.
+	 * This method extracts the plain text representation from either format.
+	 * </p>
+	 *
+	 * @param diagnostic the diagnostic
+	 * @return the diagnostic message as a String
+	 */
+	public static String getDiagnosticMessage(Diagnostic diagnostic) {
+		Either<String, MarkupContent> message = diagnostic.getMessage();
+		return message.isLeft() ? message.getLeft() : message.getRight().getValue();
+	}
 
 	/**
 	 * Create the markup content according the given markup kind and the capability

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/TextEditUtils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/TextEditUtils.java
@@ -11,23 +11,15 @@
 *******************************************************************************/
 package org.eclipse.lemminx.utils;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.commons.TextDocument;
 import org.eclipse.lemminx.dom.DOMDocument;
-import org.eclipse.lsp4j.Position;
-import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ResourceOperation;
 import org.eclipse.lsp4j.SnippetTextEdit;
 import org.eclipse.lsp4j.TextDocumentEdit;
 import org.eclipse.lsp4j.TextEdit;
-import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
@@ -35,162 +27,57 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
  * Utilities for {@link TextEdit}.
  * 
  * @author Angelo ZERR
- *
+ * @deprecated Use {@link org.eclipse.lemminx.commons.TextEditUtils} for generic LSP4J utilities
+ *             or {@link DOMTextEditUtils} for DOM-specific utilities
  */
+@Deprecated
 public class TextEditUtils {
 
-	private static final Logger LOGGER = Logger.getLogger(TextEditUtils.class.getName());
-
 	/**
-	 * Converts a list of TextEdit to a list of Either<TextEdit, SnippetTextEdit>.
-	 * <p>
-	 * In LSP4J 1.0.0, TextDocumentEdit requires Either wrappers to support both
-	 * regular text edits and snippet text edits with placeholders.
-	 * </p>
-	 *
-	 * @param textEdits the list of text edits
-	 * @return the list of Either wrappers containing the text edits
+	 * @deprecated Use {@link org.eclipse.lemminx.commons.TextEditUtils#toEitherTextEdits(List)}
 	 */
+	@Deprecated
 	public static List<Either<TextEdit, SnippetTextEdit>> toEitherTextEdits(List<TextEdit> textEdits) {
-		return textEdits.stream()
-				.map(Either::<TextEdit, SnippetTextEdit>forLeft)
-				.collect(Collectors.toList());
+		return org.eclipse.lemminx.commons.TextEditUtils.toEitherTextEdits(textEdits);
 	}
 
 	/**
-	 * Returns the {@link TextEdit} to insert the given expected content from the
-	 * given range (from, to) of the given text document and null otherwise.
-	 * 
-	 * @param from            the range from.
-	 * @param to              the range to.
-	 * @param expectedContent the expected content.
-	 * @param textDocument    the text document.
-	 * 
-	 * @return the {@link TextEdit} to insert the given expected content from the
-	 *         given range (from, to) of the given text document and null otherwise.
+	 * @deprecated Use {@link org.eclipse.lemminx.commons.TextEditUtils#createTextEditIfNeeded(int, int, String, TextDocument)}
 	 */
+	@Deprecated
 	public static TextEdit createTextEditIfNeeded(int from, int to, String expectedContent, TextDocument textDocument) {
-		String text = textDocument.getText();
-
-		// Check if content from the range [from, to] is the same than expected content
-		if (isMatchExpectedContent(from, to, expectedContent, text)) {
-			// The expected content exists, no need to create a TextEdit
-			return null;
-		}
-
-		// Insert the expected content.
-		try {
-			Position endPos = textDocument.positionAt(to);
-			Position startPos = to == from ? endPos : textDocument.positionAt(from);
-			Range range = new Range(startPos, endPos);
-			return new TextEdit(range, expectedContent);
-		} catch (BadLocationException e) {
-			LOGGER.log(Level.SEVERE, e.getMessage(), e);
-		}
-		return null;
+		return org.eclipse.lemminx.commons.TextEditUtils.createTextEditIfNeeded(from, to, expectedContent, textDocument);
 	}
 
 	/**
-	 * Returns true if the given content from the range [from, to] of the given text
-	 * is the same than expected content and false otherwise.
-	 * 
-	 * @param from            the from range.
-	 * @param to              the to range.
-	 * @param expectedContent the expected content.
-	 * @param text            the text document.
-	 * 
-	 * @return true if the given content from the range [from, to] of the given text
-	 *         is the same than expected content and false otherwise.
+	 * @deprecated Use {@link org.eclipse.lemminx.commons.TextEditUtils#applyEdits(TextDocument, List)}
 	 */
-	private static boolean isMatchExpectedContent(int from, int to, String expectedContent, String text) {
-		if (expectedContent.length() == to - from) {
-			int j = 0;
-			for (int i = from; i < to; i++) {
-				char c = text.charAt(i);
-				if (expectedContent.charAt(j) != c) {
-					return false;
-				}
-				j++;
-			}
-		} else {
-			return false;
-		}
-		return true;
-	}
-
+	@Deprecated
 	public static String applyEdits(TextDocument document, List<? extends TextEdit> edits) throws BadLocationException {
-		String text = document.getText();
-		Collections.sort(edits /* .map(getWellformedEdit) */, (a, b) -> {
-			int diff = a.getRange().getStart().getLine() - b.getRange().getStart().getLine();
-			if (diff == 0) {
-				return a.getRange().getStart().getCharacter() - b.getRange().getStart().getCharacter();
-			}
-			return diff;
-		});
-		
-		// Use StringBuilder for better memory efficiency, especially for large files
-		// Pre-allocate capacity based on original text size to minimize reallocations
-		StringBuilder result = new StringBuilder(text.length());
-		int lastModifiedOffset = 0;
-		
-		for (TextEdit e : edits) {
-			int startOffset = document.offsetAt(e.getRange().getStart());
-			if (startOffset < lastModifiedOffset) {
-				throw new Error("Overlapping edit");
-			} else if (startOffset > lastModifiedOffset) {
-				// Append unchanged text between edits
-				result.append(text, lastModifiedOffset, startOffset);
-			}
-			if (e.getNewText() != null) {
-				result.append(e.getNewText());
-			}
-			lastModifiedOffset = document.offsetAt(e.getRange().getEnd());
-		}
-		// Append remaining text after last edit
-		result.append(text, lastModifiedOffset, text.length());
-		return result.toString();
+		return org.eclipse.lemminx.commons.TextEditUtils.applyEdits(document, edits);
 	}
 
 	/**
-	 * Returns the offset of the first whitespace that's found in the given range
-	 * [leftLimit,to] from the left of the to, and leftLimit otherwise.
-	 * 
-	 * @param leftLimit the left limit range.
-	 * @param to        the to range.
-	 * 
-	 * @return the offset of the first whitespace that's found in the given range
-	 *         [leftLimit,to] from the left of the to, and leftLimit otherwise.
+	 * @deprecated Use {@link org.eclipse.lemminx.commons.TextEditUtils#adjustOffsetWithLeftWhitespaces(int, int, String)}
 	 */
+	@Deprecated
 	public static int adjustOffsetWithLeftWhitespaces(int leftLimit, int to, String text) {
-		if (to == 0) {
-			return -1;
-		}
-		for (int i = to - 1; i >= leftLimit; i--) {
-			char c = text.charAt(i);
-			if (!Character.isWhitespace(c)) {
-				// The current character is not a whitespace, return the offset of the character
-				return i + 1;
-			}
-		}
-		return leftLimit;
+		return org.eclipse.lemminx.commons.TextEditUtils.adjustOffsetWithLeftWhitespaces(leftLimit, to, text);
 	}
 
 	/**
-	 * Creates a TextDocumentEdit object for the specified document and list of text edits
-	 *
-	 * @param document Document to be changed
-	 * @param textEdits a list of text edit changes
-	 * @return A Text Dpcument Edit object
+	 * @deprecated Use {@link DOMTextEditUtils#creatTextDocumentEdit(DOMDocument, List)}
 	 */
+	@Deprecated
 	public static TextDocumentEdit creatTextDocumentEdit(DOMDocument document, List<TextEdit> textEdits) {
-		VersionedTextDocumentIdentifier projectVersionedTextDocumentIdentifier = new VersionedTextDocumentIdentifier(
-				document.getDocumentURI(), document.getTextDocument().getVersion());
-		// Convert List<TextEdit> to List<Either<TextEdit, SnippetTextEdit>> for LSP4J 1.0.0
-		List<Either<TextEdit, SnippetTextEdit>> edits = toEitherTextEdits(textEdits);
-		return new TextDocumentEdit(projectVersionedTextDocumentIdentifier, edits);
+		return DOMTextEditUtils.creatTextDocumentEdit(document, textEdits);
 	}
 	
+	/**
+	 * @deprecated Use {@link org.eclipse.lemminx.commons.TextEditUtils#createWorkspaceEdit(List)}
+	 */
+	@Deprecated
 	public static WorkspaceEdit createWorkspaceEdit(List<Either<TextDocumentEdit, ResourceOperation>> documentChanges) {
-		return new WorkspaceEdit(documentChanges);
+		return org.eclipse.lemminx.commons.TextEditUtils.createWorkspaceEdit(documentChanges);
 	}
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/TextEditUtils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/TextEditUtils.java
@@ -30,7 +30,6 @@ import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 /**
  * Utilities for {@link TextEdit}.
@@ -41,6 +40,22 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 public class TextEditUtils {
 
 	private static final Logger LOGGER = Logger.getLogger(TextEditUtils.class.getName());
+
+	/**
+	 * Converts a list of TextEdit to a list of Either<TextEdit, SnippetTextEdit>.
+	 * <p>
+	 * In LSP4J 1.0.0, TextDocumentEdit requires Either wrappers to support both
+	 * regular text edits and snippet text edits with placeholders.
+	 * </p>
+	 *
+	 * @param textEdits the list of text edits
+	 * @return the list of Either wrappers containing the text edits
+	 */
+	public static List<Either<TextEdit, SnippetTextEdit>> toEitherTextEdits(List<TextEdit> textEdits) {
+		return textEdits.stream()
+				.map(Either::<TextEdit, SnippetTextEdit>forLeft)
+				.collect(Collectors.toList());
+	}
 
 	/**
 	 * Returns the {@link TextEdit} to insert the given expected content from the
@@ -171,9 +186,7 @@ public class TextEditUtils {
 		VersionedTextDocumentIdentifier projectVersionedTextDocumentIdentifier = new VersionedTextDocumentIdentifier(
 				document.getDocumentURI(), document.getTextDocument().getVersion());
 		// Convert List<TextEdit> to List<Either<TextEdit, SnippetTextEdit>> for LSP4J 1.0.0
-		List<Either<TextEdit, SnippetTextEdit>> edits = textEdits.stream()
-				.map(Either::<TextEdit, SnippetTextEdit>forLeft)
-				.collect(Collectors.toList());
+		List<Either<TextEdit, SnippetTextEdit>> edits = toEitherTextEdits(textEdits);
 		return new TextDocumentEdit(projectVersionedTextDocumentIdentifier, edits);
 	}
 	

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/TextEditUtils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/TextEditUtils.java
@@ -24,10 +24,12 @@ import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ResourceOperation;
+import org.eclipse.lsp4j.SnippetTextEdit;
 import org.eclipse.lsp4j.TextDocumentEdit;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 /**
@@ -160,7 +162,7 @@ public class TextEditUtils {
 
 	/**
 	 * Creates a TextDocumentEdit object for the specified document and list of text edits
-	 * 
+	 *
 	 * @param document Document to be changed
 	 * @param textEdits a list of text edit changes
 	 * @return A Text Dpcument Edit object
@@ -168,7 +170,11 @@ public class TextEditUtils {
 	public static TextDocumentEdit creatTextDocumentEdit(DOMDocument document, List<TextEdit> textEdits) {
 		VersionedTextDocumentIdentifier projectVersionedTextDocumentIdentifier = new VersionedTextDocumentIdentifier(
 				document.getDocumentURI(), document.getTextDocument().getVersion());
-		return new TextDocumentEdit(projectVersionedTextDocumentIdentifier, textEdits);
+		// Convert List<TextEdit> to List<Either<TextEdit, SnippetTextEdit>> for LSP4J 1.0.0
+		List<Either<TextEdit, SnippetTextEdit>> edits = textEdits.stream()
+				.map(Either::<TextEdit, SnippetTextEdit>forLeft)
+				.collect(Collectors.toList());
+		return new TextDocumentEdit(projectVersionedTextDocumentIdentifier, edits);
 	}
 	
 	public static WorkspaceEdit createWorkspaceEdit(List<Either<TextDocumentEdit, ResourceOperation>> documentChanges) {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/XMLAssert.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/XMLAssert.java
@@ -103,6 +103,7 @@ import org.eclipse.lsp4j.ResourceOperation;
 import org.eclipse.lsp4j.SelectionRange;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.SymbolKind;
+import org.eclipse.lsp4j.SnippetTextEdit;
 import org.eclipse.lsp4j.TextDocumentEdit;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextEdit;
@@ -746,7 +747,7 @@ public class XMLAssert {
 	public static void assertDiagnostics(List<Diagnostic> actual, List<Diagnostic> expected, boolean filter) {
 		List<Diagnostic> received = actual;
 		final boolean filterMessage;
-		if (expected != null && !expected.isEmpty() && !StringUtils.isEmpty(expected.get(0).getMessage())) {
+		if (expected != null && !expected.isEmpty() && !StringUtils.isEmpty(getMessageAsString(expected.get(0)))) {
 			filterMessage = true;
 		} else {
 			filterMessage = false;
@@ -870,10 +871,12 @@ public class XMLAssert {
 		for (int i = 0; i < expected.length; i++) {
 			assertEquals(expected[i].getUri(), actual.get(i).getUri());
 			actual.get(i).getDiagnostics().forEach(d -> {
-				d.setMessage(cleanExceptionMessage.apply(d.getMessage()));
+				String msg = getMessageAsString(d);
+				d.setMessage(cleanExceptionMessage.apply(msg));
 			});
 			expected[i].getDiagnostics().forEach(d -> {
-				d.setMessage(cleanExceptionMessage.apply(d.getMessage()));
+				String msg = getMessageAsString(d);
+				d.setMessage(cleanExceptionMessage.apply(msg));
 			});
 			assertDiagnostics(actual.get(i).getDiagnostics(), expected[i].getDiagnostics(), false);
 		}
@@ -881,7 +884,16 @@ public class XMLAssert {
 
 	private static List<String> getMessages(Stream<PublishDiagnosticsParams> diagParams) {
 		return diagParams.flatMap(d -> d.getDiagnostics().stream())
-				.map(d -> cleanExceptionMessage.apply(d.getMessage())).collect(Collectors.toList());
+				.map(d -> cleanExceptionMessage.apply(getMessageAsString(d))).collect(Collectors.toList());
+	}
+	
+	/**
+		* Helper method to extract String from Either<String, MarkupContent>
+		*/
+	private static String getMessageAsString(Diagnostic diagnostic) {
+		return diagnostic.getMessage().isLeft() ?
+			diagnostic.getMessage().getLeft() :
+			diagnostic.getMessage().getRight().getValue();
 	}
 
 	private static final Function<String, String> cleanExceptionMessage = (message) -> {
@@ -1185,7 +1197,10 @@ public class XMLAssert {
 	public static TextDocumentEdit tde(String uri, int version, TextEdit... te) {
 		VersionedTextDocumentIdentifier versionedTextDocumentIdentifier = new VersionedTextDocumentIdentifier(uri,
 				version);
-		return new TextDocumentEdit(versionedTextDocumentIdentifier, Arrays.asList(te));
+		List<Either<TextEdit, SnippetTextEdit>> edits = Arrays.stream(te)
+				.map(Either::<TextEdit, SnippetTextEdit>forLeft)
+				.collect(Collectors.toList());
+		return new TextDocumentEdit(versionedTextDocumentIdentifier, edits);
 	}
 
 	public static TextEdit te(int startLine, int startCharacter, int endLine, int endCharacter, String newText) {
@@ -1204,12 +1219,17 @@ public class XMLAssert {
 
 	public static Either<TextDocumentEdit, ResourceOperation> teOp(String uri, int startLine, int startChar,
 			int endLine, int endChar, String newText) {
-		return Either.forLeft(new TextDocumentEdit(new VersionedTextDocumentIdentifier(uri, 0),
-				Collections.singletonList(te(startLine, startChar, endLine, endChar, newText))));
+		TextEdit edit = te(startLine, startChar, endLine, endChar, newText);
+		List<Either<TextEdit, SnippetTextEdit>> edits = Collections.singletonList(
+				Either.<TextEdit, SnippetTextEdit>forLeft(edit));
+		return Either.forLeft(new TextDocumentEdit(new VersionedTextDocumentIdentifier(uri, 0), edits));
 	}
 
 	public static Either<TextDocumentEdit, ResourceOperation> teOp(String uri, TextEdit... te) {
-		return Either.forLeft(new TextDocumentEdit(new VersionedTextDocumentIdentifier(uri, 0), Arrays.asList(te)));
+		List<Either<TextEdit, SnippetTextEdit>> edits = Arrays.stream(te)
+				.map(Either::<TextEdit, SnippetTextEdit>forLeft)
+				.collect(Collectors.toList());
+		return Either.forLeft(new TextDocumentEdit(new VersionedTextDocumentIdentifier(uri, 0), edits));
 	}
 
 	// ------------------- Hover assert
@@ -1887,7 +1907,11 @@ public class XMLAssert {
 		final String uri = fileURI;
 		Optional<TextDocumentEdit> documentChange = workspaceEdit.getDocumentChanges().stream().filter(Either::isLeft)
 				.filter(e -> uri.equals(e.getLeft().getTextDocument().getUri())).map(Either::getLeft).findFirst();
-		List<TextEdit> actualEdits = documentChange.isPresent() ? documentChange.get().getEdits()
+		List<TextEdit> actualEdits = documentChange.isPresent() ?
+				documentChange.get().getEdits().stream()
+					.filter(Either::isLeft)
+					.map(Either::getLeft)
+					.collect(Collectors.toList())
 				: Collections.emptyList();
 		assertArrayEquals(expectedEdits.toArray(), actualEdits.toArray());
 	}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/commons/IncrementalParsingTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/commons/IncrementalParsingTest.java
@@ -50,7 +50,7 @@ public class IncrementalParsingTest {
 		document.setIncremental(true);
 
 		Range range1 = new Range(new Position(0, 1), new Position(0, 1));
-		TextDocumentContentChangeEvent change1 = new TextDocumentContentChangeEvent(range1, 0, "a");
+		TextDocumentContentChangeEvent change1 = new TextDocumentContentChangeEvent(range1, "a");
 
 		ArrayList<TextDocumentContentChangeEvent> changes = new ArrayList<>();
 		changes.add(change1);
@@ -77,7 +77,7 @@ public class IncrementalParsingTest {
 		document.setIncremental(true);
 
 		Range range1 = new Range(new Position(0, 1), new Position(0, 1));
-		TextDocumentContentChangeEvent change1 = new TextDocumentContentChangeEvent(range1, 0, "aaa");
+		TextDocumentContentChangeEvent change1 = new TextDocumentContentChangeEvent(range1, "aaa");
 
 		ArrayList<TextDocumentContentChangeEvent> changes = new ArrayList<>();
 		changes.add(change1);
@@ -103,7 +103,7 @@ public class IncrementalParsingTest {
 		document.setIncremental(true);
 
 		Range range1 = new Range(new Position(0, 1), new Position(0, 4));
-		TextDocumentContentChangeEvent change1 = new TextDocumentContentChangeEvent(range1, 3, "aaa");
+		TextDocumentContentChangeEvent change1 = new TextDocumentContentChangeEvent(range1, "aaa");
 
 		ArrayList<TextDocumentContentChangeEvent> changes = new ArrayList<>();
 		changes.add(change1);
@@ -115,12 +115,14 @@ public class IncrementalParsingTest {
 
 	@Test
 	public void testRangeLengthPreferredOverRangeEndPosition() {
-		String text = "<zzz>\r\n" + // /// <-- inserting 'a' in tag name
+		// Note: In LSP4J 1.0.0, rangeLength parameter was removed.
+		// This test now uses the proper range end position instead.
+		String text = "<zzz>\r\n" + // /// <-- replacing 'zzz' with 'aaa' in tag name
 				"  <b>\r\n" + //
 				"  </b>\r\n" + //
 				"</aaa>\r\n";
 
-		String expectedText = "<aaa>\r\n" + // /// <-- inserted 'a' in tag name
+		String expectedText = "<aaa>\r\n" + // /// <-- replaced 'zzz' with 'aaa' in tag name
 				"  <b>\r\n" + //
 				"  </b>\r\n" + //
 				"</aaa>\r\n";
@@ -128,8 +130,9 @@ public class IncrementalParsingTest {
 		TextDocument document = new TextDocument(text, "uri");
 		document.setIncremental(true);
 
-		Range range1 = new Range(new Position(0, 1), new Position(-1, -1));
-		TextDocumentContentChangeEvent change1 = new TextDocumentContentChangeEvent(range1, 3, "aaa");
+		// Use proper range end position (0, 4) to replace "zzz" with "aaa"
+		Range range1 = new Range(new Position(0, 1), new Position(0, 4));
+		TextDocumentContentChangeEvent change1 = new TextDocumentContentChangeEvent(range1, "aaa");
 
 		ArrayList<TextDocumentContentChangeEvent> changes = new ArrayList<>();
 		changes.add(change1);
@@ -152,7 +155,7 @@ public class IncrementalParsingTest {
 		document.setIncremental(true);
 
 		Range range1 = new Range(new Position(0, 4), new Position(2, 5));
-		TextDocumentContentChangeEvent change1 = new TextDocumentContentChangeEvent(range1, null, "/");
+		TextDocumentContentChangeEvent change1 = new TextDocumentContentChangeEvent(range1, "/");
 
 		ArrayList<TextDocumentContentChangeEvent> changes = new ArrayList<>();
 		changes.add(change1);
@@ -178,10 +181,10 @@ public class IncrementalParsingTest {
 		document.setIncremental(true);
 
 		Range range1 = new Range(new Position(0, 1), new Position(0, 1));
-		TextDocumentContentChangeEvent change1 = new TextDocumentContentChangeEvent(range1, 0, "a");
+		TextDocumentContentChangeEvent change1 = new TextDocumentContentChangeEvent(range1, "a");
 
 		Range range2 = new Range(new Position(2, 4), new Position(2, 4));
-		TextDocumentContentChangeEvent change2 = new TextDocumentContentChangeEvent(range2, 0, "b");
+		TextDocumentContentChangeEvent change2 = new TextDocumentContentChangeEvent(range2, "b");
 
 		ArrayList<TextDocumentContentChangeEvent> changes = new ArrayList<>();
 		// The order they are added in is backwards with the largest offset being first
@@ -210,10 +213,10 @@ public class IncrementalParsingTest {
 		document.setIncremental(true);
 
 		Range range1 = new Range(new Position(0, 1), new Position(0, 4));
-		TextDocumentContentChangeEvent change1 = new TextDocumentContentChangeEvent(range1, 3, "a");
+		TextDocumentContentChangeEvent change1 = new TextDocumentContentChangeEvent(range1, "a");
 
 		Range range2 = new Range(new Position(2, 4), new Position(2, 7));
-		TextDocumentContentChangeEvent change2 = new TextDocumentContentChangeEvent(range2, 3, "b");
+		TextDocumentContentChangeEvent change2 = new TextDocumentContentChangeEvent(range2, "b");
 
 		ArrayList<TextDocumentContentChangeEvent> changes = new ArrayList<>();
 		// The order they are added in is backwards with the largest offset being first
@@ -242,7 +245,7 @@ public class IncrementalParsingTest {
 		document.setIncremental(true);
 
 		Range range1 = new Range(new Position(0, 2), new Position(0, 3));
-		TextDocumentContentChangeEvent change1 = new TextDocumentContentChangeEvent(range1, 1, "");
+		TextDocumentContentChangeEvent change1 = new TextDocumentContentChangeEvent(range1, "");
 
 		ArrayList<TextDocumentContentChangeEvent> changes = new ArrayList<>();
 		changes.add(change1);
@@ -269,10 +272,10 @@ public class IncrementalParsingTest {
 		document.setIncremental(true);
 
 		Range range1 = new Range(new Position(0, 2), new Position(0, 3));
-		TextDocumentContentChangeEvent change1 = new TextDocumentContentChangeEvent(range1, 1, "");
+		TextDocumentContentChangeEvent change1 = new TextDocumentContentChangeEvent(range1, "");
 
 		Range range2 = new Range(new Position(2, 5), new Position(2, 6));
-		TextDocumentContentChangeEvent change2 = new TextDocumentContentChangeEvent(range2, 1, "");
+		TextDocumentContentChangeEvent change2 = new TextDocumentContentChangeEvent(range2, "");
 
 		ArrayList<TextDocumentContentChangeEvent> changes = new ArrayList<>();
 		changes.add(change2);

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/performance/TextDocumentUpdatePerformance.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/performance/TextDocumentUpdatePerformance.java
@@ -42,7 +42,7 @@ public class TextDocumentUpdatePerformance {
 			// Insert a space
 			List<TextDocumentContentChangeEvent> changes = new ArrayList<>();
 			TextDocumentContentChangeEvent change = new TextDocumentContentChangeEvent(
-					new Range(new Position(14, 13), new Position(14, 13)), 0, " ");
+					new Range(new Position(14, 13), new Position(14, 13)), " ");
 			changes.add(change);
 			document.update(changes);
 			System.err.println("Update 'content.xml' text document in " + (System.currentTimeMillis() - start) + " ms.");

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<description>LemMinX is a XML Language Server Protocol (LSP), and can be used with any editor that supports LSP, to offer an outstanding XML editing experience</description>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<lsp4j.version>0.23.1</lsp4j.version>
+		<lsp4j.version>1.0.0</lsp4j.version>
 		<junit.version>5.10.1</junit.version>
 	</properties>
 	<url>https://github.com/eclipse/lemminx</url>


### PR DESCRIPTION
Related to #1780 

Method signatures updated

1. The TextDocumentEdit constructor now requires List<Either<TextEdit, SnippetTextEdit>> instead of List<TextEdit>.
```
// OLD (LSP4J 0.23.1)
new TextDocumentEdit(identifier, List<TextEdit> edits)
// NEW (LSP4J 1.0.0)
new TextDocumentEdit(identifier, List<Either<TextEdit, SnippetTextEdit>> edits)
```

2. Diagnostic.getMessage() now returns Either<String, MarkupContent> instead of String.
```
// OLD (LSP4J 0.23.1)
String message = diagnostic.getMessage();
// NEW (LSP4J 1.0.0)
Either<String, MarkupContent> message = diagnostic.getMessage();
```

3. TextDocumentEdit.getEdits() Return Type Change
```

// OLD (LSP4J 0.23.1)
List<TextEdit> edits = textDocumentEdit.getEdits();
// NEW (LSP4J 1.0.0)
List<Either<TextEdit, SnippetTextEdit>> edits = textDocumentEdit.getEdits();
```


also found some invalid constructors for TextEdit and TextDocumentContentChangeEvent