### PR TITLE
fix: update MissingChildElementCodeActionTest for PreTeXt schema change

### DIFF
--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/relaxng/xml/codeaction/MissingChildElementCodeActionTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/relaxng/xml/codeaction/MissingChildElementCodeActionTest.java
@@ -452,7 +452,9 @@ public class MissingChildElementCodeActionTest extends AbstractCacheBasedTest {
 				ca(d, createData("test.xml", required_elements_missing_expectedCodeActionResolver.PARTICIPANT_ID,
 						"letter")),
 				ca(d, createData("test.xml", required_elements_missing_expectedCodeActionResolver.PARTICIPANT_ID,
-						"memo")), //
+						"memo")),
+				ca(d, createData("test.xml", required_elements_missing_expectedCodeActionResolver.PARTICIPANT_ID,
+						"slideshow")), //
 				// XML Minify
 				ca(null, createData("test.xml", MinifyCodeActionResolver.PARTICIPANT_ID, null)));
 


### PR DESCRIPTION
The upstream PreTeXt RNG schema added 'slideshow' as a new root element choice. Update the test to expect this additional code action.

Fixes #1799