### PR TITLE
fix xml scanner to handle angle brackets in PI content

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/parser/XMLScanner.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/parser/XMLScanner.java
@@ -271,10 +271,7 @@ public class XMLScanner implements Scanner {
 					return finishToken(offset, TokenType.PIName);
 				}
 			}
-			stream.advanceUntilCharsOrNewTag(END_PROLOG_PATTERN); // ?>
-			if (stream.peekChar() == _LAN) {
-				state = ScannerState.WithinContent; // TODO: check if EOF causes issues
-			}
+			stream.advanceUntilChars(END_PROLOG_PATTERN); // ?>
 			return internalScan();
 
 		case WithinPI:
@@ -286,14 +283,7 @@ public class XMLScanner implements Scanner {
 				state = getWithinContentState();
 				return finishToken(offset, TokenType.PIEnd);
 			}
-			if (stream.advanceUntilCharsOrNewTag(END_PROLOG_PATTERN)) { // ?>
-				if (stream.peekChar() == _LAN) {
-					state = getWithinContentState();
-				}
-				if (getTokenTextFromOffset(offset).length() == 0) {
-					return finishToken(offset, TokenType.PIEnd);
-				}
-			}
+			stream.advanceUntilChars(END_PROLOG_PATTERN); // ?>
 			return finishToken(offset, TokenType.PIContent);
 
 		case WithinContent:

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/dom/parser/XMLScannerTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/dom/parser/XMLScannerTest.java
@@ -802,6 +802,22 @@ public class XMLScannerTest {
 	}
 
 	@Test
+	public void testPIWithBracketsInContent() {
+		scanner = XMLScanner.createScanner("<a><?form <varGrp/>?></a>");
+		assertOffsetAndToken(0, TokenType.StartTagOpen);
+		assertOffsetAndToken(1, TokenType.StartTag);
+		assertOffsetAndToken(2, TokenType.StartTagClose);
+		assertOffsetAndToken(3, TokenType.StartPrologOrPI);
+		assertOffsetAndToken(5, TokenType.PIName, "form");
+		assertOffsetAndToken(9, TokenType.Whitespace);
+		assertOffsetAndToken(10, TokenType.PIContent);
+		assertOffsetAndToken(19, TokenType.PIEnd);
+		assertOffsetAndToken(21, TokenType.EndTagOpen);
+		assertOffsetAndToken(23, TokenType.EndTag);
+		assertOffsetAndToken(24, TokenType.EndTagClose);
+	}
+
+	@Test
 	public void testMissingClosingBracket() {
 		scanner = XMLScanner.createScanner("<a</a>");
 		assertOffsetAndToken(0, TokenType.StartTagOpen);


### PR DESCRIPTION
Hello, 

With the current implementation, "<" inside a PI content breaks the scanner. As per https://www.w3.org/TR/xml/#sec-pi, the content of a PI should be opaque and a square bracket shouldn't have an effect. 

This PR replaces stream.advanceUntilCharsOrNewTag with stream.advanceUntilChars  in XMLScanner and adds a test.

I'm happy to follow your instructions if I missed an edge case ! Thank you for your time. 

Cheers,

Yoelis