### PR TITLE
Fix DOM not freed from memory when closing documents

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLTextDocumentService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLTextDocumentService.java
@@ -414,8 +414,6 @@ public class XMLTextDocumentService implements TextDocumentService {
 		TextDocumentIdentifier identifier = params.getTextDocument();
 		String uri = identifier.getUri();
 		DOMDocument xmlDocument = documents.getExistingModel(uri);
-		// Remove the document from the cache
-		documents.onDidCloseTextDocument(params);
 		// Remove the validation from the delayer
 		xmlValidatorDelayer.cleanPendingValidation(uri);
 		// Publish empty errors from the document
@@ -433,6 +431,8 @@ public class XMLTextDocumentService implements TextDocumentService {
 				}
 			});
 		}
+		// Remove the document from the cache and dispose it
+		documents.onDidCloseTextDocument(params);
 	}
 
 	@Override

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/ModelTextDocument.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/ModelTextDocument.java
@@ -29,6 +29,8 @@ public class ModelTextDocument<T> extends TextDocument {
 
 	private static final Logger LOGGER = Logger.getLogger(ModelTextDocument.class.getName());
 
+	private static final int DISPOSED_VERSION = -9999;
+
 	private final BiFunction<TextDocument, CancelChecker, T> parse;
 
 	private T model;
@@ -60,6 +62,9 @@ public class ModelTextDocument<T> extends TextDocument {
 	 * @return the parsed model synchronized with last version of the text document.
 	 */
 	public T getModel() {
+		if (isDisposed()) {
+			return null;
+		}
 		if (model == null) {
 			return getSynchronizedModel();
 		}
@@ -74,6 +79,9 @@ public class ModelTextDocument<T> extends TextDocument {
 	 *         document or parse the model.
 	 */
 	private synchronized T getSynchronizedModel() {
+		if (isDisposed()) {
+			return null;
+		}
 		if (model != null) {
 			return model;
 		}
@@ -116,6 +124,19 @@ public class ModelTextDocument<T> extends TextDocument {
 	 */
 	private void cancelModel() {
 		model = null;
+	}
+
+	/**
+	 * Dispose this document, preventing any further re-parsing and releasing
+	 * all retained memory (model and text content) for garbage collection.
+	 */
+	@Override
+	public void dispose() {
+		// Setting an invalid version cancels any in-progress parse via
+		// TextDocumentVersionChecker, and triggers cancelModel() which
+		// releases the cached DOM tree.
+		setVersion(DISPOSED_VERSION);
+		super.dispose();
 	}
 
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/ModelTextDocuments.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/ModelTextDocuments.java
@@ -15,6 +15,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import org.eclipse.lsp4j.DidCloseTextDocumentParams;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextDocumentItem;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
@@ -34,6 +35,15 @@ public class ModelTextDocuments<T> extends TextDocuments<ModelTextDocument<T>> {
 
 	public ModelTextDocuments(BiFunction<TextDocument, CancelChecker, T> parse) {
 		this.parse = parse;
+	}
+
+	@Override
+	public ModelTextDocument<T> onDidCloseTextDocument(DidCloseTextDocumentParams params) {
+		ModelTextDocument<T> document = super.onDidCloseTextDocument(params);
+		if (document != null) {
+			document.dispose();
+		}
+		return document;
 	}
 
 	@Override

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/TextDocument.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/TextDocument.java
@@ -38,6 +38,8 @@ public class TextDocument extends TextDocumentItem {
 
 	private ILineTracker lineTracker;
 
+	private volatile boolean disposed;
+
 	private boolean incremental;
 
 	private CharSequence textSequence;
@@ -209,6 +211,25 @@ public class TextDocument extends TextDocumentItem {
 		ILineTracker lineTracker = isIncremental() ? new TreeLineTracker(new ListLineTracker()) : new ListLineTracker();
 		lineTracker.set(textSequence);
 		return lineTracker;
+	}
+
+	/**
+	 * Dispose this document, releasing all retained memory (text content and
+	 * line tracker) for garbage collection.
+	 */
+	public void dispose() {
+		this.disposed = true;
+		this.textSequence = null;
+		this.lineTracker = null;
+	}
+
+	/**
+	 * Returns true if this document has been disposed and false otherwise.
+	 *
+	 * @return true if this document has been disposed and false otherwise.
+	 */
+	public boolean isDisposed() {
+		return disposed;
 	}
 
 	/**


### PR DESCRIPTION
When a document is closed, the DOM tree is not released from memory. Async tasks (validation, documentColor, etc.) can call getModel() on the closed ModelTextDocument, triggering a full re-parse whose result is stored in the model field but never cleaned up since the document is already removed from the documents cache.

Add a closed flag to ModelTextDocument that prevents re-parsing after close, and call close() from ModelTextDocuments.onDidCloseTextDocument to release the cached model for garbage collection.