### PR TITLE
fix: register InlineCompletion LSP4J classes for native image reflection

### DIFF
--- a/org.eclipse.lemminx/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/org.eclipse.lemminx/src/main/resources/META-INF/native-image/reflect-config.json
@@ -1365,8 +1365,16 @@
             "parameterTypes": []
         }]
     },
-	{
-		"name": "org.eclipse.lsp4j.FoldingRangeProviderOptions",
+    {
+        "name": "org.eclipse.lsp4j.FoldingRangeWorkspaceCapabilities",
+        "allDeclaredFields": true,
+        "methods": [{
+            "name": "<init>",
+            "parameterTypes": []
+        }]
+    },
+ {
+  "name": "org.eclipse.lsp4j.FoldingRangeProviderOptions",
 		"allDeclaredFields": true,
 		"methods": [{
 			"name": "<init>",
@@ -2286,6 +2294,13 @@
 	},
 	{
 		"name": "org.eclipse.lsp4j.adapters.SemanticTokensFullDeltaResponseAdapter",
+		"methods": [{
+			"name": "<init>",
+			"parameterTypes": []
+		}]
+	},
+	{
+		"name": "org.eclipse.lsp4j.adapters.TextEditListAdapter",
 		"methods": [{
 			"name": "<init>",
 			"parameterTypes": []

--- a/org.eclipse.lemminx/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/org.eclipse.lemminx/src/main/resources/META-INF/native-image/reflect-config.json
@@ -1471,7 +1471,61 @@
             "parameterTypes": []
         }]
     },
-            {
+    {
+        "name": "org.eclipse.lsp4j.InlineCompletionCapabilities",
+        "allDeclaredFields": true,
+        "methods": [{
+            "name": "<init>",
+            "parameterTypes": []
+        }]
+    },
+    {
+        "name": "org.eclipse.lsp4j.InlineCompletionContext",
+        "allDeclaredFields": true,
+        "methods": [{
+            "name": "<init>",
+            "parameterTypes": []
+        }]
+    },
+    {
+        "name": "org.eclipse.lsp4j.InlineCompletionItem",
+        "allDeclaredFields": true,
+        "methods": [{
+            "name": "<init>",
+            "parameterTypes": []
+        }]
+    },
+    {
+        "name": "org.eclipse.lsp4j.InlineCompletionList",
+        "allDeclaredFields": true,
+        "methods": [{
+            "name": "<init>",
+            "parameterTypes": []
+        }]
+    },
+    {
+        "name": "org.eclipse.lsp4j.InlineCompletionParams",
+        "allDeclaredFields": true,
+        "methods": [{
+            "name": "<init>",
+            "parameterTypes": []
+        }]
+    },
+    {
+        "name": "org.eclipse.lsp4j.InlineCompletionRegistrationOptions",
+        "allDeclaredFields": true,
+        "methods": [{
+            "name": "<init>",
+            "parameterTypes": []
+        }]
+    },
+    {
+        "name": "org.eclipse.lsp4j.InlineCompletionTriggerKind",
+        "fields": [{
+            "name": "value"
+        }]
+    },
+    {
         "name": "org.eclipse.lsp4j.InlineValueCapabilities",
         "allDeclaredFields": true,
         "methods": [{


### PR DESCRIPTION
The inline completion feature introduced in PR #1784 uses new LSP4J classes that were not registered for GraalVM native image reflection, breaking the binary build of LemMinX.

Register the following classes in reflect-config.json:
- InlineCompletionCapabilities
- InlineCompletionContext
- InlineCompletionItem
- InlineCompletionList
- InlineCompletionParams
- InlineCompletionRegistrationOptions
- InlineCompletionTriggerKind

Fixes https://github.com/eclipse-lemminx/lemminx/pull/1784#issuecomment-5127633255