### PR TITLE
Handle referencing schemas through UNC paths

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/XMLModelUtils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/XMLModelUtils.java
@@ -21,14 +21,14 @@ import org.eclipse.lemminx.dom.XMLModel;
 
 /**
  * XML model utilities.
- * 
+ *
  */
 public class XMLModelUtils {
 
 	/**
 	 * Returns the DOM range of the href of the xml-model processing instruction
 	 * which matches the given hrefLocation.
-	 * 
+	 *
 	 * @param document     the DOM document.
 	 * @param hrefLocation the href location.
 	 * @return the DOM range of the href of the xml-model processing instruction
@@ -46,6 +46,8 @@ public class XMLModelUtils {
 				String href = xmlModel.getHref();
 				String xmlModelLocation = getResolvedLocation(documentURI, href);
 				if (hrefLocation.equals(xmlModelLocation)) {
+					return xmlModel.getHrefNode();
+				} else if (hrefLocation.equals(href)) {
 					return xmlModel.getHrefNode();
 				}
 			}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/uriresolver/CacheResourcesManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/uriresolver/CacheResourcesManager.java
@@ -316,10 +316,17 @@ public class CacheResourcesManager {
 		if (normalizedUri.getPath().contains("/../")) {
 			throw new InvalidURIException(uri.toString(), InvalidURIError.INVALID_PATH);
 		}
-		Path resourceCachePath = normalizedUri.getPort() > 0
-				? Paths.get(CACHE_PATH, normalizedUri.getScheme(), normalizedUri.getHost(),
-						String.valueOf(normalizedUri.getPort()), normalizedUri.getPath())
-				: Paths.get(CACHE_PATH, normalizedUri.getScheme(), normalizedUri.getHost(), normalizedUri.getPath());
+		Path resourceCachePath;
+		if (normalizedUri.getPort() > 0) {
+			resourceCachePath = Paths.get(CACHE_PATH, normalizedUri.getScheme(), normalizedUri.getHost(),
+						String.valueOf(normalizedUri.getPort()), normalizedUri.getPath());
+		} else {
+			if (normalizedUri.getHost() != null) {
+				resourceCachePath = Paths.get(CACHE_PATH, normalizedUri.getScheme(), normalizedUri.getHost(), normalizedUri.getPath());
+			} else {
+				resourceCachePath = Paths.get(CACHE_PATH, normalizedUri.getScheme(), normalizedUri.getPath());
+			}
+		}
 		return FilesUtils.getDeployedPath(resourceCachePath);
 	}
 
@@ -459,6 +466,17 @@ public class CacheResourcesManager {
 			if (url.startsWith(protocol)) {
 				return true;
 			}
+		}
+		try {
+			URI uri = URI.create(url);
+			if ((uri.getScheme() == null || uri.getScheme().isEmpty() || "file".equals(uri.getScheme()))
+					&& ((uri.getHost() != null && !uri.getHost().isEmpty() && !"localhost".equals(uri.getHost()))
+							|| ((uri.getHost() == null || uri.getHost().isEmpty()) && uri.getPath().startsWith(
+									"//")))) {
+				// UNC path
+				return true;
+			}
+		} catch (Exception e) {
 		}
 		return false;
 	}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLValidationExternalResourcesBasedOnXSDTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLValidationExternalResourcesBasedOnXSDTest.java
@@ -16,6 +16,7 @@ import static org.eclipse.lemminx.XMLAssert.ca;
 import static org.eclipse.lemminx.XMLAssert.pd;
 import static org.eclipse.lemminx.XMLAssert.r;
 import static org.eclipse.lemminx.XMLAssert.testCodeActionsFor;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
@@ -143,6 +144,173 @@ public class XMLValidationExternalResourcesBasedOnXSDTest extends AbstractCacheB
 				ca(d, DownloadDisabledResourceCodeAction.createDownloadCommand(
 						"Force download of 'http://localhost:8080/sample.xsd'.", "http://localhost:8080/sample.xsd",
 						fileURI)));
+	}
+
+	@Test
+	public void schemaLocationDownloadDisabledUNC() throws Exception {
+
+		XMLValidationRootSettings validation = new XMLValidationRootSettings();
+		validation.setResolveExternalEntities(true);
+
+		XMLLanguageService ls = new XMLLanguageService();
+		ls.initializeIfNeeded();
+		// Disable download
+		ContentModelManager contentModelManager = ls.getComponent(ContentModelManager.class);
+		contentModelManager.setDownloadExternalResources(false);
+
+		String xml = "<?xml-model href=\"file://example.com/schemas/my-schema.xsd\"?>\r\n" + //
+				"<root-element>\r\n" + //
+				"	\r\n" + //
+				"</root-element>\r\n";
+
+		String fileURI = "test.xml";
+
+		Diagnostic d = new Diagnostic(r(0, 18, 0, 58), "Downloading external resources is disabled.",
+				DiagnosticSeverity.Error, "xml", ExternalResourceErrorCode.DownloadResourceDisabled.getCode());
+
+		// Test diagnostics
+		XMLAssert.testPublishDiagnosticsFor(xml, fileURI, validation, ls, pd(fileURI, d, //
+				new Diagnostic(r(1, 1, 1, 13), "cvc-elt.1.a: Cannot find the declaration of element 'root-element'.",
+						DiagnosticSeverity.Error, "xml", XMLSchemaErrorCode.cvc_elt_1_a.getCode())));
+
+		// Test code action
+		testCodeActionsFor(xml, fileURI, d, //
+				ca(d, DownloadDisabledResourceCodeAction.createDownloadCommand(
+						"Force download of 'file://example.com/schemas/my-schema.xsd'.", "file://example.com/schemas/my-schema.xsd",
+						fileURI)));
+	}
+
+	@Test
+	public void schemaLocationDownloadDisabledUNC2() throws Exception {
+
+		XMLValidationRootSettings validation = new XMLValidationRootSettings();
+		validation.setResolveExternalEntities(true);
+
+		XMLLanguageService ls = new XMLLanguageService();
+		ls.initializeIfNeeded();
+		// Disable download
+		ContentModelManager contentModelManager = ls.getComponent(ContentModelManager.class);
+		contentModelManager.setDownloadExternalResources(false);
+
+		String xml = "<?xml-model href=\"//example.com/schemas/my-schema.xsd\"?>\r\n" + //
+				"<root-element>\r\n" + //
+				"	\r\n" + //
+				"</root-element>\r\n";
+
+		String fileURI = "test.xml";
+
+		Diagnostic d = new Diagnostic(r(0, 18, 0, 53), "Downloading external resources is disabled.",
+				DiagnosticSeverity.Error, "xml", ExternalResourceErrorCode.DownloadResourceDisabled.getCode());
+
+		// Test diagnostics
+		XMLAssert.testPublishDiagnosticsFor(xml, fileURI, validation, ls, pd(fileURI, d, //
+				new Diagnostic(r(1, 1, 1, 13), "cvc-elt.1.a: Cannot find the declaration of element 'root-element'.",
+						DiagnosticSeverity.Error, "xml", XMLSchemaErrorCode.cvc_elt_1_a.getCode())));
+
+		// FIXME:
+		testCodeActionsFor(xml, fileURI, d, //
+				ca(d, DownloadDisabledResourceCodeAction.createDownloadCommand(
+						"Force download of '//example.com/schemas/my-schema.xsd'.", "//example.com/schemas/my-schema.xsd",
+						fileURI)));
+	}
+
+	@Test
+	public void schemaLocationDownloadDisabledUNC3() throws Exception {
+
+		XMLValidationRootSettings validation = new XMLValidationRootSettings();
+		validation.setResolveExternalEntities(true);
+
+		XMLLanguageService ls = new XMLLanguageService();
+		ls.initializeIfNeeded();
+		// Disable download
+		ContentModelManager contentModelManager = ls.getComponent(ContentModelManager.class);
+		contentModelManager.setDownloadExternalResources(false);
+
+		String xml = "<?xml-model href=\"file:////example.com/schemas/my-schema.xsd\"?>\r\n" + //
+				"<root-element>\r\n" + //
+				"	\r\n" + //
+				"</root-element>\r\n";
+
+		String fileURI = "test.xml";
+
+		Diagnostic d = new Diagnostic(r(0, 18, 0, 60), "Downloading external resources is disabled.",
+				DiagnosticSeverity.Error, "xml", ExternalResourceErrorCode.DownloadResourceDisabled.getCode());
+
+		// Test diagnostics
+		XMLAssert.testPublishDiagnosticsFor(xml, fileURI, validation, ls, pd(fileURI, d, //
+				new Diagnostic(r(1, 1, 1, 13), "cvc-elt.1.a: Cannot find the declaration of element 'root-element'.",
+						DiagnosticSeverity.Error, "xml", XMLSchemaErrorCode.cvc_elt_1_a.getCode())));
+
+		testCodeActionsFor(xml, fileURI, d, //
+				ca(d, DownloadDisabledResourceCodeAction.createDownloadCommand(
+						"Force download of 'file:////example.com/schemas/my-schema.xsd'.", "file:////example.com/schemas/my-schema.xsd",
+						fileURI)));
+	}
+
+	@Test
+	public void schemaLocationDownloadDisabledUNC4() throws Exception {
+
+		assumeTrue("\r\n".equals(System.lineSeparator()));
+
+		XMLValidationRootSettings validation = new XMLValidationRootSettings();
+		validation.setResolveExternalEntities(true);
+
+		XMLLanguageService ls = new XMLLanguageService();
+		ls.initializeIfNeeded();
+		// Disable download
+		ContentModelManager contentModelManager = ls.getComponent(ContentModelManager.class);
+		contentModelManager.setDownloadExternalResources(false);
+
+		String xml = "<?xml-model href=\"\\\\example.com\\schemas\\my-schema.xsd\"?>\r\n" + //
+				"<root-element>\r\n" + //
+				"	\r\n" + //
+				"</root-element>\r\n";
+
+		String fileURI = "test.xml";
+
+		Diagnostic d = new Diagnostic(r(0, 18, 0, 53), "Downloading external resources is disabled.",
+				DiagnosticSeverity.Error, "xml", ExternalResourceErrorCode.DownloadResourceDisabled.getCode());
+
+		// Test diagnostics
+		XMLAssert.testPublishDiagnosticsFor(xml, fileURI, validation, ls, pd(fileURI, d, //
+				new Diagnostic(r(1, 1, 1, 13), "cvc-elt.1.a: Cannot find the declaration of element 'root-element'.",
+						DiagnosticSeverity.Error, "xml", XMLSchemaErrorCode.cvc_elt_1_a.getCode())));
+
+		testCodeActionsFor(xml, fileURI, d, //
+				ca(d, DownloadDisabledResourceCodeAction.createDownloadCommand(
+						"Force download of '\\\\example.com\\schemas\\my-schema.xsd'.", "\\\\example.com\\schemas\\my-schema.xsd",
+						fileURI)));
+	}
+
+	@Test
+	public void schemaLocationDownloadDisabledUNC5() throws Exception {
+
+		assumeTrue("\r\n".equals(System.lineSeparator()));
+
+		XMLValidationRootSettings validation = new XMLValidationRootSettings();
+		validation.setResolveExternalEntities(true);
+
+		XMLLanguageService ls = new XMLLanguageService();
+		ls.initializeIfNeeded();
+		// Disable download
+		ContentModelManager contentModelManager = ls.getComponent(ContentModelManager.class);
+		contentModelManager.setDownloadExternalResources(false);
+
+		String xml = "<?xml-model href=\"\\\\localhost\\C$\\Users\\Mira\\schemas\\my-schema.xsd\"?>\r\n" + //
+				"<root-element>\r\n" + //
+				"	\r\n" + //
+				"</root-element>\r\n";
+
+		String fileURI = "test.xml";
+
+		Diagnostic d = new Diagnostic(r(0, 18, 0, 65), "schema_reference.4: Failed to read schema document 'file://localhost/C$/Users/Mira/schemas/my-schema.xsd', because 1) could not find the document; 2) the document could not be read; 3) the root element of the document is not <xsd:schema>.",
+				DiagnosticSeverity.Warning, "xml", XMLSchemaErrorCode.schema_reference_4.getCode());
+
+		// Test diagnostics
+		XMLAssert.testPublishDiagnosticsFor(xml, fileURI, validation, ls, pd(fileURI, d, //
+				new Diagnostic(r(1, 1, 1, 13), "cvc-elt.1.a: Cannot find the declaration of element 'root-element'.",
+						DiagnosticSeverity.Error, "xml", XMLSchemaErrorCode.cvc_elt_1_a.getCode())));
+
 	}
 
 	@Test

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/uriresolver/CacheResourcesManagerTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/uriresolver/CacheResourcesManagerTest.java
@@ -70,6 +70,8 @@ public class CacheResourcesManagerTest extends AbstractCacheBasedTest {
 		assertEquals(useCacheEnabled, cacheResourcesManager.canUseCache("ftp://foo"));
 		assertEquals(useCacheEnabled, cacheResourcesManager.canUseCache("https://foo"));
 		assertFalse(cacheResourcesManager.canUseCache("file:///foo"));
+		assertEquals(useCacheEnabled, cacheResourcesManager.canUseCache("file://example.com/schemas/my-schema.xsd"));
+		assertEquals(useCacheEnabled, cacheResourcesManager.canUseCache("//example.com/schemas/my-schema.xsd"));
 	}
 
 	@Test


### PR DESCRIPTION
- When downloading external resources is disabled, don't attempt to download non-local schema files referenced using UNCs
  - eg. `file://example.org/schemas/my-schema.xsd`, `//example.org/schemas/my-schema.xsd`, `file:////example.org/schemas/my-schema.xsd`
- Use the schema cache for resources referenced through UNCs
  - Unless the authority is `localhost` eg. `//localhost/C$/Users/Mira/my-schema.xsd`
- Fix a minor bug where the error range is wrong for schemas referenced through a UNC starting with `//` in `<?xml-model href="...`