### PR TITLE
Add CharSequence API to avoid String allocation on document updates

### DIFF
--- a/org.eclipse.lemminx/src/main/java/com/thaiopensource/relaxng/pattern/CMRelaxNGDocument.java
+++ b/org.eclipse.lemminx/src/main/java/com/thaiopensource/relaxng/pattern/CMRelaxNGDocument.java
@@ -317,6 +317,6 @@ public class CMRelaxNGDocument implements CMDocument {
 	private static String getTextContent(DOMElement element) {
 		int start = element.getStartTagCloseOffset() + 1;
 		int end = element.getEndTagOpenOffset();
-		return element.getOwnerDocument().getText().substring(start, end);
+		return element.getOwnerDocument().getText(start, end);
 	}
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/CharSequenceReader.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/CharSequenceReader.java
@@ -1,0 +1,95 @@
+/**
+ *  Copyright (c) 2026 Angelo ZERR.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v2.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ */
+package org.eclipse.lemminx.commons;
+
+import java.io.Reader;
+
+/**
+ * A {@link Reader} that reads from a {@link CharSequence} without requiring
+ * conversion to {@link String}. This avoids the memory cost of materializing a
+ * full String copy when the backing store is a {@link StringBuilder}.
+ * <p>
+ * Supports {@link #mark(int)}/{@link #reset()} for compatibility with parsers
+ * (e.g. Xerces) that may use mark/reset during encoding detection.
+ * </p>
+ */
+public class CharSequenceReader extends Reader {
+
+	private final CharSequence source;
+	private final int length;
+	private int pos;
+	private int mark;
+
+	public CharSequenceReader(CharSequence source) {
+		this.source = source;
+		this.length = source.length();
+	}
+
+	@Override
+	public int read() {
+		if (pos >= length) {
+			return -1;
+		}
+		return source.charAt(pos++);
+	}
+
+	@Override
+	public int read(char[] cbuf, int off, int len) {
+		if (pos >= length) {
+			return -1;
+		}
+		int count = Math.min(len, length - pos);
+		if (source instanceof String) {
+			((String) source).getChars(pos, pos + count, cbuf, off);
+		} else if (source instanceof StringBuilder) {
+			((StringBuilder) source).getChars(pos, pos + count, cbuf, off);
+		} else {
+			for (int i = 0; i < count; i++) {
+				cbuf[off + i] = source.charAt(pos + i);
+			}
+		}
+		pos += count;
+		return count;
+	}
+
+	@Override
+	public long skip(long n) {
+		long skipped = Math.min(n, length - pos);
+		pos += (int) skipped;
+		return skipped;
+	}
+
+	@Override
+	public boolean ready() {
+		return pos < length;
+	}
+
+	@Override
+	public boolean markSupported() {
+		return true;
+	}
+
+	@Override
+	public void mark(int readAheadLimit) {
+		mark = pos;
+	}
+
+	@Override
+	public void reset() {
+		pos = mark;
+	}
+
+	@Override
+	public void close() {
+	}
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/ILineTracker.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/ILineTracker.java
@@ -142,7 +142,7 @@ public interface ILineTracker {
 	 *
 	 * @param text the new tracked text
 	 */
-	void set(String text);
+	void set(CharSequence text);
 
 	Position getPositionAt(int position) throws BadLocationException;
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/ListLineTracker.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/ListLineTracker.java
@@ -343,7 +343,7 @@ class ListLineTracker implements ILineTracker {
 	 * @param offset the offset in the given text
 	 * @return the information of the first found delimiter or <code>null</code>
 	 */
-	protected DelimiterInfo nextDelimiterInfo(String text, int offset) {
+	protected DelimiterInfo nextDelimiterInfo(CharSequence text, int offset) {
 		char ch;
 		int length = text.length();
 		for (int i = offset; i < length; i++) {
@@ -389,7 +389,7 @@ class ListLineTracker implements ILineTracker {
 	 * @param offset         the offset of all newly created lines
 	 * @return the number of newly created lines
 	 */
-	private int createLines(String text, int insertPosition, int offset) {
+	private int createLines(CharSequence text, int insertPosition, int offset) {
 
 		int count = 0;
 		int start = 0;
@@ -432,7 +432,7 @@ class ListLineTracker implements ILineTracker {
 	}
 
 	@Override
-	public final void set(String text) {
+	public final void set(CharSequence text) {
 		fLines.clear();
 		if (text != null) {
 			fTextLength = text.length();

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/TextDocument.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/TextDocument.java
@@ -17,6 +17,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.eclipse.lemminx.utils.StringUtils;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
@@ -39,6 +40,9 @@ public class TextDocument extends TextDocumentItem {
 
 	private boolean incremental;
 
+	private CharSequence textSequence;
+	private boolean textDirty;
+
 	public TextDocument(TextDocumentItem document) {
 		this(document.getText(), document.getUri());
 		super.setVersion(document.getVersion());
@@ -47,12 +51,68 @@ public class TextDocument extends TextDocumentItem {
 
 	public TextDocument(String text, String uri) {
 		super.setUri(uri);
-		super.setText(text);
+		setText(text);
+	}
+
+	@Override
+	public void setText(String text) {
+		this.textSequence = text;
+		this.textDirty = true;
+	}
+
+	/**
+	 * Returns the text content as a {@link String}. Prefer
+	 * {@link #getTextSequence()} which avoids costly string materialization when
+	 * the document is backed by a {@link StringBuilder}.
+	 *
+	 * @deprecated Use {@link #getTextSequence()} instead to avoid allocating a full
+	 *             String copy of the document text.
+	 */
+	@Deprecated
+	@Override
+	public String getText() {
+		if (textDirty) {
+			super.setText(textSequence.toString());
+			textDirty = false;
+		}
+		return super.getText();
+	}
+
+	/**
+	 * Returns the text content as a {@link CharSequence}, avoiding the allocation
+	 * of a full {@link String} copy when the document is backed by a
+	 * {@link StringBuilder}.
+	 * <p>
+	 * <b>Thread-safety contract:</b> The returned {@link CharSequence} references
+	 * the live internal buffer and is valid until the next call to
+	 * {@link #update(List)}. Callers must not retain or read the returned sequence
+	 * across an update. In practice, the LSP protocol guarantees that
+	 * {@code textDocument/didChange} (which calls {@link #update(List)}) cancels
+	 * any in-progress parse via {@code CancelChecker} before modifying the buffer,
+	 * so concurrent reads cannot occur.
+	 * </p>
+	 *
+	 * @return the text content as a {@link CharSequence}.
+	 */
+	public CharSequence getTextSequence() {
+		return textSequence;
+	}
+
+	/**
+	 * Returns a {@link String} from the text content between the given
+	 * <code>start</code> and <code>end</code> offsets.
+	 *
+	 * @param start the start offset.
+	 * @param end   the end offset.
+	 * @return a {@link String} from the text content between the given
+	 *         <code>start</code> and <code>end</code> offsets.
+	 */
+	public String getText(int start, int end) {
+		return StringUtils.getString(textSequence, start, end);
 	}
 
 	public void setIncremental(boolean incremental) {
 		this.incremental = incremental;
-		// reset line tracker
 		lineTracker = null;
 		getLineTracker();
 	}
@@ -74,8 +134,7 @@ public class TextDocument extends TextDocumentItem {
 	public String lineText(int lineNumber) throws BadLocationException {
 		ILineTracker lineTracker = getLineTracker();
 		Line line = lineTracker.getLineInformation(lineNumber);
-		String text = super.getText();
-		return text.substring(line.offset, line.offset + line.length);
+		return StringUtils.getString(textSequence, line.offset, line.offset + line.length);
 	}
 
 	public int lineOffsetAt(int position) throws BadLocationException {
@@ -115,8 +174,7 @@ public class TextDocument extends TextDocumentItem {
 			Position pos = positionAt(textOffset);
 			ILineTracker lineTracker = getLineTracker();
 			Line line = lineTracker.getLineInformation(pos.getLine());
-			String text = super.getText();
-			String lineText = text.substring(line.offset, textOffset);
+			String lineText = StringUtils.getString(textSequence, line.offset, textOffset);
 			int position = lineText.length();
 			Matcher m = wordDefinition.matcher(lineText);
 			int currentPosition = 0;
@@ -149,7 +207,7 @@ public class TextDocument extends TextDocumentItem {
 			return lineTracker;
 		}
 		ILineTracker lineTracker = isIncremental() ? new TreeLineTracker(new ListLineTracker()) : new ListLineTracker();
-		lineTracker.set(super.getText());
+		lineTracker.set(textSequence);
 		return lineTracker;
 	}
 
@@ -168,10 +226,16 @@ public class TextDocument extends TextDocumentItem {
 			try {
 				long start = System.currentTimeMillis();
 				synchronized (lock) {
-					// Initialize buffer and line tracker from the current text document
-					StringBuilder buffer = new StringBuilder(getText());
-
-					// Loop for each changes and update the buffer
+					// Lazy conversion to StringBuilder for in-place editing via
+					// buffer.replace() — avoids creating a new String on every keystroke.
+					// Done here (first keystroke) instead of in setIncremental() so that
+					// the humongous allocation triggers G1GC, which collects the old DOM
+					// tree (nulled by cancelModel()) before re-parse — avoiding a
+					// transient memory peak that could cause OOM.
+					if (!(textSequence instanceof StringBuilder)) {
+						textSequence = new StringBuilder(textSequence);
+					}
+					StringBuilder buffer = (StringBuilder) textSequence;
 					for (int i = 0; i < changes.size(); i++) {
 
 						TextDocumentContentChangeEvent changeEvent = changes.get(i);
@@ -180,7 +244,8 @@ public class TextDocument extends TextDocumentItem {
 
 						if (range != null) {
 							Integer rangeLength = changeEvent.getRangeLength();
-							length = rangeLength != null ? rangeLength.intValue() : offsetAt(range.getEnd()) - offsetAt(range.getStart());
+							length = rangeLength != null ? rangeLength.intValue()
+									: offsetAt(range.getEnd()) - offsetAt(range.getStart());
 						} else {
 							// range is optional and if not given, the whole file content is replaced
 							length = buffer.length();
@@ -191,8 +256,7 @@ public class TextDocument extends TextDocumentItem {
 						buffer.replace(startOffset, startOffset + length, text);
 						lineTracker.replace(startOffset, length, text);
 					}
-					// Update the new text content from the updated buffer
-					setText(buffer.toString());
+					textDirty = true;
 				}
 				LOGGER.fine("Text document content updated in " + (System.currentTimeMillis() - start) + "ms");
 			} catch (BadLocationException e) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/TextEditUtils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/TextEditUtils.java
@@ -64,7 +64,7 @@ public class TextEditUtils {
 	 *         given range (from, to) of the given text document and null otherwise.
 	 */
 	public static TextEdit createTextEditIfNeeded(int from, int to, String expectedContent, TextDocument textDocument) {
-		String text = textDocument.getText();
+		CharSequence text = textDocument.getTextSequence();
 
 		// Check if content from the range [from, to] is the same than expected content
 		if (isMatchExpectedContent(from, to, expectedContent, text)) {
@@ -96,7 +96,7 @@ public class TextEditUtils {
 	 * @return true if the given content from the range [from, to] of the given text
 	 *         is the same than expected content and false otherwise.
 	 */
-	private static boolean isMatchExpectedContent(int from, int to, String expectedContent, String text) {
+	private static boolean isMatchExpectedContent(int from, int to, String expectedContent, CharSequence text) {
 		if (expectedContent.length() == to - from) {
 			int j = 0;
 			for (int i = from; i < to; i++) {
@@ -113,7 +113,7 @@ public class TextEditUtils {
 	}
 
 	public static String applyEdits(TextDocument document, List<? extends TextEdit> edits) throws BadLocationException {
-		String text = document.getText();
+		CharSequence text = document.getTextSequence();
 		Collections.sort(edits /* .map(getWellformedEdit) */, (a, b) -> {
 			int diff = a.getRange().getStart().getLine() - b.getRange().getStart().getLine();
 			if (diff == 0) {
@@ -155,7 +155,7 @@ public class TextEditUtils {
 	 * @return the offset of the first whitespace that's found in the given range
 	 *         [leftLimit,to] from the left of the to, and leftLimit otherwise.
 	 */
-	public static int adjustOffsetWithLeftWhitespaces(int leftLimit, int to, String text) {
+	public static int adjustOffsetWithLeftWhitespaces(int leftLimit, int to, CharSequence text) {
 		if (to == 0) {
 			return -1;
 		}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/TreeLineTracker.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/TreeLineTracker.java
@@ -1179,7 +1179,7 @@ public class TreeLineTracker implements ILineTracker {
 	 * @param offset the offset in the given text
 	 * @return the information of the first found delimiter or <code>null</code>
 	 */
-	protected DelimiterInfo nextDelimiterInfo(String text, int offset) {
+	protected DelimiterInfo nextDelimiterInfo(CharSequence text, int offset) {
 		char ch;
 		int length = text.length();
 		for (int i = offset; i < length; i++) {
@@ -1416,10 +1416,10 @@ public class TreeLineTracker implements ILineTracker {
 	}
 
 	@Override
-	public final void set(String text) {
+	public final void set(CharSequence text) {
 		fRoot = new Node(0, NO_DELIM);
 		try {
-			replace(0, 0, text);
+			replace(0, 0, text.toString());
 		} catch (BadLocationException x) {
 			throw new InternalError();
 		}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMAttr.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMAttr.java
@@ -90,7 +90,7 @@ public class DOMAttr extends DOMNode implements org.w3c.dom.Attr {
 		// Memory optimization: Extract name from document instead of caching
 		if (nameStart != NULL_VALUE && nameEnd != NULL_VALUE) {
 			// Name is in the document, extract it
-			return getOwnerDocument().getText().substring(nameStart, nameEnd);
+			return getOwnerDocument().getText(nameStart, nameEnd);
 		}
 		// Name was set programmatically or doesn't exist
 		return name;
@@ -228,7 +228,7 @@ public class DOMAttr extends DOMNode implements org.w3c.dom.Attr {
 	public String getOriginalValue() {
 		// Memory optimization: Extract from document instead of caching
 		if (valueStart != NULL_VALUE && delimiter < valueStart) {
-			return getOwnerDocument().getText().substring(valueStart, valueEnd);
+			return getOwnerDocument().getText(valueStart, valueEnd);
 		}
 		return value;
 	}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMCharacterData.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMCharacterData.java
@@ -137,7 +137,7 @@ public abstract class DOMCharacterData extends DOMNode implements org.w3c.dom.Ch
 	public String getData() {
 		// No caching - extract directly from document to save memory
 		// The document text is already in memory, so this is just a substring operation
-		return getOwnerDocument().getText().substring(getStartContent(), getEndContent());
+		return getOwnerDocument().getText(getStartContent(), getEndContent());
 	}
 
 	/*

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMDocument.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMDocument.java
@@ -67,7 +67,7 @@ public class DOMDocument extends DOMNode implements Document {
 	private String externalGrammarFromNamespaceURI;
 
 	public DOMDocument(TextDocument textDocument, URIResolverExtensionManager resolverExtensionManager) {
-		super(0, textDocument.getText().length());
+		super(0, textDocument.getTextSequence().length());
 		this.textDocument = textDocument;
 		this.resolverExtensionManager = resolverExtensionManager;
 		resetGrammar();
@@ -133,11 +133,35 @@ public class DOMDocument extends DOMNode implements Document {
 
 	/**
 	 * Returns the text content of the XML document.
-	 * 
+	 *
 	 * @return the text content of the XML document.
+	 * @deprecated Use {@link #getTextSequence()} instead.
 	 */
+	@Deprecated
 	public String getText() {
 		return textDocument.getText();
+	}
+
+	/**
+	 * Returns the text content as a {@link CharSequence}.
+	 *
+	 * @return the text content as a {@link CharSequence}.
+	 */
+	public CharSequence getTextSequence() {
+		return textDocument.getTextSequence();
+	}
+
+	/**
+	 * Returns a {@link String} from the text content between the given
+	 * <code>start</code> and <code>end</code> offsets.
+	 *
+	 * @param start the start offset.
+	 * @param end   the end offset.
+	 * @return a {@link String} from the text content between the given
+	 *         <code>start</code> and <code>end</code> offsets.
+	 */
+	public String getText(int start, int end) {
+		return textDocument.getText(start, end);
 	}
 
 	public TextDocument getTextDocument() {
@@ -892,7 +916,7 @@ public class DOMDocument extends DOMNode implements Document {
 	}
 
 	public Range getTrimmedRange(int start, int end) {
-		String text = getText();
+		CharSequence text = getTextSequence();
 		char c = text.charAt(start);
 		while (Character.isWhitespace(c)) {
 			start++;

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMDocumentType.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMDocumentType.java
@@ -47,7 +47,7 @@ public class DOMDocumentType extends DTDDeclNode implements org.w3c.dom.Document
 	@Override
 	public String getTextContent() {
 		if (content == null) {
-			content = getOwnerDocument().getText().substring(getStart(), getEnd());
+			content = getOwnerDocument().getText(getStart(), getEnd());
 		}
 		return content;
 	}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMElement.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMElement.java
@@ -249,7 +249,7 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 	 * position after the character you want to start at.
 	 */
 	public Integer endsWith(char c, int startOffset) {
-		String text = this.getOwnerDocument().getText();
+		CharSequence text = this.getOwnerDocument().getTextSequence();
 		if (startOffset > text.length() || startOffset < 0) {
 			return null;
 		}
@@ -458,7 +458,7 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 	 *          with an angle bracket
 	 */
 	public int getUnclosedStartTagCloseOffset() {
-		String documentText = getOwnerDocument().getText();
+		CharSequence documentText = getOwnerDocument().getTextSequence();
 		int i = getStart() + 1;
 		for (; i < documentText.length() && documentText.charAt(i) != '/' && documentText.charAt(i) != '<'; i++) {
 		}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMParser.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMParser.java
@@ -69,7 +69,7 @@ public class DOMParser {
 			boolean ignoreWhitespaceContent, CancelChecker monitor) {
 		boolean isDTD = DOMUtils.isDTD(document.getUri());
 		boolean inDTDInternalSubset = false;
-		String text = document.getText();
+		CharSequence text = document.getTextSequence();
 		Scanner scanner = XMLScanner.createScanner(text, 0, isDTD);
 		DOMDocument xmlDocument = new DOMDocument(document, resolverExtensionManager);
 		xmlDocument.setCancelChecker(monitor);

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMText.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMText.java
@@ -62,7 +62,7 @@ public class DOMText extends DOMCharacterData implements org.w3c.dom.Text {
 	 */
 	@Override
 	public boolean isElementContentWhitespace() {
-		String text = getOwnerDocument().getOwnerDocument().getText();
+		CharSequence text = getOwnerDocument().getOwnerDocument().getTextSequence();
 		return StringUtils.isWhitespace(text, getStart(), getEnd());
 	}
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DTDElementDecl.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DTDElementDecl.java
@@ -101,7 +101,7 @@ public class DTDElementDecl extends DTDDeclNode {
 			return null;
 		}
 		// We are after the <!ELEMENT name, search the parameter
-		String text = getOwnerDocument().getText();
+		CharSequence text = getOwnerDocument().getTextSequence();
 		// Find the start word offset from the left of the offset (ex : (head|ing) will
 		// return offset of 'h'
 		int paramStart = findStartWord(text, offset, isValidChar);
@@ -134,7 +134,7 @@ public class DTDElementDecl extends DTDDeclNode {
 		int start = name.getEnd();
 		int end = getEnd();
 
-		String text = getOwnerDocument().getText();
+		CharSequence text = getOwnerDocument().getTextSequence();
 		int wordStart = -1;
 		int wordEnd = -1;
 		// Loop for content after <!ELEMENT element-name (
@@ -180,7 +180,7 @@ public class DTDElementDecl extends DTDDeclNode {
 	 *         <code>wordStart</code> offset and ends at <code>wordEnd</code>
 	 *         matches the given <code>searchName</code>
 	 */
-	private static boolean isMatchName(String searchWord, String text, int wordStart, int wordEnd) {
+	private static boolean isMatchName(String searchWord, CharSequence text, int wordStart, int wordEnd) {
 		int length = wordEnd - wordStart;
 		if (searchWord.length() != length) {
 			return false;

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/parser/MultiLineStream.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/parser/MultiLineStream.java
@@ -28,6 +28,8 @@ import static org.eclipse.lemminx.dom.parser.Constants._TAB;
 import static org.eclipse.lemminx.dom.parser.Constants._WSP;
 
 import java.util.HashMap;
+
+import org.eclipse.lemminx.utils.StringUtils;
 import java.util.Map;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
@@ -43,12 +45,12 @@ public class MultiLineStream {
 		return ch == _WSP || ch == _TAB || ch == _NWL || ch == _LFD || ch == _CAR;
 	};
 
-	private final String source;
+	private final CharSequence source;
 	private final int len;
 	private int position;
 	private final Map<Pattern, Matcher> regexpCache;
 
-	public MultiLineStream(String source, int position) {
+	public MultiLineStream(CharSequence source, int position) {
 		this.source = source;
 		this.len = source.length();
 		this.position = position;
@@ -59,8 +61,21 @@ public class MultiLineStream {
 		return this.len <= this.position;
 	}
 
-	public String getSource() {
+	public CharSequence getSource() {
 		return this.source;
+	}
+
+	/**
+	 * Returns a {@link String} from the source between the given
+	 * <code>start</code> and <code>end</code> offsets.
+	 *
+	 * @param start the start offset.
+	 * @param end   the end offset.
+	 * @return a {@link String} from the source between the given
+	 *         <code>start</code> and <code>end</code> offsets.
+	 */
+	public String getText(int start, int end) {
+		return StringUtils.getString(source, start, end);
 	}
 
 	public int pos() {
@@ -103,7 +118,7 @@ public class MultiLineStream {
 		if (pos >= len) {
 			return -1;
 		}
-		return this.source.codePointAt(pos);
+		return Character.codePointAt(this.source, pos);
 	}
 
 	/**
@@ -115,7 +130,7 @@ public class MultiLineStream {
 		if (offset >= len || offset < 0) {
 			return -1;
 		}
-		return this.source.codePointAt(offset);
+		return Character.codePointAt(this.source, offset);
 	}
 
 	public boolean advanceIfChar(int ch) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/parser/XMLScanner.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/parser/XMLScanner.java
@@ -139,7 +139,7 @@ public class XMLScanner implements Scanner {
 	boolean isInitialAttlistDeclCompleted = false;
 	private int nbBraceOpened;
 
-	public XMLScanner(String input, int initialOffset, ScannerState initialState, boolean isDTDFile) {
+	public XMLScanner(CharSequence input, int initialOffset, ScannerState initialState, boolean isDTDFile) {
 		stream = new MultiLineStream(input, initialOffset);
 		state = initialState;
 		tokenOffset = 0;
@@ -1031,7 +1031,7 @@ public class XMLScanner implements Scanner {
 
 	@Override
 	public String getTokenText() {
-		return stream.getSource().substring(tokenOffset, stream.pos());
+		return stream.getText(tokenOffset, stream.pos());
 	}
 
 	@Override
@@ -1050,31 +1050,31 @@ public class XMLScanner implements Scanner {
 	}
 
 	public String getTokenTextFromOffset(int offset) {
-		return stream.getSource().substring(offset, stream.pos());
+		return stream.getText(offset, stream.pos());
 	}
 
-	public static Scanner createScanner(String input) {
+	public static Scanner createScanner(CharSequence input) {
 		return createScanner(input, false);
 	}
 
-	public static Scanner createScanner(String input, boolean isDTD) {
+	public static Scanner createScanner(CharSequence input, boolean isDTD) {
 		return createScanner(input, 0, isDTD);
 	}
 
-	public static Scanner createScanner(String input, int initialOffset) {
+	public static Scanner createScanner(CharSequence input, int initialOffset) {
 		return createScanner(input, initialOffset, false);
 	}
 
-	public static Scanner createScanner(String input, int initialOffset, boolean isDTDFile) {
+	public static Scanner createScanner(CharSequence input, int initialOffset, boolean isDTDFile) {
 		return createScanner(input, initialOffset,
 				isDTDFile ? ScannerState.DTDWithinContent : ScannerState.WithinContent, isDTDFile);
 	}
 
-	public static Scanner createScanner(String input, int initialOffset, ScannerState initialState) {
+	public static Scanner createScanner(CharSequence input, int initialOffset, ScannerState initialState) {
 		return new XMLScanner(input, initialOffset, initialState, false);
 	}
 
-	public static Scanner createScanner(String input, int initialOffset, ScannerState initialState, boolean isDTDFile) {
+	public static Scanner createScanner(CharSequence input, int initialOffset, ScannerState initialState, boolean isDTDFile) {
 		return new XMLScanner(input, initialOffset, initialState, isDTDFile);
 	}
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/ContentModelCompletionParticipant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/ContentModelCompletionParticipant.java
@@ -240,7 +240,7 @@ public class ContentModelCompletionParticipant extends CompletionParticipantAdap
 						CompletionItem item = new CompletionItem(tagName);
 						item.setKind(CompletionItemKind.Property);
 						item.setFilterText(request.getFilterForStartTagName(tagName));
-						String xml = elt.getOwnerDocument().getText().substring(elt.getStart(), elt.getEnd());
+						String xml = elt.getOwnerDocument().getText(elt.getStart(), elt.getEnd());
 						item.setTextEdit(Either.forLeft(new TextEdit(request.getReplaceRange(), xml)));
 						response.addCompletionItem(item);
 						tags.add(item.getLabel());
@@ -456,7 +456,7 @@ public class ContentModelCompletionParticipant extends CompletionParticipantAdap
 							end = document.positionAt(endOffset);
 						}
 						int completionOffset = request.getOffset();
-						String tokenStart = StringUtils.getWhitespaces(document.getText(), startOffset,
+						String tokenStart = StringUtils.getWhitespaces(document.getTextSequence(), startOffset,
 								completionOffset);
 						Range fullRange = new Range(start, end);
 						values.forEach(value -> {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/XMLSyntaxErrorCode.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/XMLSyntaxErrorCode.java
@@ -39,6 +39,7 @@ import org.eclipse.lemminx.extensions.contentmodel.participants.codeactions.nogr
 import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionParticipant;
 import org.eclipse.lemminx.services.extensions.diagnostics.IXMLErrorCode;
 import org.eclipse.lemminx.settings.SharedSettings;
+import org.eclipse.lemminx.utils.StringUtils;
 import org.eclipse.lemminx.utils.XMLPositionUtility;
 import org.eclipse.lemminx.utils.XMLPositionUtility.EntityReferenceRange;
 import org.eclipse.lsp4j.Range;
@@ -191,7 +192,7 @@ public enum XMLSyntaxErrorCode implements IXMLErrorCode {
 			 *
 			 * <a> <a> </a> </b
 			 */
-			int endOffset = removeLeftSpaces(offset, document.getText());
+			int endOffset = removeLeftSpaces(offset, document.getTextSequence());
 			return XMLPositionUtility.selectEndTagName(endOffset, document);
 		}
 		case CustomETag:
@@ -257,8 +258,8 @@ public enum XMLSyntaxErrorCode implements IXMLErrorCode {
 			int startOffset = offset + 1;
 			int endOffset = 0;
 			int errorOffset = offset + 1;
-			String text = document.getText();
-			int startPrologOffset = text.indexOf("<");
+			CharSequence text = document.getTextSequence();
+			int startPrologOffset = StringUtils.indexOf(text, '<', 0);
 			if (errorOffset < startPrologOffset) {
 				// Invalid content given before prolog. Prolog should be the first thing in the
 				// file if given.
@@ -267,7 +268,7 @@ public enum XMLSyntaxErrorCode implements IXMLErrorCode {
 			} else {
 				// Invalid content given after prolog. Either root tag or comment should be
 				// present
-				int firstStartTagOffset = text.indexOf("<", errorOffset);
+				int firstStartTagOffset = StringUtils.indexOf(text, '<', errorOffset);
 				startOffset = errorOffset;
 				endOffset = firstStartTagOffset != -1 ? firstStartTagOffset : text.length();
 			}
@@ -328,7 +329,7 @@ public enum XMLSyntaxErrorCode implements IXMLErrorCode {
 	 * @return the offset of the first character from the left offset which is not a
 	 *         whitespace.
 	 */
-	private static int removeLeftSpaces(final int initialOffset, String text) {
+	private static int removeLeftSpaces(final int initialOffset, CharSequence text) {
 		int offset = initialOffset;
 		if (offset >= text.length()) {
 			return text.length();
@@ -369,7 +370,7 @@ public enum XMLSyntaxErrorCode implements IXMLErrorCode {
 	 * @return the proper range from the given node to the given offset.
 	 */
 	private static Range getRangeFromStartNodeToOffset(DOMNode fromNode, int toOffset, DOMDocument document) {
-		int endOffset = removeLeftSpaces(toOffset, document.getText());
+		int endOffset = removeLeftSpaces(toOffset, document.getTextSequence());
 		int startOffset = fromNode.getStart();
 		if (fromNode.isElement()) {
 			// The from node is a DOM element, adjust end and start offset

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/CloseTagCodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/CloseTagCodeAction.java
@@ -21,6 +21,7 @@ import org.eclipse.lemminx.dom.DOMNode;
 import org.eclipse.lemminx.dom.LineIndentInfo;
 import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionParticipant;
 import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionRequest;
+import org.eclipse.lemminx.utils.StringUtils;
 import org.eclipse.lemminx.utils.XMLPositionUtility;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
@@ -98,7 +99,7 @@ public class CloseTagCodeAction implements ICodeActionParticipant {
 	private void doCodeActionsForStartTagUnclosed(DOMElement element, DOMDocument document, Range diagnosticRange,
 			Diagnostic diagnostic, List<CodeAction> codeActions) throws BadLocationException {
 		// Here start tag element is not closed with '>'.
-		String text = document.getText();
+		CharSequence text = document.getTextSequence();
 		int closeAngleBracketOffset = element.getUnclosedStartTagCloseOffset();
 		final Position closeAngleBracketPosition = document.positionAt(closeAngleBracketOffset);
 		if (!element.hasEndTag()) {
@@ -150,7 +151,7 @@ public class CloseTagCodeAction implements ICodeActionParticipant {
 	private void doCodeActionsForStartTagClosed(DOMElement element, DOMDocument document, Range diagnosticRange,
 			Diagnostic diagnostic, List<CodeAction> codeActions) throws BadLocationException {
 		// Here start tag element is closed with '>'.
-		String text = document.getText();
+		CharSequence text = document.getTextSequence();
 		if (!element.hasEndTag()) {
 			// The element has no an end tag
 			// ex : <foo attr="" >
@@ -261,10 +262,10 @@ public class CloseTagCodeAction implements ICodeActionParticipant {
 	 */
 	private static CodeAction removeTagCodeAction(DOMElement element, DOMDocument document, Diagnostic diagnostic)
 			throws BadLocationException {
-		String text = document.getText();
+		CharSequence text = document.getTextSequence();
 		Position startPosition = document.positionAt(element.getStart());
 		Position endPosition = document.positionAt(element.getEnd());
-		String contentToRemove = text.substring(element.getStart(), element.getEnd());
+		String contentToRemove = StringUtils.getString(text, element.getStart(), element.getEnd());
 		CodeAction removeAction = CodeActionFactory.remove("Remove '" + contentToRemove + "'",
 				new Range(startPosition, endPosition), document.getTextDocument(), diagnostic);
 		return removeAction;
@@ -316,7 +317,7 @@ public class CloseTagCodeAction implements ICodeActionParticipant {
 		return false;
 	}
 
-	private static boolean isCharAt(String text, int offset, char ch) {
+	private static boolean isCharAt(CharSequence text, int offset, char ch) {
 		if (text.length() <= offset) {
 			return false;
 		}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/DownloadDisabledResourceCodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/DownloadDisabledResourceCodeAction.java
@@ -53,7 +53,7 @@ public class DownloadDisabledResourceCodeAction implements ICodeActionParticipan
 			Range diagnosticRange = diagnostic.getRange();
 			int start = document.offsetAt(diagnosticRange.getStart());
 			int end = document.offsetAt(diagnosticRange.getEnd());
-			String url = document.getText().substring(start, end);
+			String url = document.getText(start, end);
 
 			String title = MessageFormat.format(FORCE_DOWNLOAD_TITLE, url);
 			CodeAction codeAction = new CodeAction(title);

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/EntityNotDeclaredCodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/EntityNotDeclaredCodeAction.java
@@ -225,7 +225,7 @@ public class EntityNotDeclaredCodeAction implements ICodeActionParticipant {
 	 */
 	private static String getEntityName(Diagnostic diagnostic, DOMDocument doc) throws BadLocationException {
 		Range range = diagnostic.getRange();
-		String name = doc.getText().substring(doc.offsetAt(range.getStart()), doc.offsetAt(range.getEnd()));
+		String name = doc.getText(doc.offsetAt(range.getStart()), doc.offsetAt(range.getEnd()));
 		String removedAmpAndSemiColon = name.substring(1, name.length() - 1);
 		String message = DiagnosticUtils.getDiagnosticMessage(diagnostic);
 		if (!message.contains("\"" + removedAmpAndSemiColon + "\"")) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/FixMissingSpaceCodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/FixMissingSpaceCodeAction.java
@@ -14,6 +14,7 @@ import java.util.List;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.commons.CodeActionFactory;
 import org.eclipse.lemminx.dom.DOMDocument;
+import org.eclipse.lemminx.utils.StringUtils;
 import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionParticipant;
 import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionRequest;
 import org.eclipse.lsp4j.CodeAction;
@@ -35,8 +36,8 @@ public class FixMissingSpaceCodeAction implements ICodeActionParticipant {
 		try {
 			int startOffset = document.offsetAt(diagnosticRange.getStart());
 			int endOffset = document.offsetAt(diagnosticRange.getEnd());
-			String text = document.getText();
-			String value = text.substring(startOffset, endOffset);
+			CharSequence text = document.getTextSequence();
+			String value = StringUtils.getString(text, startOffset, endOffset);
 			codeActions.add(CodeActionFactory.insert("Add space after '" + value + "'", diagnosticRange.getEnd(), " ",
 					document.getTextDocument(), diagnostic));
 		} catch (BadLocationException | IndexOutOfBoundsException e) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/core/participants/inlinecompletion/XMLCloseTagInlineCompletionParticipant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/core/participants/inlinecompletion/XMLCloseTagInlineCompletionParticipant.java
@@ -49,9 +49,9 @@ public class XMLCloseTagInlineCompletionParticipant implements IInlineCompletion
 		}
 
 		// Check if the cursor is at a position where we should suggest a closing tag
-		String text = document.getText();
+		CharSequence text = document.getTextSequence();
 		if (offset > 0 && offset <= text.length()) {
-			int charBefore = text.codePointAt(offset - 1);
+			int charBefore = Character.codePointAt(text, offset - 1);
 
 			// Suggest closing tag after '>' or after content
 			if (charBefore == _RAN || Character.isLetterOrDigit(charBefore) || Character.isWhitespace(charBefore)) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/dtd/participants/diagnostics/DTDValidator.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/dtd/participants/diagnostics/DTDValidator.java
@@ -14,7 +14,7 @@ package org.eclipse.lemminx.extensions.dtd.participants.diagnostics;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.io.StringReader;
+import org.eclipse.lemminx.commons.CharSequenceReader;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.CancellationException;
@@ -52,10 +52,9 @@ public class DTDValidator {
 					validationSettings);
 
 			XMLDTDLoader loader = new LSPXML11DTDProcessor(entityManager, reporterForXML, entityResolver);
-			String content = document.getText();
 			String uri = document.getDocumentURI();
 
-			Reader inputStream = new StringReader(content);
+			Reader inputStream = new CharSequenceReader(document.getTextSequence());
 			XMLInputSource source = new XMLInputSource(null, uri, uri, inputStream, null);
 			loader.loadGrammar(source);
 		} catch (IOException | CancellationException exception) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/filepath/participants/FilePathCompletionParticipant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/filepath/participants/FilePathCompletionParticipant.java
@@ -216,7 +216,7 @@ public class FilePathCompletionParticipant extends CompletionParticipantAdapter 
 		// ex: <a href="|path/to/fil|" />
 		// base dir is equals for instance to C://path/to
 		Character separator = expression != null ? expression.getSeparator() : null;
-		FilePathCompletionResult result = FilePathCompletionResult.create(xmlDocument.getText(),
+		FilePathCompletionResult result = FilePathCompletionResult.create(xmlDocument.getTextSequence(),
 				xmlDocument.getDocumentURI(), startOffset, endOffset, completionOffset, separator);
 		Path baseDir = result.getBaseDir();
 		if (baseDir == null) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/filepath/participants/FilePathCompletionResult.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/filepath/participants/FilePathCompletionResult.java
@@ -88,7 +88,7 @@ public class FilePathCompletionResult {
 	 *                         otherwise.
 	 * @return the file path completion result.
 	 */
-	public static FilePathCompletionResult create(String content, String fileUri, int startNodeOffset,
+	public static FilePathCompletionResult create(CharSequence content, String fileUri, int startNodeOffset,
 			int endNodeOffset, int completionOffset, Character separator) {
 		boolean isMultiFilePath = separator != null;
 		Predicate<Character> isStartValidChar = isStartValidCharForSimplePath;
@@ -118,10 +118,10 @@ public class FilePathCompletionResult {
 		return new FilePathCompletionResult(startPathOffset, endPathOffset, baseDir);
 	}
 
-	private static Path getBaseDir(String content, String fileUri, int start, int end) {
+	private static Path getBaseDir(CharSequence content, String fileUri, int start, int end) {
 		if (end > start) {
 			// ex : <a href="path/to/file.xml" />
-			String basePath = content.substring(start, end);
+			String basePath = StringUtils.getString(content, start, end);
 			if (!hasPathBeginning(basePath)) {
 				// Try to returns the absolute path
 				// Ex basePath=

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/minify/XMLMinifierDocument.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/minify/XMLMinifierDocument.java
@@ -81,7 +81,7 @@ public class XMLMinifierDocument {
 
 	public List<? extends TextEdit> minify(DOMDocument document, int start, int end) {
 		// Pre-allocate list capacity based on document size
-		int estimatedCapacity = Math.min(textDocument.getText().length() / 100, 10000);
+		int estimatedCapacity = Math.min(textDocument.getTextSequence().length() / 100, 10000);
 		List<TextEdit> edits = new ArrayList<>(estimatedCapacity);
 
 		// Get initial document region
@@ -302,7 +302,7 @@ public class XMLMinifierDocument {
 
 			if (afterElementName < beforeFirstAttr) {
 				int length = beforeFirstAttr - afterElementName;
-				if (StringUtils.isWhitespace(textDocument.getText(), afterElementName, beforeFirstAttr) && length > 1) {
+				if (StringUtils.isWhitespace(textDocument.getTextSequence(), afterElementName, beforeFirstAttr) && length > 1) {
 					// Replace multiple spaces with single space
 					try {
 						Range range = new Range(textDocument.positionAt(afterElementName),
@@ -325,7 +325,7 @@ public class XMLMinifierDocument {
 
 			if (afterAttr < beforeNextAttr) {
 				int length = beforeNextAttr - afterAttr;
-				if (StringUtils.isWhitespace(textDocument.getText(), afterAttr, beforeNextAttr) && length > 1) {
+				if (StringUtils.isWhitespace(textDocument.getTextSequence(), afterAttr, beforeNextAttr) && length > 1) {
 					// Replace multiple spaces with single space
 					try {
 						Range range = new Range(textDocument.positionAt(afterAttr),
@@ -383,7 +383,7 @@ public class XMLMinifierDocument {
 		if (start >= end) {
 			return;
 		}
-		if (StringUtils.isWhitespace(textDocument.getText(), start, end)) {
+		if (StringUtils.isWhitespace(textDocument.getTextSequence(), start, end)) {
 			// Only whitespace, remove it
 			removeContent(edits, start, end);
 		}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/references/search/SearchNode.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/references/search/SearchNode.java
@@ -99,7 +99,7 @@ public class SearchNode implements DOMRange {
 		if (forcedPrefix != null) {
 			value.append(forcedPrefix);
 		}
-		String text = getOwnerDocument().getText();
+		CharSequence text = getOwnerDocument().getTextSequence();
 		for (int i = getStart(); i < getEnd(); i++) {
 			value.append(text.charAt(i));
 		}
@@ -122,7 +122,7 @@ public class SearchNode implements DOMRange {
 	public boolean matchesValue(SearchNode searchNode) {
 		int fromStart = getStart();
 		int fromEnd = getEnd();
-		String fromText = getOwnerDocument().getText();
+		CharSequence fromText = getOwnerDocument().getTextSequence();
 		if (direction == Direction.FROM) {
 			int adjust = adjustWithPrefix(this);
 			if (adjust == -1) {
@@ -132,7 +132,7 @@ public class SearchNode implements DOMRange {
 		}
 		int toStart = searchNode.getStart();
 		int toEnd = searchNode.getEnd();
-		String toText = searchNode.getOwnerDocument().getText();
+		CharSequence toText = searchNode.getOwnerDocument().getTextSequence();
 		if (direction == Direction.TO) {
 			int adjust = adjustWithPrefix(searchNode);
 			if (adjust == -1) {
@@ -270,7 +270,7 @@ public class SearchNode implements DOMRange {
 		if (prefix.length() > (end - start)) {
 			return false;
 		}
-		String text = node.getOwnerDocument().getText();
+		CharSequence text = node.getOwnerDocument().getTextSequence();
 		for (int i = 0; i < prefix.length(); i++) {
 			if (text.charAt(start + i) != prefix.charAt(i)) {
 				return false;
@@ -282,8 +282,8 @@ public class SearchNode implements DOMRange {
 	@Override
 	public String toString() {
 		StringBuilder result = new StringBuilder();
-		String text = node.getOwnerDocument().getText();
-		result.append(text.substring(start, end));
+		CharSequence text = node.getOwnerDocument().getTextSequence();
+		result.append(text.subSequence(start, end));
 		result.append(direction == Direction.FROM ? " -->" : " <--");
 		return result.toString();
 	}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/references/search/SearchNodeFactory.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/references/search/SearchNodeFactory.java
@@ -67,7 +67,7 @@ public class SearchNodeFactory {
 		}
 
 		if (multiple) {
-			String text = node.getOwnerDocument().getText();
+			CharSequence text = node.getOwnerDocument().getTextSequence();
 			List<SearchNode> searchNodes = new ArrayList<>();
 			int itemStart = -1;
 			for (int j = startNode; j < endNode; j++) {
@@ -124,7 +124,7 @@ public class SearchNodeFactory {
 			return null;
 		}
 		if (multiple) {
-			String text = node.getOwnerDocument().getText();
+			CharSequence text = node.getOwnerDocument().getTextSequence();
 			if (offset != startNode) {
 				int left = StringUtils.findStartWord(text, offset, startNode, NAME_PREDICATE);
 				if (left != -1) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/participants/diagnostics/XSDValidator.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/participants/diagnostics/XSDValidator.java
@@ -14,7 +14,7 @@ package org.eclipse.lemminx.extensions.xsd.participants.diagnostics;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.io.StringReader;
+import org.eclipse.lemminx.commons.CharSequenceReader;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -101,9 +101,8 @@ public class XSDValidator {
 				grammarPreparser.setEntityResolver(entityResolver);
 			}
 
-			String content = document.getText();
 			String uri = document.getDocumentURI();
-			Reader inputStream = new StringReader(content);
+			Reader inputStream = new CharSequenceReader(document.getTextSequence());
 			XMLInputSource source = new XMLInputSource(null, uri, uri, inputStream, null);
 
 			grammarPreparser.getLoader(XMLGrammarDescription.XML_SCHEMA);

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLCompletions.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLCompletions.java
@@ -95,11 +95,11 @@ public class XMLCompletions {
 			return completionResponse;
 		}
 
-		String text = xmlDocument.getText();
+		CharSequence text = xmlDocument.getTextSequence();
 		int offset = completionRequest.getOffset();
 		DOMNode node = completionRequest.getNode();
 		try {
-			if (text.isEmpty()) {
+			if (text.length() == 0) {
 				// When XML document is empty, try to collect root element (from file
 				// association)
 				collectInsideContent(completionRequest, completionResponse, cancelChecker);
@@ -233,7 +233,7 @@ public class XMLCompletions {
 					case StartTagSelfClose:
 						if (offset <= scanner.getTokenEnd()) {
 							if (currentTag != null && currentTag.length() > 0
-									&& xmlDocument.getText().charAt(offset - 1) == '>') { // if the actual character
+									&& xmlDocument.getTextSequence().charAt(offset - 1) == '>') { // if the actual character
 																							// typed
 																							// was
 																							// '>'
@@ -358,7 +358,7 @@ public class XMLCompletions {
 	 */
 	private void collectSnippetSuggestions(CompletionRequest completionRequest, CompletionResponse completionResponse) {
 		DOMDocument document = completionRequest.getXMLDocument();
-		String text = document.getText();
+		CharSequence text = document.getTextSequence();
 		int endExpr = completionRequest.getOffset();
 		// compute the from for search expression according to the node
 		int fromSearchExpr = getExprLimitStart(completionRequest.getNode(), endExpr);
@@ -407,7 +407,7 @@ public class XMLCompletions {
 		}
 	}
 
-	private static Integer getSuffixIndex(String text, String suffix, final int initOffset) {
+	private static Integer getSuffixIndex(CharSequence text, String suffix, final int initOffset) {
 		int offset = initOffset;
 		char ch = text.charAt(offset);
 		// Try to search the first character which matches the suffix
@@ -491,7 +491,7 @@ public class XMLCompletions {
 		return element.getStartTagCloseOffset() + 1;
 	}
 
-	private static int getExprStart(String value, int from, int to) {
+	private static int getExprStart(CharSequence value, int from, int to) {
 		if (to == 0) {
 			return to;
 		}
@@ -556,8 +556,8 @@ public class XMLCompletions {
 		if (offset <= 0) {
 			return null;
 		}
-		char c = xmlDocument.getText().charAt(offset - 1);
-		char cBefore = xmlDocument.getText().charAt(offset - 2);
+		char c = xmlDocument.getTextSequence().charAt(offset - 1);
+		char cBefore = xmlDocument.getTextSequence().charAt(offset - 2);
 		String snippet = null;
 		if (XMLPositionUtility.isInAttributeValue(xmlDocument, position)) {
 			return null;
@@ -598,7 +598,7 @@ public class XMLCompletions {
 							return null;
 						}
 					}
-					String text = xmlDocument.getText();
+					CharSequence text = xmlDocument.getTextSequence();
 					// After the slash is a close bracket
 					boolean closeBracketAfterSlash = offset < text.length() ? text.charAt(offset) == '>' : false;
 
@@ -684,7 +684,7 @@ public class XMLCompletions {
 			CompletionRequest completionRequest, CompletionResponse completionResponse, CancelChecker cancelChecker) {
 		try {
 			DOMDocument document = completionRequest.getXMLDocument();
-			String text = document.getText();
+			CharSequence text = document.getTextSequence();
 			int tagNameEnd = document.offsetAt(replaceRange.getEnd());
 			int newOffset = getOffsetFollowedBy(text, tagNameEnd, ScannerState.WithinEndTag, TokenType.EndTagClose);
 			if (newOffset != -1) {
@@ -731,7 +731,7 @@ public class XMLCompletions {
 			CompletionRequest completionRequest, CompletionResponse completionResponse, CancelChecker cancelChecker) {
 		try {
 			Range range = getReplaceRange(afterOpenBracket, tagNameEnd, completionRequest);
-			String text = completionRequest.getXMLDocument().getText();
+			CharSequence text = completionRequest.getXMLDocument().getTextSequence();
 			boolean hasCloseTag = isFollowedBy(text, tagNameEnd, ScannerState.WithinEndTag, TokenType.EndTagClose);
 			collectCloseTagSuggestions(range, false, !hasCloseTag, inOpenTag, completionRequest, completionResponse);
 		} catch (BadLocationException e) {
@@ -742,7 +742,7 @@ public class XMLCompletions {
 	private void collectCloseTagSuggestions(Range range, boolean openEndTag, boolean closeEndTag, boolean inOpenTag,
 			CompletionRequest completionRequest, CompletionResponse completionResponse) {
 		try {
-			String text = completionRequest.getXMLDocument().getText();
+			CharSequence text = completionRequest.getXMLDocument().getTextSequence();
 			DOMNode curr = completionRequest.getNode();
 			if (inOpenTag) {
 				curr = curr.getParentNode(); // don't suggest the own tag, it's not yet open
@@ -887,7 +887,7 @@ public class XMLCompletions {
 	private void collectAttributeNameSuggestions(int nameStart, int nameEnd, CompletionRequest completionRequest,
 			CompletionResponse completionResponse, CancelChecker cancelChecker) {
 		int replaceEnd = completionRequest.getOffset();
-		String text = completionRequest.getXMLDocument().getText();
+		CharSequence text = completionRequest.getXMLDocument().getTextSequence();
 		while (replaceEnd < nameEnd && text.charAt(replaceEnd) != '<' && text.charAt(replaceEnd) != '?') { // < is a
 																											// valid
 																											// attribute
@@ -928,7 +928,7 @@ public class XMLCompletions {
 		boolean addQuotes = false;
 		String valuePrefix;
 		int offset = completionRequest.getOffset();
-		String text = completionRequest.getXMLDocument().getText();
+		CharSequence text = completionRequest.getXMLDocument().getTextSequence();
 
 		// Adjusts range to handle if quotations for the value exist
 		if (offset > valueStart && offset <= valueEnd && StringUtils.isQuote(text.charAt(valueStart))) {
@@ -940,13 +940,13 @@ public class XMLCompletions {
 				valueContentEnd--;
 			}
 			valuePrefix = offset >= valueContentStart && offset <= valueContentEnd
-					? text.substring(valueContentStart, offset)
+					? StringUtils.getString(text, valueContentStart, offset)
 					: "";
 			valueStart = valueContentStart;
 			valueEnd = valueContentEnd;
 			addQuotes = false;
 		} else {
-			valuePrefix = text.substring(valueStart, offset);
+			valuePrefix = StringUtils.getString(text, valueStart, offset);
 			addQuotes = true;
 		}
 
@@ -992,11 +992,11 @@ public class XMLCompletions {
 	private void collectDTDSystemIdSuggestions(int valueStart, int valueEnd, CompletionRequest completionRequest,
 			CompletionResponse completionResponse, CancelChecker cancelChecker) {
 		int offset = completionRequest.getOffset();
-		String text = completionRequest.getXMLDocument().getText();
+		CharSequence text = completionRequest.getXMLDocument().getTextSequence();
 		int valueContentStart = valueStart + 1;
 		int valueContentEnd = valueEnd - 1;
 		String valuePrefix = offset >= valueContentStart && offset <= valueContentEnd
-				? text.substring(valueContentStart, offset)
+				? StringUtils.getString(text, valueContentStart, offset)
 				: "";
 		Collection<ICompletionParticipant> completionParticipants = getCompletionParticipants();
 
@@ -1046,7 +1046,7 @@ public class XMLCompletions {
 		return extensionsRegistry.getCompletionParticipants();
 	}
 
-	private static boolean isFollowedBy(String s, int offset, ScannerState intialState, TokenType expectedToken) {
+	private static boolean isFollowedBy(CharSequence s, int offset, ScannerState intialState, TokenType expectedToken) {
 		return getOffsetFollowedBy(s, offset, intialState, expectedToken) != -1;
 	}
 
@@ -1060,7 +1060,7 @@ public class XMLCompletions {
 	 * @param expectedToken
 	 * @return
 	 */
-	public static int getOffsetFollowedBy(String s, int offset, ScannerState intialState, TokenType expectedToken) {
+	public static int getOffsetFollowedBy(CharSequence s, int offset, ScannerState intialState, TokenType expectedToken) {
 		Scanner scanner = XMLScanner.createScanner(s, offset, intialState);
 		TokenType token = scanner.scan();
 		while (token == TokenType.Whitespace) {
@@ -1079,19 +1079,19 @@ public class XMLCompletions {
 		return XMLPositionUtility.createRange(replaceStart, replaceEnd, document);
 	}
 
-	private static String getLineIndent(int offset, String text) {
+	private static String getLineIndent(int offset, CharSequence text) {
 		int start = offset;
 		while (start > 0) {
 			char ch = text.charAt(start - 1);
 			if ("\n\r".indexOf(ch) >= 0) {
-				return text.substring(start, offset);
+				return StringUtils.getString(text, start, offset);
 			}
 			if (!isWhitespace(ch)) {
 				return null;
 			}
 			start--;
 		}
-		return text.substring(0, offset);
+		return StringUtils.getString(text, 0, offset);
 	}
 
 	private boolean isEmptyElement(String tag) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLFoldings.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLFoldings.java
@@ -63,10 +63,10 @@ class XMLFoldings {
 
 	public List<FoldingRange> getFoldingRanges(TextDocument document, XMLFoldingSettings context,
 			CancelChecker cancelChecker) {
-		Scanner scanner = XMLScanner.createScanner(document.getText());
+		Scanner scanner = XMLScanner.createScanner(document.getTextSequence());
 		TokenType token = scanner.scan();
 		// Pre-allocate capacity based on document size (estimate: 1 folding per 500 chars)
-		int estimatedCapacity = Math.min(document.getText().length() / 500, 1000);
+		int estimatedCapacity = Math.min(document.getTextSequence().length() / 500, 1000);
 		List<FoldingRange> ranges = new ArrayList<>(estimatedCapacity);
 
 		// Pre-allocate stack capacity (estimate: max nesting depth of 50)

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLFormatter.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLFormatter.java
@@ -88,7 +88,7 @@ class XMLFormatter {
 	private boolean shouldMergeEdits(List<? extends TextEdit> edits, DOMDocument xmlDocument) {
 		// Merge if there are many edits (> 1000) or if the document is large (> 100KB)
 		int editCount = edits != null ? edits.size() : 0;
-		int documentSize = xmlDocument.getTextDocument().getText().length();
+		int documentSize = xmlDocument.getTextDocument().getTextSequence().length();
 		return editCount > 1000 || documentSize > 100_000;
 	}
 	
@@ -102,7 +102,7 @@ class XMLFormatter {
 	private Range getFullDocumentRange(DOMDocument xmlDocument) throws BadLocationException {
 		TextDocument textDocument = xmlDocument.getTextDocument();
 		Position start = new Position(0, 0);
-		Position end = textDocument.positionAt(textDocument.getText().length());
+		Position end = textDocument.positionAt(textDocument.getTextSequence().length());
 		return new Range(start, end);
 	}
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLHover.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLHover.java
@@ -129,7 +129,7 @@ class XMLHover {
 	}
 
 	private Range getTagNameRange(TokenType tokenType, int startOffset, int offset, DOMDocument document) {
-		Scanner scanner = XMLScanner.createScanner(document.getText(), startOffset);
+		Scanner scanner = XMLScanner.createScanner(document.getTextSequence(), startOffset);
 		TokenType token = scanner.scan();
 		while (token != TokenType.EOS
 				&& (scanner.getTokenEnd() < offset || scanner.getTokenEnd() == offset && token != tokenType)) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLLanguageService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLLanguageService.java
@@ -337,7 +337,7 @@ public class XMLLanguageService extends XMLExtensionsRegistry implements IXMLFul
 			XMLCompletionSettings completionSettings, CancelChecker cancelChecker) {
 		try {
 			int offset = xmlDocument.offsetAt(position);
-			String text = xmlDocument.getText();
+			CharSequence text = xmlDocument.getTextSequence();
 			if (offset > 0) {
 				char c = text.charAt(offset - 1);
 				if (c == '>' || c == '/') {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLMinifier.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLMinifier.java
@@ -75,7 +75,7 @@ public class XMLMinifier {
 	private boolean shouldMergeEdits(List<? extends TextEdit> edits, DOMDocument xmlDocument) {
 		// Merge if there are many edits (> 1000) or if the document is large (> 100KB)
 		int editCount = edits != null ? edits.size() : 0;
-		int documentSize = xmlDocument.getTextDocument().getText().length();
+		int documentSize = xmlDocument.getTextDocument().getTextSequence().length();
 		return editCount > 1000 || documentSize > 100_000;
 	}
 
@@ -89,7 +89,7 @@ public class XMLMinifier {
 	private Range getFullDocumentRange(DOMDocument xmlDocument) throws BadLocationException {
 		TextDocument textDocument = xmlDocument.getTextDocument();
 		Position start = new Position(0, 0);
-		Position end = textDocument.positionAt(textDocument.getText().length());
+		Position end = textDocument.positionAt(textDocument.getTextSequence().length());
 		return new Range(start, end);
 	}
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/DOMCDATAFormatter.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/DOMCDATAFormatter.java
@@ -28,7 +28,7 @@ public class DOMCDATAFormatter {
 
 	public void formatCDATASection(DOMCDATASection cDATANode, XMLFormattingConstraints parentConstraints,
 			List<TextEdit> edits) {
-		String text = formatterDocument.getText();
+		CharSequence text = formatterDocument.getTextSequence();
 		int start = cDATANode.getStart();
 		int leftWhitespaceOffset = start > 0 ? start - 1 : 0;
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/DOMCommentFormatter.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/DOMCommentFormatter.java
@@ -35,7 +35,7 @@ public class DOMCommentFormatter {
 			return;
 		}
 
-		String text = formatterDocument.getText();
+		CharSequence text = formatterDocument.getTextSequence();
 		int availableLineWidth = parentConstraints.getAvailableLineWidth();
 		int start = commentNode.getStart();
 		int leftWhitespaceOffset = start > 0 ? start - 1 : 0;

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/DOMDocTypeFormatter.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/DOMDocTypeFormatter.java
@@ -136,7 +136,7 @@ public class DOMDocTypeFormatter {
 		int nodeDeclStart = nodeDecl.getStart();
 		int indentLevel = parentConstraints.getIndentLevel();
 		int preservedNewLines = getPreservedNewlines();
-		int currentNewLineCount = XMLFormatterDocument.getExistingNewLineCount(formatterDocument.getText(),
+		int currentNewLineCount = XMLFormatterDocument.getExistingNewLineCount(formatterDocument.getTextSequence(),
 				nodeDeclStart, formatterDocument.getLineDelimiter());
 		if (currentNewLineCount > preservedNewLines) {
 			// Reduce to number of new lines to the new line number specified by
@@ -287,8 +287,8 @@ public class DOMDocTypeFormatter {
 	private void replaceQuoteWithPreferred(DTDDeclNode nodeDecl, DTDDeclParameter parameter, List<TextEdit> edits) {
 		int paramStart = parameter.getStart();
 		int paramEnd = parameter.getEnd();
-		if (StringUtils.isQuote(nodeDecl.getOwnerDocument().getText().charAt(paramStart))
-				&& StringUtils.isQuote(nodeDecl.getOwnerDocument().getText().charAt(paramEnd - 1))) {
+		if (StringUtils.isQuote(nodeDecl.getOwnerDocument().getTextSequence().charAt(paramStart))
+				&& StringUtils.isQuote(nodeDecl.getOwnerDocument().getTextSequence().charAt(paramEnd - 1))) {
 			if (getEnforceQuoteStyle() == EnforceQuoteStyle.preferred) {
 				formatterDocument.replaceQuoteWithPreferred(paramStart, paramStart + 1, edits);
 				formatterDocument.replaceQuoteWithPreferred(paramEnd - 1, paramEnd, edits);

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/DOMElementFormatter.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/DOMElementFormatter.java
@@ -105,7 +105,7 @@ public class DOMElementFormatter {
 			// after formatting: <a>\n <b> </b> example text </a>
 			int parentStartCloseOffset = element.getParentElement() != null ? element.getParentElement().getStartTagCloseOffset() + 1 : 0;
 			if ((parentStartCloseOffset != startTagOpenOffset
-					&& StringUtils.isWhitespace(formatterDocument.getText(), parentStartCloseOffset,
+					&& StringUtils.isWhitespace(formatterDocument.getTextSequence(), parentStartCloseOffset,
 							startTagOpenOffset))) {
 				replaceLeftSpacesWithIndentationPreservedNewLines(parentStartCloseOffset, startTagOpenOffset,
 						indentLevel, edits);
@@ -321,7 +321,7 @@ public class DOMElementFormatter {
 			DOMNode lastChild = element.getLastChild();
 			if (lastChild != null
 					&& (lastChild.isElement() || lastChild.isComment())
-					&& Character.isWhitespace(formatterDocument.getText().charAt(endTagOpenOffset - 1))) {
+					&& Character.isWhitespace(formatterDocument.getTextSequence().charAt(endTagOpenOffset - 1))) {
 				replaceLeftSpacesWithIndentationPreservedNewLines(startTagCloseOffset, endTagOpenOffset,
 						indentLevel, edits);
 				width += indentLevel * getTabSize();

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/DOMTextFormatter.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/DOMTextFormatter.java
@@ -38,7 +38,7 @@ public class DOMTextFormatter {
 		// Don't format the spacing in text for case of preserve empty content setting
 		FormatElementCategory formatElementCategory = parentConstraints.getFormatElementCategory();
 		if (formatElementCategory == FormatElementCategory.PreserveSpace && isTrimTrailingWhitespace()) {
-			String text = formatterDocument.getText();
+			CharSequence text = formatterDocument.getTextSequence();
 			int i = text.length() - 1;
 			char curr = text.charAt(i);
 			boolean removeSpaces = true;
@@ -68,7 +68,7 @@ public class DOMTextFormatter {
 		} else if (formatElementCategory == FormatElementCategory.PreserveSpace) {
 			return;
 		}
-		String text = formatterDocument.getText();
+		CharSequence text = formatterDocument.getTextSequence();
 		int availableLineWidth = parentConstraints.getAvailableLineWidth();
 		int indentLevel = parentConstraints.getIndentLevel();
 		boolean isMixedContent = formatElementCategory == FormatElementCategory.MixedContent;

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/XMLFormatterDocument.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/XMLFormatterDocument.java
@@ -145,7 +145,7 @@ public class XMLFormatterDocument {
 	public List<? extends TextEdit> format(DOMDocument document, int start, int end) {
 		// Pre-allocate list capacity based on document size to reduce reallocations
 		// Estimate: 1 edit per 100 characters for typical XML formatting
-		int estimatedCapacity = Math.min(textDocument.getText().length() / 100, 10000);
+		int estimatedCapacity = Math.min(textDocument.getTextSequence().length() / 100, 10000);
 		List<TextEdit> edits = new ArrayList<>(estimatedCapacity);
 
 		// get initial document region
@@ -179,7 +179,7 @@ public class XMLFormatterDocument {
 		}
 
 		boolean insertFinalNewline = isInsertFinalNewline();
-		String xml = textDocument.getText();
+		CharSequence xml = textDocument.getTextSequence();
 		int endDocument = xml.length() - 1;
 		if (isTrimFinalNewlines() && (end == -1 || endDocument < end)) {
 			trimFinalNewlines(insertFinalNewline, edits);
@@ -417,7 +417,7 @@ public class XMLFormatterDocument {
 	}
 
 	public int adjustOffsetWithLeftWhitespaces(int leftLimit, int to) {
-		return TextEditUtils.adjustOffsetWithLeftWhitespaces(leftLimit, to, textDocument.getText());
+		return TextEditUtils.adjustOffsetWithLeftWhitespaces(leftLimit, to, textDocument.getTextSequence());
 	}
 
 	public int replaceLeftSpacesWithIndentation(int indentLevel, int leftLimit, int to, boolean addLineSeparator,
@@ -457,7 +457,7 @@ public class XMLFormatterDocument {
 			int indentLevel, List<TextEdit> edits) {
 		int preservedNewLines = getFormattingSettings().getPreservedNewlines();
 		int currentNewLineCount = XMLFormatterDocument.getExistingNewLineCount(
-				textDocument.getText(), spaceEnd, lineDelimiter);
+				textDocument.getTextSequence(), spaceEnd, lineDelimiter);
 		if (currentNewLineCount > preservedNewLines) {
 			replaceLeftSpacesWithIndentationWithMultiNewLines(indentLevel, spaceStart,
 					spaceEnd, preservedNewLines + 1, edits);
@@ -469,7 +469,7 @@ public class XMLFormatterDocument {
 	}
 
 	boolean hasLineBreak(int from, int to) {
-		String text = textDocument.getText();
+		CharSequence text = textDocument.getTextSequence();
 		for (int i = from; i < to; i++) {
 			char c = text.charAt(i);
 			if (isLineSeparator(c)) {
@@ -480,7 +480,7 @@ public class XMLFormatterDocument {
 	}
 
 	public int getNormalizedLength(int from, int to) {
-		String text = textDocument.getText();
+		CharSequence text = textDocument.getTextSequence();
 		int contentOffset = 0;
 		for (int i = from; i < to; i++) {
 			if (Character.isWhitespace(text.charAt(i)) && !Character.isWhitespace(text.charAt(i + 1))) {
@@ -495,7 +495,7 @@ public class XMLFormatterDocument {
 
 	public int getOffsetWithPreserveLineBreaks(int from, int to, int tabSize, boolean isInsertSpaces) {
 		int initialTo = to;
-		String text = textDocument.getText();
+		CharSequence text = textDocument.getTextSequence();
 		for (int i = to; i > from; i--) {
 			if (text.charAt(i) == '\t') {
 				to -= tabSize;
@@ -530,7 +530,7 @@ public class XMLFormatterDocument {
 	// ------- Utilities method
 
 	int updateLineWidthWithLastLine(DOMNode child, int availableLineWidth) {
-		String text = textDocument.getText();
+		CharSequence text = textDocument.getTextSequence();
 		int lineWidth = availableLineWidth;
 		int end = child.getEnd();
 		// Check if next char after the end of the DOM node is a new line feed.
@@ -557,7 +557,7 @@ public class XMLFormatterDocument {
 	}
 
 	public int getLineBreakOffset(int startAttr, int start) {
-		String text = textDocument.getText();
+		CharSequence text = textDocument.getTextSequence();
 		for (int i = startAttr; i < start; i++) {
 			char c = text.charAt(i);
 			if (isLineSeparator(c)) {
@@ -736,7 +736,7 @@ public class XMLFormatterDocument {
 	}
 
 	private void trimFinalNewlines(boolean insertFinalNewline, List<TextEdit> edits) {
-		String xml = textDocument.getText();
+		CharSequence xml = textDocument.getTextSequence();
 		int end = xml.length() - 1;
 		int i = end;
 		while (i >= 0 && isLineSeparator(xml.charAt(i))) {
@@ -774,14 +774,13 @@ public class XMLFormatterDocument {
 	 * @return the number of new lines in the whitespaces to the left of the given
 	 *         offset.
 	 */
-	public static int getExistingNewLineCount(String text, int offset, String delimiter) {
+	public static int getExistingNewLineCount(CharSequence text, int offset, String delimiter) {
 		boolean delimiterHasTwoCharacters = delimiter.length() == 2;
 		int newLineCounter = 0;
 		for (int i = offset; i > 1; i--) {
-			String c;
 			if (!Character.isWhitespace(text.charAt(i - 1))) {
 				if (!delimiterHasTwoCharacters) {
-					c = String.valueOf(text.charAt(i));
+					String c = String.valueOf(text.charAt(i));
 					if (delimiter.equals(c)) {
 						newLineCounter++;
 					}
@@ -789,13 +788,13 @@ public class XMLFormatterDocument {
 				return newLineCounter;
 			}
 			if (delimiterHasTwoCharacters) {
-				c = text.substring(i - 2, i);
-				if (delimiter.equals(c)) {
+				CharSequence c = text.subSequence(i - 2, i);
+				if (delimiter.contentEquals(c)) {
 					newLineCounter++;
 					i--; // skip the second char of the delimiter
 				}
 			} else {
-				c = String.valueOf(text.charAt(i));
+				String c = String.valueOf(text.charAt(i));
 				if (delimiter.equals(c)) {
 					newLineCounter++;
 				}
@@ -848,8 +847,8 @@ public class XMLFormatterDocument {
 		return lineDelimiter;
 	}
 
-	String getText() {
-		return textDocument.getText();
+	CharSequence getTextSequence() {
+		return textDocument.getTextSequence();
 	}
 
 	public int getLineAtOffset(int offset) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/XMLFormatterDocumentOld.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/XMLFormatterDocumentOld.java
@@ -33,6 +33,7 @@ import org.eclipse.lemminx.dom.DTDDeclNode;
 import org.eclipse.lemminx.dom.DTDDeclParameter;
 import org.eclipse.lemminx.services.extensions.format.IFormatterParticipant;
 import org.eclipse.lemminx.settings.SharedSettings;
+import org.eclipse.lemminx.utils.StringUtils;
 import org.eclipse.lemminx.settings.XMLFormattingOptions.EmptyElements;
 import org.eclipse.lemminx.settings.XMLFormattingOptions.SplitAttributes;
 import org.eclipse.lemminx.utils.XMLBuilder;
@@ -84,8 +85,7 @@ public class XMLFormatterDocumentOld {
 	 * @throws BadLocationException
 	 */
 	public List<? extends TextEdit> format() throws BadLocationException {
-		this.fullDomDocument = DOMParser.getInstance().parse(textDocument.getText(), textDocument.getUri(), null,
-				false);
+		this.fullDomDocument = DOMParser.getInstance().parse(textDocument, null, false);
 
 		if (isRangeFormatting()) {
 			setupRangeFormatting(range);
@@ -115,8 +115,8 @@ public class XMLFormatterDocumentOld {
 		this.startOffset = this.textDocument.offsetAt(startPosition);
 		this.endOffset = this.textDocument.offsetAt(endPosition);
 
-		String fullText = this.textDocument.getText();
-		String rangeText = fullText.substring(this.startOffset, this.endOffset);
+		CharSequence fullText = this.textDocument.getTextSequence();
+		String rangeText = StringUtils.getString(fullText, this.startOffset, this.endOffset);
 
 		withinDTDContent = this.fullDomDocument.isWithinInternalDTD(startOffset);
 		String uri = this.textDocument.getUri();
@@ -127,7 +127,7 @@ public class XMLFormatterDocumentOld {
 
 		if (containsTextWithinStartTag()) {
 			adjustOffsetToStartTag();
-			rangeText = fullText.substring(this.startOffset, this.endOffset);
+			rangeText = StringUtils.getString(fullText, this.startOffset, this.endOffset);
 			this.rangeDomDocument = DOMParser.getInstance().parse(rangeText, uri, null, false);
 		}
 
@@ -167,7 +167,7 @@ public class XMLFormatterDocumentOld {
 
 	private void setupFullFormatting(Range range) throws BadLocationException {
 		this.startOffset = 0;
-		this.endOffset = textDocument.getText().length();
+		this.endOffset = textDocument.getTextSequence().length();
 		this.rangeDomDocument = this.fullDomDocument;
 
 		Position startPosition = textDocument.positionAt(startOffset);
@@ -751,7 +751,7 @@ public class XMLFormatterDocumentOld {
 		List<TextEdit> edits = new ArrayList<>();
 
 		// check if format range reaches the end of the document
-		if (this.endOffset == this.textDocument.getText().length()) {
+		if (this.endOffset == this.textDocument.getTextSequence().length()) {
 
 			if (this.sharedSettings.getFormattingSettings().isTrimFinalNewlines()) {
 				this.xmlBuilder.trimFinalNewlines();

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/snippets/SnippetContextUtils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/snippets/SnippetContextUtils.java
@@ -58,7 +58,7 @@ public class SnippetContextUtils {
 			if (element.isInInsideStartEndTag(offset)) {
 				// <a>|</a>
 				// <a></|</a>
-				String text = request.getXMLDocument().getText();
+				CharSequence text = request.getXMLDocument().getTextSequence();
 				if (text.charAt(offset - 1) == '/') {
 					// <a></|</a> -> should be ignore
 					return false;
@@ -78,7 +78,7 @@ public class SnippetContextUtils {
 			if (!element.hasEndTag()) {
 				// <a>|
 				// <a></|
-				String text = request.getXMLDocument().getText();
+				CharSequence text = request.getXMLDocument().getTextSequence();
 				if (text.charAt(node.getEnd() - 1) == '/') {
 					// <a></ -> should be ignore
 					return false;

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/DOMUtils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/DOMUtils.java
@@ -11,7 +11,7 @@
 *******************************************************************************/
 package org.eclipse.lemminx.utils;
 
-import java.io.StringReader;
+import org.eclipse.lemminx.commons.CharSequenceReader;
 import java.net.URL;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -281,10 +281,9 @@ public class DOMUtils {
 	}
 
 	public static InputSource createInputSource(DOMDocument document) {
-		String content = document.getText();
 		String uri = document.getDocumentURI();
 		InputSource inputSource = new InputSource();
-		inputSource.setCharacterStream(new StringReader(content));
+		inputSource.setCharacterStream(new CharSequenceReader(document.getTextSequence()));
 		inputSource.setSystemId(uri);
 		return inputSource;
 	}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/StringUtils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/StringUtils.java
@@ -42,11 +42,45 @@ public class StringUtils {
 		return c == '\'' || c == '"';
 	}
 
+	/**
+	 * Returns a {@link String} from the given {@link CharSequence} between the
+	 * given <code>start</code> and <code>end</code> offsets.
+	 *
+	 * @param text  the character sequence.
+	 * @param start the start offset.
+	 * @param end   the end offset.
+	 * @return a {@link String} from the given {@link CharSequence} between the
+	 *         given <code>start</code> and <code>end</code> offsets.
+	 */
+	public static String getString(CharSequence text, int start, int end) {
+		return text.subSequence(start, end).toString();
+	}
+
+	/**
+	 * Returns the index within the given {@link CharSequence} of the first
+	 * occurrence of the specified character, starting the search at the given
+	 * index.
+	 *
+	 * @param text      the character sequence.
+	 * @param ch        the character to search for.
+	 * @param fromIndex the index to start the search from.
+	 * @return the index of the first occurrence of the character, or -1 if not
+	 *         found.
+	 */
+	public static int indexOf(CharSequence text, char ch, int fromIndex) {
+		for (int i = fromIndex; i < text.length(); i++) {
+			if (text.charAt(i) == ch) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
 	public static boolean isWhitespace(String value, int index) {
 		return isWhitespace(value, index, value.length());
 	}
 
-	public static boolean isWhitespace(String value, int index, int end) {
+	public static boolean isWhitespace(CharSequence value, int index, int end) {
 		if (value == null) {
 			return false;
 		}
@@ -134,7 +168,7 @@ public class StringUtils {
 	 * @param text  the text
 	 * @return the whitespaces from the given range start/end of the given text.
 	 */
-	public static String getWhitespaces(String text, int start, int end) {
+	public static String getWhitespaces(CharSequence text, int start, int end) {
 		StringBuilder whitespaces = new StringBuilder();
 		for (int i = start; i < end; i++) {
 			char c = text.charAt(i);
@@ -421,7 +455,7 @@ public class StringUtils {
 	 * @return the start word offset from the left of the given <code>offset</code>
 	 *         and -1 if no word.
 	 */
-	public static int findStartWord(String text, int offset, Predicate<Character> isValidChar) {
+	public static int findStartWord(CharSequence text, int offset, Predicate<Character> isValidChar) {
 		return findStartWord(text, offset, 0, isValidChar);
 	}
 
@@ -437,7 +471,7 @@ public class StringUtils {
 	 * @return the start word offset from the left of the given <code>offset</code>
 	 *         to the given <code>min</code> and -1 if no word.
 	 */
-	public static int findStartWord(String text, int offset, int min, Predicate<Character> isValidChar) {
+	public static int findStartWord(CharSequence text, int offset, int min, Predicate<Character> isValidChar) {
 		if (offset < 0 || offset >= text.length()) {
 			return -1;
 		}
@@ -460,7 +494,7 @@ public class StringUtils {
 	 * @return the start word offset from the right of the given <code>offset</code>
 	 *         and -1 if no word.
 	 */
-	public static int findEndWord(String text, int offset, Predicate<Character> isValidChar) {
+	public static int findEndWord(CharSequence text, int offset, Predicate<Character> isValidChar) {
 		return findEndWord(text, offset, text.length(), isValidChar);
 	}
 
@@ -475,7 +509,7 @@ public class StringUtils {
 	 * @return the start word offset from the right of the given <code>offset</code>
 	 *         and -1 if no word.
 	 */
-	public static int findEndWord(String text, int offset, int max, Predicate<Character> isValidChar) {
+	public static int findEndWord(CharSequence text, int offset, int max, Predicate<Character> isValidChar) {
 		if (offset < 0 || offset >= text.length() || !isValidChar.test(text.charAt(offset))) {
 			return -1;
 		}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/TextEditUtils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/TextEditUtils.java
@@ -58,10 +58,10 @@ public class TextEditUtils {
 	}
 
 	/**
-	 * @deprecated Use {@link org.eclipse.lemminx.commons.TextEditUtils#adjustOffsetWithLeftWhitespaces(int, int, String)}
+	 * @deprecated Use {@link org.eclipse.lemminx.commons.TextEditUtils#adjustOffsetWithLeftWhitespaces(int, int, CharSequence)}
 	 */
 	@Deprecated
-	public static int adjustOffsetWithLeftWhitespaces(int leftLimit, int to, String text) {
+	public static int adjustOffsetWithLeftWhitespaces(int leftLimit, int to, CharSequence text) {
 		return org.eclipse.lemminx.commons.TextEditUtils.adjustOffsetWithLeftWhitespaces(leftLimit, to, text);
 	}
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/XMLPositionUtility.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/XMLPositionUtility.java
@@ -294,7 +294,7 @@ public class XMLPositionUtility {
 		// -> <a b="" b="" |>
 		// -> <a b="" b=""|>
 		// Remove spaces
-		String text = document.getText();
+		CharSequence text = document.getTextSequence();
 		char c = text.charAt(offset);
 		if (c == '>') {
 			offset--;
@@ -635,7 +635,7 @@ public class XMLPositionUtility {
 	 */
 	public static EntityReferenceRange selectEntityReference(int offset, DOMDocument document,
 			boolean endsWithSemicolon) {
-		String text = document.getText();
+		CharSequence text = document.getTextSequence();
 		// Search '&' or '%' character on the left of the offset
 		int entityReferenceStart = getEntityReferenceStartOffset(text, offset);
 		if (entityReferenceStart == -1) {
@@ -649,7 +649,7 @@ public class XMLPositionUtility {
 			}
 			entityReferenceEnd = offset;
 		}
-		String name = endsWithSemicolon ? document.getText().substring(entityReferenceStart + 1, entityReferenceEnd - 1)
+		String name = endsWithSemicolon ? StringUtils.getString(text, entityReferenceStart + 1, entityReferenceEnd - 1)
 				: null;
 		return new EntityReferenceRange(name, createRange(entityReferenceStart, entityReferenceEnd, document));
 	}
@@ -663,7 +663,7 @@ public class XMLPositionUtility {
 	 * @return the start offset of the entity reference (ex : &am|p;) from the left
 	 *         of the given offset and -1 if no entity reference.
 	 */
-	public static int getEntityReferenceStartOffset(String text, int offset) {
+	public static int getEntityReferenceStartOffset(CharSequence text, int offset) {
 		// adjust offset to get the left character of the offset
 		offset--;
 		if (offset < 0) {
@@ -700,7 +700,7 @@ public class XMLPositionUtility {
 	 * @return the end offset of the entity reference (ex : &am|p;) from the right
 	 *         of the given offset and -1 if no entity reference.
 	 */
-	public static int getEntityReferenceEndOffset(String text, int offset) {
+	public static int getEntityReferenceEndOffset(CharSequence text, int offset) {
 		int endEntityOffset = StringUtils.findEndWord(text, offset, ENTITY_NAME_PREDICATE);
 		if (endEntityOffset == -1) {
 			return -1;
@@ -721,7 +721,7 @@ public class XMLPositionUtility {
 					DOMCharacterData data = (DOMCharacterData) node;
 					int start = data.getStartContent();
 					Integer end = null;
-					String text = document.getText();
+					CharSequence text = document.getTextSequence();
 					for (int i = start; i < data.getEndContent(); i++) {
 						char c = text.charAt(i);
 						if (end == null) {
@@ -1142,7 +1142,7 @@ public class XMLPositionUtility {
 
 	public static Range getTagNameRange(TokenType tokenType, int startOffset, DOMDocument xmlDocument) {
 
-		Scanner scanner = XMLScanner.createScanner(xmlDocument.getText(), startOffset);
+		Scanner scanner = XMLScanner.createScanner(xmlDocument.getTextSequence(), startOffset);
 
 		TokenType token = scanner.scan();
 		while (token != TokenType.EOS && token != tokenType) {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/commons/TextDocumentTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/commons/TextDocumentTest.java
@@ -14,9 +14,17 @@ package org.eclipse.lemminx.commons;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
 
 import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -265,6 +273,86 @@ public class TextDocumentTest {
 			ex = e;
 		}
 		assertNotNull(ex);
+	}
+
+	// CharSequence / StringBuilder tests
+
+	@Test
+	public void testGetTextSequenceReturnsContent() {
+		TextDocument document = new TextDocument("hello world", "test.xml");
+		CharSequence seq = document.getTextSequence();
+		assertEquals("hello world", seq.toString());
+		assertEquals(11, seq.length());
+		assertEquals('h', seq.charAt(0));
+		assertEquals('d', seq.charAt(10));
+	}
+
+	@Test
+	public void testGetTextSequenceReturnsSameInstance() {
+		TextDocument document = new TextDocument("abc", "test.xml");
+		CharSequence seq1 = document.getTextSequence();
+		CharSequence seq2 = document.getTextSequence();
+		assertSame(seq1, seq2);
+	}
+
+	@Test
+	public void testGetTextSequenceReflectsIncrementalUpdate() throws BadLocationException {
+		TextDocument document = new TextDocument("<root></root>", "test.xml");
+		document.setIncremental(true);
+
+		TextDocumentContentChangeEvent change = new TextDocumentContentChangeEvent(
+				new Range(new Position(0, 6), new Position(0, 6)), " attr=\"v\"");
+		document.update(Collections.singletonList(change));
+
+		assertEquals("<root> attr=\"v\"</root>", document.getTextSequence().toString());
+	}
+
+	@Test
+	public void testGetTextLazySyncAfterIncrementalUpdate() throws BadLocationException {
+		TextDocument document = new TextDocument("<a/>", "test.xml");
+		document.setIncremental(true);
+
+		TextDocumentContentChangeEvent change = new TextDocumentContentChangeEvent(
+				new Range(new Position(0, 2), new Position(0, 2)), " x=\"1\"");
+		document.update(Collections.singletonList(change));
+
+		assertEquals("<a x=\"1\"/>", document.getTextSequence().toString());
+		@SuppressWarnings("deprecation")
+		String text = document.getText();
+		assertEquals("<a x=\"1\"/>", text);
+	}
+
+	@Test
+	public void testCharSequenceReaderReadsContent() throws IOException {
+		CharSequence source = new StringBuilder("hello");
+		CharSequenceReader reader = new CharSequenceReader(source);
+		char[] buf = new char[10];
+		int read = reader.read(buf, 0, 10);
+		assertEquals(5, read);
+		assertEquals("hello", new String(buf, 0, read));
+		assertEquals(-1, reader.read(buf, 0, 10));
+		reader.close();
+	}
+
+	@Test
+	public void testCharSequenceReaderChunkedRead() throws IOException {
+		CharSequence source = new StringBuilder("abcdef");
+		CharSequenceReader reader = new CharSequenceReader(source);
+		char[] buf = new char[3];
+		assertEquals(3, reader.read(buf, 0, 3));
+		assertEquals("abc", new String(buf));
+		assertEquals(3, reader.read(buf, 0, 3));
+		assertEquals("def", new String(buf));
+		assertEquals(-1, reader.read(buf, 0, 3));
+		reader.close();
+	}
+
+	@Test
+	public void testCharSequenceReaderEmpty() throws IOException {
+		CharSequenceReader reader = new CharSequenceReader("");
+		char[] buf = new char[5];
+		assertEquals(-1, reader.read(buf, 0, 5));
+		reader.close();
 	}
 
 }


### PR DESCRIPTION
## Use CharSequence API to avoid String allocation on document updates

### Problem

On every keystroke (`textDocument/didChange`), `TextDocument.update()` was:
1. Creating a **new `StringBuilder`** from the full document text (~60 MB for large files)

https://github.com/eclipse-lemminx/lemminx/blob/110f99525a1f5b78a4bfc798dc1aa94fde294fed/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/TextDocument.java#L172

2. Applying the 1-character change
3. Calling `toString()` to materialize back to `String` (~60 MB)

https://github.com/eclipse-lemminx/lemminx/blob/110f99525a1f5b78a4bfc798dc1aa94fde294fed/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/TextDocument.java#L195

4. Passing that `String` to the parser

For a 60 MB XML document, this meant **~120 MB of throwaway allocation per keystroke** just for text handling.

### Solution

- **`TextDocument`** stores a `CharSequence textSequence` field (String in non-incremental mode, StringBuilder in incremental mode)
- **`getTextSequence()`** returns the CharSequence directly — zero-copy for StringBuilder
- **`getText()`** is `@Deprecated` — kept for external extension compatibility, with lazy String materialization via a `textDirty` flag
- **`DOMParser`** / **`XMLScanner`** / **`MultiLineStream`** accept `CharSequence` instead of `String`
- **`CharSequenceReader`** — new Reader that reads char-by-char from CharSequence without `toString()`
- All internal LemMinX code migrated from `getText()` → `getTextSequence()` (50 files)

### Lazy StringBuilder to prevent OOM

The `String` → `StringBuilder` conversion is done **lazily in `update()`** (first keystroke), not in `setIncremental()`. This is intentional: the ~60 MB humongous allocation triggers G1GC at the right moment — after `cancelModel()` has released the old DOM tree. Without this, the old DOM (~300 MB) and new DOM (~300 MB) would coexist in memory, causing a transient **~660 MB peak that could trigger OOM** on constrained heaps.

### JFR Profiling Results

Tested with [sample-30mb.xml](https://samplelib.com/xml/sample-30mb.xml) (~60 MB unzipped), single space keystroke.

| Metric | `main` | `CharSequence + lazy` |
|--------|--------|-----------------------|
| GC events | 18 | 5 |
| GC pause time | 115 ms | 50 ms |
| Steady-state heap | 473 MB | 372 MB |
| StringBuilder in update | ~120 MB **every** keystroke | 148 MB **once** (1st keystroke only) |
| OOM risk on large files | No (GC triggered by accident) | **No (GC triggered by design)** |

### Test plan

- [x] Existing test suite passes (DOM parsing, completions, diagnostics, formatting)
- [x] New `TextDocumentTest` validates CharSequence behavior for incremental updates
- [x] JFR profiling confirms allocation reduction on large XML files
- [x] No transient memory peak on first keystroke (verified with heap monitoring)
