### PR TITLE
Reduce DOM memory by 64 MB via tag interning and attribute node move

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMCharacterData.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMCharacterData.java
@@ -26,8 +26,6 @@ import org.w3c.dom.DOMException;
  */
 public abstract class DOMCharacterData extends DOMNode implements org.w3c.dom.CharacterData {
 
-	private boolean isWhitespace;
-
 	private String delimiter;
 
 	public DOMCharacterData(int start, int end) {
@@ -150,20 +148,12 @@ public abstract class DOMCharacterData extends DOMNode implements org.w3c.dom.Ch
 		return getData();
 	}
 
-	/**
-	 * @return the isWhitespace
-	 */
 	public boolean isWhitespace() {
-		return isWhitespace;
+		return getFlag(FLAG_WHITESPACE);
 	}
 
-	/**
-	 * Set true if this node's data is all whitespace
-	 * 
-	 * @param isWhitespace
-	 */
-	public void setWhitespace(boolean isWhitespace) {
-		this.isWhitespace = isWhitespace;
+	public void setWhitespace(boolean whitespace) {
+		setFlag(FLAG_WHITESPACE, whitespace);
 	}
 
 	/*

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMComment.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMComment.java
@@ -18,8 +18,6 @@ package org.eclipse.lemminx.dom;
  */
 public class DOMComment extends DOMCharacterData implements org.w3c.dom.Comment {
 
-	boolean commentSameLineEndTag;
-
 	int startContent;
 
 	int endContent;
@@ -29,7 +27,11 @@ public class DOMComment extends DOMCharacterData implements org.w3c.dom.Comment 
 	}
 
 	public boolean isCommentSameLineEndTag() {
-		return commentSameLineEndTag;
+		return getFlag(FLAG_COMMENT_SAME_LINE);
+	}
+
+	void setCommentSameLineEndTag(boolean value) {
+		setFlag(FLAG_COMMENT_SAME_LINE, value);
 	}
 
 	@Override

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMDocument.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMDocument.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -65,6 +66,13 @@ public class DOMDocument extends DOMNode implements Document {
 	private String schemaPrefix;
 	private CancelChecker cancelChecker;
 	private String externalGrammarFromNamespaceURI;
+
+	/**
+	 * Pool used by {@link #internTag(String)} to deduplicate tag name strings
+	 * during parsing, avoiding millions of identical String instances for
+	 * documents with many repeated element names.
+	 */
+	private Map<String, String> tagPool;
 
 	public DOMDocument(TextDocument textDocument, URIResolverExtensionManager resolverExtensionManager) {
 		super(0, textDocument.getTextSequence().length());
@@ -487,6 +495,24 @@ public class DOMDocument extends DOMNode implements Document {
 
 	private static String getPrefixedName(String prefix, String localName) {
 		return prefix != null && prefix.length() > 0 ? prefix + ":" + localName : localName; //$NON-NLS-1$
+	}
+
+	/**
+	 * Returns a canonical instance of the given tag name, so that all elements
+	 * sharing the same tag name share a single String object.
+	 *
+	 * @param tag the tag name to intern.
+	 * @return the interned tag name, or {@code null} if {@code tag} is {@code null}.
+	 */
+	String internTag(String tag) {
+		if (tag == null) {
+			return null;
+		}
+		if (tagPool == null) {
+			tagPool = new HashMap<>();
+		}
+		String existing = tagPool.putIfAbsent(tag, tag);
+		return existing != null ? existing : tag;
 	}
 
 	public DOMElement createElement(int start, int end) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMElement.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMElement.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 
 import org.eclipse.lemminx.utils.StringUtils;
 import org.w3c.dom.DOMException;
+import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.NodeList;
 import org.w3c.dom.TypeInfo;
 
@@ -32,8 +33,9 @@ import org.w3c.dom.TypeInfo;
  */
 public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 
+	private XMLNamedNodeMap<DOMAttr> attributeNodes;
+
 	String tag;
-	boolean selfClosed;
 
 	// DomElement.start == startTagOpenOffset
 	int startTagOpenOffset = NULL_VALUE; // |<root>
@@ -45,6 +47,29 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 
 	public DOMElement(int start, int end) {
 		super(start, end);
+	}
+
+	@Override
+	public boolean hasAttributes() {
+		return attributeNodes != null && !attributeNodes.isEmpty();
+	}
+
+	@Override
+	public List<DOMAttr> getAttributeNodes() {
+		return attributeNodes;
+	}
+
+	@Override
+	public NamedNodeMap getAttributes() {
+		return attributeNodes;
+	}
+
+	@Override
+	public void setAttributeNode(DOMAttr attr) {
+		if (attributeNodes == null) {
+			attributeNodes = new XMLNamedNodeMap<>();
+		}
+		attributeNodes.add(attr);
 	}
 
 	/*
@@ -235,7 +260,11 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 	}
 
 	public boolean isSelfClosed() {
-		return selfClosed;
+		return getFlag(FLAG_SELF_CLOSED);
+	}
+
+	void setSelfClosed(boolean selfClosed) {
+		setFlag(FLAG_SELF_CLOSED, selfClosed);
 	}
 
 	/**

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMNode.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMNode.java
@@ -60,13 +60,15 @@ public abstract class DOMNode implements Node, DOMRange {
 	 */
 	public static final short DTD_DECL_NODE = 105;
 
-	// Memory optimization: Use byte flags instead of multiple boolean fields
-	// This saves 7 bytes per node (boolean with padding = 8 bytes, byte = 1 byte)
 	private byte flags = 0;
-	private static final byte FLAG_CLOSED = 0x01;
-	// Reserved for future flags: 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80
+	static final byte FLAG_CLOSED = 0x01;
+	static final byte FLAG_SELF_CLOSED = 0x02;           // DOMElement
+	static final byte FLAG_START_TAG_CLOSE = 0x04;       // DOMProcessingInstruction
+	static final byte FLAG_PROLOG = 0x08;                // DOMProcessingInstruction
+	static final byte FLAG_PROCESSING_INSTRUCTION = 0x10;// DOMProcessingInstruction
+	static final byte FLAG_WHITESPACE = 0x20;            // DOMCharacterData
+	static final byte FLAG_COMMENT_SAME_LINE = 0x40;     // DOMComment
 
-	private XMLNamedNodeMap<DOMAttr> attributeNodes;
 	private XMLNodeList<DOMNode> children;
 
 	final int start; // |<root> </root>
@@ -403,7 +405,7 @@ public abstract class DOMNode implements Node, DOMRange {
 
 	/**
 	 * Returns the attribute that matches the given name.
-	 * 
+	 *
 	 * If there is no namespace, set prefix to null.
 	 */
 	public DOMAttr getAttributeNode(String prefix, String suffix) {
@@ -417,7 +419,7 @@ public abstract class DOMNode implements Node, DOMRange {
 		if (!hasAttributes()) {
 			return null;
 		}
-		for (DOMAttr attr : attributeNodes) {
+		for (DOMAttr attr : getAttributeNodes()) {
 			if (name.equals(attr.getName())) {
 				return attr;
 			}
@@ -450,7 +452,7 @@ public abstract class DOMNode implements Node, DOMRange {
 	/**
 	 * Returns the attribute at the given index, the order is how the attributes
 	 * appear in the document.
-	 * 
+	 *
 	 * @param index Starting at 0, index of attribute you want
 	 * @return
 	 */
@@ -458,11 +460,11 @@ public abstract class DOMNode implements Node, DOMRange {
 		if (!hasAttributes()) {
 			return null;
 		}
-
-		if (index > attributeNodes.getLength() - 1) {
+		List<DOMAttr> attrs = getAttributeNodes();
+		if (index > attrs.size() - 1) {
 			return null;
 		}
-		return attributeNodes.get(index);
+		return attrs.get(index);
 	}
 
 	public boolean hasAttribute(String name) {
@@ -471,12 +473,12 @@ public abstract class DOMNode implements Node, DOMRange {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.w3c.dom.Node#hasAttributes()
 	 */
 	@Override
 	public boolean hasAttributes() {
-		return attributeNodes != null && attributeNodes.size() != 0;
+		return false;
 	}
 
 	public void setAttribute(String name, String value) {
@@ -489,14 +491,10 @@ public abstract class DOMNode implements Node, DOMRange {
 	}
 
 	public void setAttributeNode(DOMAttr attr) {
-		if (attributeNodes == null) {
-			attributeNodes = new XMLNamedNodeMap<>();
-		}
-		attributeNodes.add(attr);
 	}
 
 	public List<DOMAttr> getAttributeNodes() {
-		return attributeNodes;
+		return null;
 	}
 
 	/**
@@ -557,20 +555,24 @@ public abstract class DOMNode implements Node, DOMRange {
 		return getChildren().get(index);
 	}
 
-	public boolean isClosed() {
-		return (flags & FLAG_CLOSED) != 0;
+	boolean getFlag(byte flag) {
+		return (flags & flag) != 0;
 	}
 
-	/**
-	 * Sets the closed flag for this node.
-	 * Package-private to allow DOMParser to set it.
-	 */
-	void setClosed(boolean closed) {
-		if (closed) {
-			flags |= FLAG_CLOSED;
+	void setFlag(byte flag, boolean value) {
+		if (value) {
+			flags |= flag;
 		} else {
-			flags &= ~FLAG_CLOSED;
+			flags &= ~flag;
 		}
+	}
+
+	public boolean isClosed() {
+		return getFlag(FLAG_CLOSED);
+	}
+
+	void setClosed(boolean closed) {
+		setFlag(FLAG_CLOSED, closed);
 	}
 
 	public DOMElement getParentElement() {
@@ -710,7 +712,7 @@ public abstract class DOMNode implements Node, DOMRange {
 	 */
 	@Override
 	public NamedNodeMap getAttributes() {
-		return attributeNodes;
+		return null;
 	}
 
 	/*

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMParser.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMParser.java
@@ -153,7 +153,7 @@ public class DOMParser {
 
 				case StartTag: {
 					DOMElement element = (DOMElement) curr;
-					element.tag = scanner.getTokenText();
+					element.tag = xmlDocument.internTag(scanner.getTokenText());
 					curr.end = scanner.getTokenEnd();
 					break;
 				}
@@ -172,7 +172,7 @@ public class DOMParser {
 					} else if (curr.isProcessingInstruction() || curr.isProlog()) {
 						DOMProcessingInstruction element = (DOMProcessingInstruction) curr;
 						curr.end = scanner.getTokenEnd(); // might be later set to end tag position
-						element.startTagClose = true;
+						element.setStartTagClose(true);
 						if (element.getTarget() != null && isEmptyElement(element.getTarget()) && curr.parent != null) {
 							curr.setClosed(true);
 							curr = curr.parent;
@@ -193,7 +193,7 @@ public class DOMParser {
 
 				case EndTag:
 					// end tag (ex: </root>)
-					String closeTag = scanner.getTokenText();
+					String closeTag = xmlDocument.internTag(scanner.getTokenText());
 					DOMNode current = curr;
 
 					/**
@@ -226,7 +226,7 @@ public class DOMParser {
 				case StartTagSelfClose:
 					if (curr.parent != null) {
 						curr.setClosed(true);
-						((DOMElement) curr).selfClosed = true;
+						((DOMElement) curr).setSelfClosed(true);
 						curr.end = scanner.getTokenEnd();
 						lastClosed = curr;
 						curr = curr.parent;
@@ -305,15 +305,15 @@ public class DOMParser {
 
 				case PIName: {
 					DOMProcessingInstruction processingInstruction = ((DOMProcessingInstruction) curr);
-					processingInstruction.target = scanner.getTokenText();
-					processingInstruction.processingInstruction = true;
+					processingInstruction.target = xmlDocument.internTag(scanner.getTokenText());
+					processingInstruction.setProcessingInstruction(true);
 					break;
 				}
 
 				case PrologName: {
 					DOMProcessingInstruction processingInstruction = ((DOMProcessingInstruction) curr);
-					processingInstruction.target = scanner.getTokenText();
-					processingInstruction.prolog = true;
+					processingInstruction.target = xmlDocument.internTag(scanner.getTokenText());
+					processingInstruction.setProlog(true);
 					break;
 				}
 
@@ -349,7 +349,7 @@ public class DOMParser {
 						int endLine = document.positionAt(lastClosed.end).getLine();
 						int startLine = document.positionAt(curr.start).getLine();
 						if (endLine == startLine && lastClosed.end <= curr.start) {
-							comment.commentSameLineEndTag = true;
+							comment.setCommentSameLineEndTag(true);
 						}
 					} catch (BadLocationException e) {
 						LOGGER.log(Level.SEVERE, "XMLParser StartCommentTag bad offset in document", e);

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMProcessingInstruction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMProcessingInstruction.java
@@ -12,7 +12,10 @@
  */
 package org.eclipse.lemminx.dom;
 
+import java.util.List;
+
 import org.w3c.dom.DOMException;
+import org.w3c.dom.NamedNodeMap;
 
 /**
  * A processing instruction node.
@@ -20,10 +23,9 @@ import org.w3c.dom.DOMException;
  */
 public class DOMProcessingInstruction extends DOMCharacterData implements org.w3c.dom.ProcessingInstruction {
 
-	boolean startTagClose;
+	private XMLNamedNodeMap<DOMAttr> attributeNodes;
+
 	String target;
-	boolean prolog = false;
-	boolean processingInstruction = false;
 	int startContent;
 	int endContent;
 	int endTagOpenOffset = NULL_VALUE;
@@ -32,12 +34,51 @@ public class DOMProcessingInstruction extends DOMCharacterData implements org.w3
 		super(start, end);
 	}
 
+	@Override
+	public boolean hasAttributes() {
+		return attributeNodes != null && !attributeNodes.isEmpty();
+	}
+
+	@Override
+	public List<DOMAttr> getAttributeNodes() {
+		return attributeNodes;
+	}
+
+	@Override
+	public NamedNodeMap getAttributes() {
+		return attributeNodes;
+	}
+
+	@Override
+	public void setAttributeNode(DOMAttr attr) {
+		if (attributeNodes == null) {
+			attributeNodes = new XMLNamedNodeMap<>();
+		}
+		attributeNodes.add(attr);
+	}
+
 	public boolean isProlog() {
-		return prolog;
+		return getFlag(FLAG_PROLOG);
+	}
+
+	void setProlog(boolean value) {
+		setFlag(FLAG_PROLOG, value);
 	}
 
 	public boolean isProcessingInstruction() {
-		return processingInstruction;
+		return getFlag(FLAG_PROCESSING_INSTRUCTION);
+	}
+
+	void setProcessingInstruction(boolean value) {
+		setFlag(FLAG_PROCESSING_INSTRUCTION, value);
+	}
+
+	public boolean isStartTagClose() {
+		return getFlag(FLAG_START_TAG_CLOSE);
+	}
+
+	void setStartTagClose(boolean value) {
+		setFlag(FLAG_START_TAG_CLOSE, value);
 	}
 
 	public int getStartContent() {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/dom/DOMParserTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/dom/DOMParserTest.java
@@ -15,6 +15,7 @@ package org.eclipse.lemminx.dom;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -978,7 +979,7 @@ public class DOMParserTest {
 	private static DOMProcessingInstruction createPrologNode(String tag, int start, int end, boolean closed) {
 		DOMProcessingInstruction n = (DOMProcessingInstruction) createNode(DOMNode.PROCESSING_INSTRUCTION_NODE, tag,
 				start, null, end, closed);
-		n.prolog = true;
+		n.setProlog(true);
 		return n;
 	}
 
@@ -986,7 +987,7 @@ public class DOMParserTest {
 		MockProcessingInstruction n = (MockProcessingInstruction) createNode(DOMNode.PROCESSING_INSTRUCTION_NODE, tag,
 				start, null, end, closed);
 		n.content = content;
-		n.processingInstruction = true;
+		n.setProcessingInstruction(true);
 		return n;
 	}
 
@@ -1350,6 +1351,51 @@ public class DOMParserTest {
 
 	public void insertIntoAttributes(DOMNode n, String key, String value) {
 		n.setAttribute(key, value);
+	}
+
+	@Test
+	public void testTagInterning() {
+		DOMDocument document = DOMParser.getInstance().parse(
+				"<root><item>a</item><item>b</item><item>c</item></root>", "", null);
+		DOMElement root = document.getDocumentElement();
+		List<DOMNode> children = root.getChildren();
+		DOMElement item1 = (DOMElement) children.get(0);
+		DOMElement item2 = (DOMElement) children.get(1);
+		DOMElement item3 = (DOMElement) children.get(2);
+		assertEquals("item", item1.getTagName());
+		assertSame(item1.getTagName(), item2.getTagName());
+		assertSame(item1.getTagName(), item3.getTagName());
+	}
+
+	@Test
+	public void testAttributeNodesOnElement() {
+		DOMDocument document = DOMParser.getInstance().parse(
+				"<root attr1=\"v1\" attr2=\"v2\">text</root>", "", null);
+		DOMElement root = document.getDocumentElement();
+		assertTrue(root.hasAttributes());
+		assertEquals(2, root.getAttributeNodes().size());
+		assertEquals("v1", root.getAttribute("attr1"));
+		assertEquals("v2", root.getAttribute("attr2"));
+	}
+
+	@Test
+	public void testAttributeNodesOnProlog() {
+		DOMDocument document = DOMParser.getInstance().parse(
+				"<?xml version=\"1.0\" encoding=\"UTF-8\"?><root/>", "", null);
+		DOMNode prolog = document.getProlog();
+		assertNotNull(prolog);
+		assertTrue(prolog.hasAttributes());
+		assertEquals("1.0", prolog.getAttribute("version"));
+		assertEquals("UTF-8", prolog.getAttribute("encoding"));
+	}
+
+	@Test
+	public void testNoAttributesOnTextNode() {
+		DOMDocument document = DOMParser.getInstance().parse(
+				"<root>hello</root>", "", null);
+		DOMNode text = document.getDocumentElement().getFirstChild();
+		assertTrue(text.isText());
+		assertFalse(text.hasAttributes());
 	}
 
 	public DOMDocument getXMLDocument(String input) {


### PR DESCRIPTION
Reduce DOM memory by 64 MB via tag interning and attribute node move

Tag name interning:
- Add a document-local HashMap<String, String> pool in DOMDocument to
  deduplicate tag name strings during parsing.
- DOMParser now interns tag names for StartTag, EndTag, PIName, and
  PrologName tokens.
- For a 30 MB XML file (1.17M elements with ~20 unique tag names),
  this eliminates 1.17M duplicate String + byte[] objects.
- Measured savings: 56.2 MB (String: 28.8 MB -> 0.7 MB,
  byte[]: 61.9 MB -> 33.8 MB).

Move attributeNodes from DOMNode to DOMElement/DOMProcessingInstruction:
- Only elements and processing instructions have attributes; other node
  types (text, comment, CDATA) no longer carry the unused reference.
- DOMNode attribute methods now return defaults (false/null); DOMElement
  and DOMProcessingInstruction override with the actual field.
- Measured savings: 7.8 MB (DOMText: 48 -> 40 bytes/instance,
  975K instances).

Heap histogram comparison (30 MB XML,
samplelib.com/xml/sample-30mb.xml):

  Before:  String 1,200K/28.8 MB | byte[] 1,201K/61.9 MB | DOMText
975K/46.8 MB
  After:   String 30K/0.7 MB     | byte[] 31K/33.8 MB     | DOMText
975K/39.0 MB
  Savings: -28.1 MB (String)     | -28.1 MB (byte[])      | -7.8 MB
(DOMText)
  Total:   ~64 MB saved

Signed-off-by: azerr <azerr@redhat.com>