### PR TITLE
Reduce DOM memory by ~70 MB with first-child/next-sibling linked list

### DIFF
--- a/org.eclipse.lemminx/src/main/java/com/thaiopensource/relaxng/pattern/CMRelaxNGDocument.java
+++ b/org.eclipse.lemminx/src/main/java/com/thaiopensource/relaxng/pattern/CMRelaxNGDocument.java
@@ -271,15 +271,13 @@ public class CMRelaxNGDocument implements CMDocument {
 		if (choice == null) {
 			return null;
 		}
-		int length = choice.getChildren().size();
-		for (int i = 0; i < length; i++) {
-			DOMNode child = choice.getChild(i);
+		for (DOMNode child : choice.children()) {
 			if (isDOMElement(child, VALUE_ELT)) {
 				// <value>a</value>
 				DOMElement valueElement = (DOMElement) child;
-				if (i < length - 1 && value.equals(getTextContent(valueElement))) {
-					DOMNode next = choice.getChild(i + 1);
-					if (isDOMElement(next, DOCUMENTATION_ELT)) {
+				if (value.equals(getTextContent(valueElement))) {
+					DOMNode next = child.getNextSibling();
+					if (next != null && isDOMElement(next, DOCUMENTATION_ELT)) {
 						return (DOMElement) next;
 					}
 					return null;

--- a/org.eclipse.lemminx/src/main/java/com/thaiopensource/relaxng/pattern/CMRelaxNGElementDeclaration.java
+++ b/org.eclipse.lemminx/src/main/java/com/thaiopensource/relaxng/pattern/CMRelaxNGElementDeclaration.java
@@ -133,8 +133,7 @@ public class CMRelaxNGElementDeclaration implements CMElementDeclaration {
 		Name n = createName(parentElement);
 		matcher.matchStartTagOpen(n, n.getLocalName(), context);
 		if (parentElement.hasAttributes()) {
-			List<DOMAttr> attributes = parentElement.getAttributeNodes();
-			for (DOMAttr attr : attributes) {
+			for (DOMAttr attr : parentElement.attributes()) {
 				Name a = createName(attr);
 				matcher.matchAttributeName(a, a.getLocalName(), context);
 				matcher.matchAttributeValue(attr.getValue(), a, a.getLocalName(), context);

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMAttr.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMAttr.java
@@ -12,8 +12,6 @@
  */
 package org.eclipse.lemminx.dom;
 
-import java.util.List;
-
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Node;
 import org.w3c.dom.TypeInfo;
@@ -52,7 +50,7 @@ public class DOMAttr extends DOMNode implements org.w3c.dom.Attr {
 	}
 
 	public DOMAttr(String name, int start, int end, DOMNode ownerElement) {
-		super(NULL_VALUE, NULL_VALUE);
+		super();
 		this.name = name;
 		this.delimiter = NULL_VALUE;
 		this.nameStart = start;
@@ -379,20 +377,8 @@ public class DOMAttr extends DOMNode implements org.w3c.dom.Attr {
 		return attributeName.startsWith(XMLNS_NO_DEFAULT_ATTR);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.w3c.dom.Node#getNextSibling()
-	 */
-	@Override
-	public DOMNode getNextSibling() {
-		DOMNode parentNode = getOwnerElement();
-		if (parentNode == null) {
-			return null;
-		}
-		List<DOMAttr> children = parentNode.getAttributeNodes();
-		int nextIndex = children.indexOf(this) + 1;
-		return nextIndex < children.size() ? children.get(nextIndex) : null;
+	DOMAttr nextAttr() {
+		return (DOMAttr) nextSibling;
 	}
 
 	public boolean isIncluded(int offset) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMCharacterData.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMCharacterData.java
@@ -14,108 +14,91 @@ package org.eclipse.lemminx.dom;
 
 import static java.lang.System.lineSeparator;
 
-import java.util.List;
-
 import org.eclipse.lemminx.commons.BadLocationException;
-import org.eclipse.lemminx.utils.StringUtils;
 import org.w3c.dom.DOMException;
+import org.w3c.dom.CharacterData;
 
 /**
  * A CharacterData node.
  *
  */
-public abstract class DOMCharacterData extends DOMNode implements org.w3c.dom.CharacterData {
-
-	private String delimiter;
+public abstract class DOMCharacterData extends DOMTreeNode implements CharacterData {
 
 	public DOMCharacterData(int start, int end) {
 		super(start, end);
 	}
 
 	public boolean hasMultiLine() {
-		return getData().contains(getDelimiter());
+		CharSequence text = getOwnerDocument().getTextSequence();
+		for (int i = getStartContent(); i < getEndContent(); i++) {
+			char c = text.charAt(i);
+			if (c == '\n' || c == '\r') {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	public String getDelimiter() {
-		if (delimiter != null) {
-			return delimiter;
-		}
 		try {
-			delimiter = getOwnerDocument().getTextDocument().lineDelimiter(0);
-			return delimiter;
+			return getOwnerDocument().getTextDocument().lineDelimiter(0);
 		} catch (BadLocationException e) {
-			delimiter = lineSeparator();
-			return delimiter;
+			return lineSeparator();
 		}
 	}
 
 	/**
 	 * If data ends with a new line character.
-	 * 
+	 *
 	 * Returns false if a character is found before a new line. Non-newline
 	 * whitespace will be ignored while searching.
-	 * 
+	 *
 	 * If no data exists, returns false.
-	 * 
-	 * @return true if newline character ocurrs before non-whitespace character
+	 *
+	 * @return true if newline character occurs before non-whitespace character
 	 */
 	public boolean endsWithNewLine() {
-		if (hasData()) {
-			String data = getData();
-			for (int i = data.length() - 1; i >= 0; i--) {
-				char c = data.charAt(i);
-				if (!Character.isWhitespace(c)) {
-					return false;
-				}
-				if (c == '\n') {
-					return true;
-				}
-
+		CharSequence text = getOwnerDocument().getTextSequence();
+		int startContent = getStartContent();
+		int endContent = getEndContent();
+		for (int i = endContent - 1; i >= startContent; i--) {
+			char c = text.charAt(i);
+			if (!Character.isWhitespace(c)) {
+				return false;
+			}
+			if (c == '\n') {
+				return true;
 			}
 		}
 		return false;
 	}
 
 	/**
-	 * If data ends with a new line character.
-	 * 
+	 * If data starts with a new line character.
+	 *
 	 * Returns false if a character is found before a new line. Non-newline
 	 * whitespace will be ignored while searching.
-	 * 
-	 * @return true if newline character ocurrs before non-whitespace character
+	 *
+	 * @return true if newline character occurs before non-whitespace character
 	 */
 	public boolean startsWithNewLine() {
-		if (hasData()) {
-			String data = getData();
-			for (int i = 0; i < data.length(); i++) {
-				char c = data.charAt(i);
-				if (!Character.isWhitespace(c)) {
-					return false;
-				}
-				if (c == '\n' || c == '\r') {
-					return true;
-				}
-
+		CharSequence text = getOwnerDocument().getTextSequence();
+		int startContent = getStartContent();
+		int endContent = getEndContent();
+		for (int i = startContent; i < endContent; i++) {
+			char c = text.charAt(i);
+			if (!Character.isWhitespace(c)) {
+				return false;
+			}
+			if (c == '\n' || c == '\r') {
+				return true;
 			}
 		}
 		return false;
-	}
-
-	public String getNormalizedData() {
-		// No caching - compute on demand to save memory
-		return StringUtils.normalizeSpace(getData());
 	}
 
 	public boolean hasData() {
-		return !getData().isEmpty();
-	}
-
-	/**
-	 * Returns true if this node has sibling nodes.
-	 */
-	public boolean hasSiblings() {
-		List<DOMNode> childrenOfParent = this.parent.getChildren();
-		return childrenOfParent.size() > 1;
+		return getStartContent() < getEndContent();
 	}
 
 	public int getStartContent() {
@@ -183,7 +166,7 @@ public abstract class DOMCharacterData extends DOMNode implements org.w3c.dom.Ch
 	 */
 	@Override
 	public int getLength() {
-		return getData().length();
+		return getEndContent() - getStartContent();
 	}
 
 	/*

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMComment.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMComment.java
@@ -12,11 +12,13 @@
  */
 package org.eclipse.lemminx.dom;
 
+import org.w3c.dom.Comment;
+
 /**
  * A Comment node.
  *
  */
-public class DOMComment extends DOMCharacterData implements org.w3c.dom.Comment {
+public class DOMComment extends DOMCharacterData implements Comment {
 
 	int startContent;
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMContainerNode.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMContainerNode.java
@@ -1,0 +1,214 @@
+/**
+ *  Copyright (c) 2026 Red Hat Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v2.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ */
+package org.eclipse.lemminx.dom;
+
+import java.util.AbstractList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * Base class for DOM nodes that can have children (elements, documents, DTD
+ * declarations). Leaf nodes (text, comment, CDATA, processing instruction,
+ * attribute) extend {@link DOMNode} directly.
+ */
+public abstract class DOMContainerNode extends DOMTreeNode {
+
+	DOMNode firstChild;
+	DOMNode lastChild;
+
+	public DOMContainerNode(int start, int end) {
+		super(start, end);
+	}
+
+	@Override
+	public void addChild(DOMNode child) {
+		child.parent = this;
+		child.nextSibling = null;
+		if (firstChild == null) {
+			firstChild = child;
+		} else {
+			lastChild.nextSibling = child;
+		}
+		lastChild = child;
+	}
+
+	@Override
+	public Iterable<DOMNode> children() {
+		if (firstChild == null) {
+			return Collections.emptyList();
+		}
+		return () -> new Iterator<DOMNode>() {
+			DOMNode current = firstChild;
+
+			@Override
+			public boolean hasNext() {
+				return current != null;
+			}
+
+			@Override
+			public DOMNode next() {
+				DOMNode node = current;
+				current = current.nextSibling;
+				return node;
+			}
+		};
+	}
+
+	@Deprecated
+	@Override
+	public List<DOMNode> getChildren() {
+		if (firstChild == null) {
+			return Collections.emptyList();
+		}
+		return new AbstractList<DOMNode>() {
+			@Override
+			public DOMNode get(int index) {
+				int i = 0;
+				for (DOMNode child = firstChild; child != null; child = child.nextSibling) {
+					if (i == index) {
+						return child;
+					}
+					i++;
+				}
+				throw new IndexOutOfBoundsException(index);
+			}
+
+			@Override
+			public int size() {
+				int count = 0;
+				for (DOMNode child = firstChild; child != null; child = child.nextSibling) {
+					count++;
+				}
+				return count;
+			}
+
+			@Override
+			public Iterator<DOMNode> iterator() {
+				return children().iterator();
+			}
+		};
+	}
+
+	@Override
+	public DOMNode getFirstChild() {
+		return firstChild;
+	}
+
+	@Override
+	public DOMNode getLastChild() {
+		return lastChild;
+	}
+
+	@Override
+	public boolean hasChildNodes() {
+		return firstChild != null;
+	}
+
+	@Override
+	public NodeList getChildNodes() {
+		if (firstChild == null) {
+			return EMPTY_CHILDREN;
+		}
+		return new NodeList() {
+			@Override
+			public Node item(int index) {
+				int i = 0;
+				for (DOMNode child = firstChild; child != null; child = child.nextSibling) {
+					if (i == index) {
+						return child;
+					}
+					i++;
+				}
+				return null;
+			}
+
+			@Override
+			public int getLength() {
+				int count = 0;
+				for (DOMNode child = firstChild; child != null; child = child.nextSibling) {
+					count++;
+				}
+				return count;
+			}
+		};
+	}
+
+	@Override
+	public DOMNode getChild(int index) {
+		int i = 0;
+		for (DOMNode child = firstChild; child != null; child = child.nextSibling) {
+			if (i == index) {
+				return child;
+			}
+			i++;
+		}
+		return null;
+	}
+
+	@Override
+	public DOMNode findNodeBefore(int offset) {
+		DOMNode found = null;
+		for (DOMNode child = firstChild; child != null; child = child.nextSibling) {
+			if (offset <= child.getStart()) {
+				break;
+			}
+			found = child;
+		}
+		if (found != null) {
+			if (offset > found.getStart()) {
+				if (offset < found.getEnd()) {
+					return found.findNodeBefore(offset);
+				}
+				DOMNode last = found.getLastChild();
+				if (last != null && last.getEnd() == found.getEnd()) {
+					return found.findNodeBefore(offset);
+				}
+				return found;
+			}
+		}
+		return this;
+	}
+
+	@Override
+	public DOMNode findNodeAt(int offset) {
+		DOMNode found = null;
+		for (DOMNode child = firstChild; child != null; child = child.nextSibling) {
+			if (offset <= child.getStart()) {
+				break;
+			}
+			found = child;
+		}
+		if (found != null && isIncluded(found, offset)) {
+			return found.findNodeAt(offset);
+		}
+		return this;
+	}
+
+	@Override
+	public DOMNode findChildWithAttributeValue(String name, String value) {
+		for (DOMNode child = firstChild; child != null; child = child.nextSibling) {
+			if (child.hasAttribute(name)) {
+				String attrValue = child.getAttribute(name);
+				if (Objects.equals(attrValue, value)) {
+					return child;
+				}
+			}
+		}
+		return null;
+	}
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMDocument.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMDocument.java
@@ -19,12 +19,12 @@ package org.eclipse.lemminx.dom;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.commons.TextDocument;
@@ -49,7 +49,7 @@ import org.w3c.dom.NodeList;
  * XML document.
  *
  */
-public class DOMDocument extends DOMNode implements Document {
+public class DOMDocument extends DOMContainerNode implements Document {
 
 	private SchemaLocation schemaLocation;
 	private NoNamespaceSchemaLocation noNamespaceSchemaLocation;
@@ -89,8 +89,8 @@ public class DOMDocument extends DOMNode implements Document {
 		return cancelChecker;
 	}
 
-	public List<DOMNode> getRoots() {
-		return super.getChildren();
+	public Iterable<DOMNode> getRoots() {
+		return children();
 	}
 
 	public Position positionAt(int offset) throws BadLocationException {
@@ -290,7 +290,7 @@ public class DOMDocument extends DOMNode implements Document {
 		schemaPrefix = null;
 		// Search if document element root declares namespace with "xmlns".
 		if (documentElement.hasAttributes()) {
-			for (DOMAttr attr : documentElement.getAttributeNodes()) {
+			for (DOMAttr attr : documentElement.attributes()) {
 				String attributeName = attr.getName();
 				if (attributeName != null) {
 					if (attributeName.equals(DOMAttr.XMLNS_ATTR)
@@ -323,8 +323,8 @@ public class DOMDocument extends DOMNode implements Document {
 	 * @return
 	 */
 	public boolean hasProlog() {
-		List<DOMNode> children = getChildren();
-		return (children != null && !children.isEmpty() && children.get(0).isProlog());
+		DOMNode first = getFirstChild();
+		return first != null && first.isProlog();
 	}
 
 	/**
@@ -333,11 +333,8 @@ public class DOMDocument extends DOMNode implements Document {
 	 * @return prolog DOMNode, if the document has one, null otherwise
 	 */
 	public DOMNode getProlog() {
-		if (hasProlog()) {
-			return getChild(0);
-		} else {
-			return null;
-		}
+		DOMNode first = getFirstChild();
+		return first != null && first.isProlog() ? first : null;
 	}
 
 	/**
@@ -566,12 +563,9 @@ public class DOMDocument extends DOMNode implements Document {
 	 */
 	@Override
 	public DOMElement getDocumentElement() {
-		List<DOMNode> roots = getRoots();
-		if (roots != null) {
-			for (DOMNode node : roots) {
-				if (node.isElement()) {
-					return (DOMElement) node;
-				}
+		for (DOMNode node : getRoots()) {
+			if (node.isElement()) {
+				return (DOMElement) node;
 			}
 		}
 		return null;
@@ -584,12 +578,9 @@ public class DOMDocument extends DOMNode implements Document {
 	 */
 	@Override
 	public DOMDocumentType getDoctype() {
-		List<DOMNode> roots = getRoots();
-		if (roots != null) {
-			for (DOMNode node : roots) {
-				if (node.isDoctype()) {
-					return (DOMDocumentType) node;
-				}
+		for (DOMNode node : getRoots()) {
+			if (node.isDoctype()) {
+				return (DOMDocumentType) node;
 			}
 		}
 		return null;
@@ -969,13 +960,22 @@ public class DOMDocument extends DOMNode implements Document {
 	 * @return the DTD Attribute list for the given element name and empty
 	 *         otherwise.
 	 */
-	public Collection<DOMNode> findDTDAttrList(String elementName) {
+	public Iterable<DOMNode> findDTDAttrList(String elementName) {
 		DOMDocumentType docType = getDoctype();
 		if (docType == null || elementName == null) {
 			return Collections.emptyList();
 		}
-		return docType.getChildren().stream().filter(DOMNode::isDTDAttListDecl)
-				.filter(n -> elementName.equals(((DTDAttlistDecl) n).getElementName())).collect(Collectors.toList());
+		List<DOMNode> result = null;
+		for (DOMNode child : docType.children()) {
+			if (child.isDTDAttListDecl()
+					&& elementName.equals(((DTDAttlistDecl) child).getElementName())) {
+				if (result == null) {
+					result = new ArrayList<>();
+				}
+				result.add(child);
+			}
+		}
+		return result != null ? result : Collections.emptyList();
 	}
 
 	/**

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMDocumentType.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMDocumentType.java
@@ -106,8 +106,7 @@ public class DOMDocumentType extends DTDDeclNode implements org.w3c.dom.Document
 	public NamedNodeMap getEntities() {
 		if (entitiesNodes == null) {
 			entitiesNodes = new XMLNamedNodeMap<>();
-			List<DOMNode> children = super.getChildren();
-			for (DOMNode child : children) {
+			for (DOMNode child : super.children()) {
 				if (child.getNodeType() == DOMNode.ENTITY_NODE) {
 					entitiesNodes.add((DTDEntityDecl) child);
 				}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMElement.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMElement.java
@@ -31,45 +31,37 @@ import org.w3c.dom.TypeInfo;
  * An Element node.
  *
  */
-public class DOMElement extends DOMNode implements org.w3c.dom.Element {
+public class DOMElement extends DOMContainerNode implements org.w3c.dom.Element {
 
-	private XMLNamedNodeMap<DOMAttr> attributeNodes;
+	DOMAttr firstAttr;
 
 	String tag;
 
-	// DomElement.start == startTagOpenOffset
-	int startTagOpenOffset = NULL_VALUE; // |<root>
 	int startTagCloseOffset = NULL_VALUE; // <root |>
-
 	int endTagOpenOffset = NULL_VALUE; // <root> |</root >
-	int endTagCloseOffset = NULL_VALUE;// <root> </root |>
-	// DomElement.end = <root> </root>| , is always scanner.getTokenEnd()
 
 	public DOMElement(int start, int end) {
 		super(start, end);
 	}
 
 	@Override
-	public boolean hasAttributes() {
-		return attributeNodes != null && !attributeNodes.isEmpty();
-	}
-
-	@Override
-	public List<DOMAttr> getAttributeNodes() {
-		return attributeNodes;
-	}
-
-	@Override
 	public NamedNodeMap getAttributes() {
-		return attributeNodes;
+		return createAttributeNamedNodeMap(firstAttr);
 	}
 
 	@Override
 	public void setAttributeNode(DOMAttr attr) {
-		if (attributeNodes == null) {
-			attributeNodes = new XMLNamedNodeMap<>();
-		}
-		attributeNodes.add(attr);
+		addAttribute(attr, this);
+	}
+
+	@Override
+	DOMAttr getFirstAttr() {
+		return firstAttr;
+	}
+
+	@Override
+	void setFirstAttr(DOMAttr attr) {
+		firstAttr = attr;
 	}
 
 	/*
@@ -206,7 +198,7 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 	public Collection<String> getAllPrefixes() {
 		if (hasAttributes()) {
 			Collection<String> prefixes = new ArrayList<>();
-			for (DOMAttr attr : getAttributeNodes()) {
+			for (DOMAttr attr : attributes()) {
 				if (attr.isNoDefaultXmlns()) {
 					prefixes.add(attr.extractPrefixFromXmlns());
 				}
@@ -227,7 +219,7 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 			return null;
 		}
 		if (hasAttributes()) {
-			for (DOMAttr attr : getAttributeNodes()) {
+			for (DOMAttr attr : attributes()) {
 				String prefix = attr.getPrefixIfMatchesURI(namespaceURI);
 				if (prefix != null) {
 					return prefix;
@@ -310,11 +302,11 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 	}
 
 	public boolean isInStartTag(int offset) {
-		if (startTagOpenOffset == NULL_VALUE || startTagCloseOffset == NULL_VALUE) {
+		if (!hasStartTag() || startTagCloseOffset == NULL_VALUE) {
 			// case <|
 			return true;
 		}
-		if (offset > startTagOpenOffset && offset <= startTagCloseOffset) {
+		if (offset > start && offset <= startTagCloseOffset) {
 			// case <bean | >
 			return true;
 		}
@@ -349,7 +341,7 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 	 *         doesn't exist.
 	 */
 	public int getStartTagOpenOffset() {
-		return startTagOpenOffset;
+		return hasStartTag() ? start : NULL_VALUE;
 	}
 
 	/**
@@ -382,7 +374,7 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 	 *         exist.
 	 */
 	public int getEndTagCloseOffset() {
-		return endTagCloseOffset;
+		return isEndTagClosed() ? end - 1 : NULL_VALUE;
 	}
 
 	/**
@@ -394,7 +386,7 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 	 * @return true if has a start tag.
 	 */
 	public boolean hasStartTag() {
-		return getStartTagOpenOffset() != NULL_VALUE;
+		return getFlag(FLAG_HAS_START_TAG);
 	}
 
 	/**
@@ -420,7 +412,7 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 	 * If '>' exists in </root>
 	 */
 	public boolean isEndTagClosed() {
-		return getEndTagCloseOffset() != NULL_VALUE;
+		return getFlag(FLAG_END_TAG_CLOSED);
 	}
 
 	/**
@@ -521,8 +513,7 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 		}
 		// search if it exists an end tag
 		DOMElement orphanEndElement = null;
-		List<DOMNode> children = getChildren();
-		for (DOMNode child : children) {
+		for (DOMNode child : children()) {
 			if (child.isElement()) {
 				DOMElement childElement = (DOMElement) child;
 				if (childElement.isOrphanEndTagOf(tagName)) {
@@ -550,11 +541,6 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 	@Override
 	public String getAttributeNS(String arg0, String arg1) throws DOMException {
 		return null;
-	}
-
-	@Override
-	public DOMAttr getAttributeNode(String name) {
-		return super.getAttributeNode(name);
 	}
 
 	@Override
@@ -630,7 +616,7 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 		if (!hasChildNodes()) {
 			return true;
 		}
-		for (DOMNode child : getChildren()) {
+		for (DOMNode child : children()) {
 			if (child.isText()) {
 				DOMText text = (DOMText) child;
 				if (!text.isElementContentWhitespace()) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMNode.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMNode.java
@@ -12,11 +12,11 @@
  */
 package org.eclipse.lemminx.dom;
 
+import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
-import java.util.function.Function;
 
 import org.w3c.dom.DOMException;
 import org.w3c.dom.NamedNodeMap;
@@ -60,27 +60,11 @@ public abstract class DOMNode implements Node, DOMRange {
 	 */
 	public static final short DTD_DECL_NODE = 105;
 
-	private byte flags = 0;
-	static final byte FLAG_CLOSED = 0x01;
-	static final byte FLAG_SELF_CLOSED = 0x02;           // DOMElement
-	static final byte FLAG_START_TAG_CLOSE = 0x04;       // DOMProcessingInstruction
-	static final byte FLAG_PROLOG = 0x08;                // DOMProcessingInstruction
-	static final byte FLAG_PROCESSING_INSTRUCTION = 0x10;// DOMProcessingInstruction
-	static final byte FLAG_WHITESPACE = 0x20;            // DOMCharacterData
-	static final byte FLAG_COMMENT_SAME_LINE = 0x40;     // DOMComment
-
-	private XMLNodeList<DOMNode> children;
-
-	final int start; // |<root> </root>
-	int end; // <root> </root>|
+	DOMNode nextSibling;
 
 	DOMNode parent;
-	
-	// Cache the index in parent's children list to avoid O(n) indexOf() calls
-	// This is set to -1 when not cached, and updated when needed
-	int cachedIndexInParent = -1;
 
-	private static final NodeList EMPTY_CHILDREN = new NodeList() {
+	static final NodeList EMPTY_CHILDREN = new NodeList() {
 
 		@Override
 		public Node item(int index) {
@@ -92,59 +76,6 @@ public abstract class DOMNode implements Node, DOMRange {
 			return 0;
 		}
 	};
-
-	static class XMLNodeList<T extends DOMNode> extends ArrayList<T> implements NodeList {
-
-		private static final long serialVersionUID = 1L;
-		
-		// Pre-allocate capacity to reduce ArrayList resizing overhead
-		// Most elements have 2-5 children, so start with capacity of 4
-		private static final int INITIAL_CAPACITY = 4;
-
-		XMLNodeList() {
-			super(INITIAL_CAPACITY);
-		}
-
-		@Override
-		public int getLength() {
-			return super.size();
-		}
-
-		@Override
-		public DOMNode item(int index) {
-			return super.get(index);
-		}
-		
-		@Override
-		public boolean add(T node) {
-			boolean result = super.add(node);
-			// Invalidate cached indices for all nodes after this one
-			invalidateCachedIndices(size() - 1);
-			return result;
-		}
-		
-		@Override
-		public void add(int index, T node) {
-			super.add(index, node);
-			// Invalidate cached indices for all nodes from this index onwards
-			invalidateCachedIndices(index);
-		}
-		
-		@Override
-		public T remove(int index) {
-			T removed = super.remove(index);
-			// Invalidate cached indices for all nodes from this index onwards
-			invalidateCachedIndices(index);
-			return removed;
-		}
-		
-		private void invalidateCachedIndices(int fromIndex) {
-			for (int i = fromIndex; i < size(); i++) {
-				get(i).cachedIndexInParent = -1;
-			}
-		}
-
-	}
 
 	static class XMLNamedNodeMap<T extends DOMNode> extends ArrayList<T> implements NamedNodeMap {
 
@@ -186,21 +117,18 @@ public abstract class DOMNode implements Node, DOMRange {
 		}
 
 		@Override
-		public T setNamedItem(org.w3c.dom.Node arg0) throws DOMException {
+		public T setNamedItem(Node arg0) throws DOMException {
 			throw new UnsupportedOperationException();
 		}
 
 		@Override
-		public T setNamedItemNS(org.w3c.dom.Node arg0) throws DOMException {
+		public T setNamedItemNS(Node arg0) throws DOMException {
 			throw new UnsupportedOperationException();
 		}
 
 	}
 
-	public DOMNode(int start, int end) {
-		this.start = start;
-		this.end = end;
-		// flags is already initialized to 0, so FLAG_CLOSED is not set
+	DOMNode() {
 	}
 
 	/**
@@ -231,26 +159,28 @@ public abstract class DOMNode implements Node, DOMRange {
 			result.append("\t");
 		}
 		result.append("{start: ");
-		result.append(start);
+		result.append(getStart());
 		result.append(", end: ");
-		result.append(end);
+		result.append(getEnd());
 		result.append(", name: ");
 		result.append(getNodeName());
 		result.append(", closed: ");
 		result.append(isClosed());
-		if (children != null && children.size() > 0) {
+		DOMNode fc = getFirstChild();
+		if (fc != null) {
 			result.append(", \n");
 			for (int i = 0; i < indent + 1; i++) {
 				result.append("\t");
 			}
 			result.append("children:[");
-			for (int i = 0; i < children.size(); i++) {
-				DOMNode node = children.get(i);
-				result.append("\n");
-				result.append(node.toString(indent + 2));
-				if (i < children.size() - 1) {
+			boolean first = true;
+			for (DOMNode node = fc; node != null; node = node.nextSibling) {
+				if (!first) {
 					result.append(",");
 				}
+				result.append("\n");
+				result.append(node.toString(indent + 2));
+				first = false;
 			}
 			result.append("\n");
 			for (int i = 0; i < indent + 1; i++) {
@@ -272,33 +202,10 @@ public abstract class DOMNode implements Node, DOMRange {
 	 * Returns the node before
 	 */
 	public DOMNode findNodeBefore(int offset) {
-		List<DOMNode> children = getChildren();
-		int idx = findFirst(children, c -> offset <= c.start) - 1;
-		if (idx >= 0) {
-			DOMNode child = children.get(idx);
-			if (offset > child.start) {
-				if (offset < child.end) {
-					return child.findNodeBefore(offset);
-				}
-				DOMNode lastChild = child.getLastChild();
-				if (lastChild != null && lastChild.end == child.end) {
-					return child.findNodeBefore(offset);
-				}
-				return child;
-			}
-		}
 		return this;
 	}
 
 	public DOMNode findNodeAt(int offset) {
-		List<DOMNode> children = getChildren();
-		int idx = findFirst(children, c -> offset <= c.start) - 1;
-		if (idx >= 0) {
-			DOMNode child = children.get(idx);
-			if (isIncluded(child, offset)) {
-				return child.findNodeAt(offset);
-			}
-		}
 		return this;
 	}
 
@@ -327,7 +234,7 @@ public abstract class DOMNode implements Node, DOMRange {
 
 	public static DOMAttr findAttrAt(DOMNode node, int offset) {
 		if (node != null && node.hasAttributes()) {
-			for (DOMAttr attr : node.getAttributeNodes()) {
+			for (DOMAttr attr : node.attributes()) {
 				if (attr.isIncluded(offset)) {
 					return attr;
 				}
@@ -355,7 +262,7 @@ public abstract class DOMNode implements Node, DOMRange {
 
 	public static DOMText findTextAt(DOMNode node, int offset) {
 		if (node != null && node.hasChildNodes()) {
-			for (DOMNode child : node.getChildren()) {
+			for (DOMNode child = node.getFirstChild(); child != null; child = child.nextSibling) {
 				if (child.isText() && isIncluded(child, offset)) {
 					return (DOMText) child;
 				}
@@ -375,30 +282,6 @@ public abstract class DOMNode implements Node, DOMRange {
 		return node;
 	}
 
-	/**
-	 * Takes a sorted array and a function p. The array is sorted in such a way that
-	 * all elements where p(x) is false are located before all elements where p(x)
-	 * is true.
-	 * 
-	 * @returns the least x for which p(x) is true or array.length if no element
-	 *          full fills the given function.
-	 */
-	private static <T> int findFirst(List<T> array, Function<T, Boolean> p) {
-		int low = 0, high = array.size();
-		if (high == 0) {
-			return 0; // no children
-		}
-		while (low < high) {
-			int mid = (int) Math.floor((low + high) / 2);
-			if (p.apply(array.get(mid))) {
-				high = mid;
-			} else {
-				low = mid + 1;
-			}
-		}
-		return low;
-	}
-
 	public DOMAttr getAttributeNode(String name) {
 		return getAttributeNode(null, name);
 	}
@@ -409,19 +292,24 @@ public abstract class DOMNode implements Node, DOMRange {
 	 * If there is no namespace, set prefix to null.
 	 */
 	public DOMAttr getAttributeNode(String prefix, String suffix) {
-		StringBuilder sb = new StringBuilder();
-		if (prefix != null) {
-			sb.append(prefix);
-			sb.append(":");
-		}
-		sb.append(suffix);
-		String name = sb.toString();
 		if (!hasAttributes()) {
 			return null;
 		}
-		for (DOMAttr attr : getAttributeNodes()) {
-			if (name.equals(attr.getName())) {
-				return attr;
+		for (DOMAttr attr : attributes()) {
+			String attrName = attr.getName();
+			if (prefix == null) {
+				if (suffix.equals(attrName)) {
+					return attr;
+				}
+			} else {
+				int prefixLen = prefix.length();
+				int suffixLen = suffix.length();
+				if (attrName.length() == prefixLen + 1 + suffixLen
+						&& attrName.startsWith(prefix)
+						&& attrName.charAt(prefixLen) == ':'
+						&& attrName.regionMatches(prefixLen + 1, suffix, 0, suffixLen)) {
+					return attr;
+				}
 			}
 		}
 		return null;
@@ -457,14 +345,14 @@ public abstract class DOMNode implements Node, DOMRange {
 	 * @return
 	 */
 	public DOMAttr getAttributeAtIndex(int index) {
-		if (!hasAttributes()) {
-			return null;
+		int i = 0;
+		for (DOMAttr attr : attributes()) {
+			if (i == index) {
+				return attr;
+			}
+			i++;
 		}
-		List<DOMAttr> attrs = getAttributeNodes();
-		if (index > attrs.size() - 1) {
-			return null;
-		}
-		return attrs.get(index);
+		return null;
 	}
 
 	public boolean hasAttribute(String name) {
@@ -478,7 +366,35 @@ public abstract class DOMNode implements Node, DOMRange {
 	 */
 	@Override
 	public boolean hasAttributes() {
-		return false;
+		return getFirstAttr() != null;
+	}
+
+	/**
+	 * Returns true if this node has exactly one attribute.
+	 *
+	 * @return true if this node has exactly one attribute and false otherwise.
+	 */
+	public boolean hasSingleAttribute() {
+		DOMAttr first = getFirstAttr();
+		return first != null && first.nextAttr() == null;
+	}
+
+	/**
+	 * Returns the last attribute of this node, or null if there are no
+	 * attributes.
+	 *
+	 * @return the last attribute of this node, or null.
+	 */
+	public DOMAttr getLastAttr() {
+		DOMAttr first = getFirstAttr();
+		if (first == null) {
+			return null;
+		}
+		DOMAttr last = first;
+		for (DOMAttr next = first.nextAttr(); next != null; next = next.nextAttr()) {
+			last = next;
+		}
+		return last;
 	}
 
 	public void setAttribute(String name, String value) {
@@ -493,41 +409,199 @@ public abstract class DOMNode implements Node, DOMRange {
 	public void setAttributeNode(DOMAttr attr) {
 	}
 
+	public Iterable<DOMAttr> attributes() {
+		DOMAttr first = getFirstAttr();
+		if (first == null) {
+			return Collections.emptyList();
+		}
+		return () -> new Iterator<DOMAttr>() {
+			DOMAttr current = first;
+
+			@Override
+			public boolean hasNext() {
+				return current != null;
+			}
+
+			@Override
+			public DOMAttr next() {
+				DOMAttr attr = current;
+				current = current.nextAttr();
+				return attr;
+			}
+		};
+	}
+
+	/**
+	 * @deprecated Use {@link #attributes()} to traverse attributes without
+	 *             allocating a list.
+	 */
+	@Deprecated
 	public List<DOMAttr> getAttributeNodes() {
+		return createAttributeList(getFirstAttr());
+	}
+
+	static void addAttribute(DOMAttr attr, DOMNode owner) {
+		attr.nextSibling = null;
+		DOMAttr first = owner.getFirstAttr();
+		if (first == null) {
+			owner.setFirstAttr(attr);
+		} else {
+			DOMAttr last = first;
+			while (last.nextAttr() != null) {
+				last = last.nextAttr();
+			}
+			last.nextSibling = attr;
+		}
+	}
+
+	DOMAttr getFirstAttr() {
+		return null;
+	}
+
+	void setFirstAttr(DOMAttr attr) {
+	}
+
+	static List<DOMAttr> createAttributeList(DOMAttr firstAttr) {
+		if (firstAttr == null) {
+			return Collections.emptyList();
+		}
+		return new AbstractList<DOMAttr>() {
+			@Override
+			public DOMAttr get(int index) {
+				int i = 0;
+				for (DOMAttr attr = firstAttr; attr != null; attr = attr.nextAttr()) {
+					if (i == index) {
+						return attr;
+					}
+					i++;
+				}
+				throw new IndexOutOfBoundsException(index);
+			}
+
+			@Override
+			public int size() {
+				int count = 0;
+				for (DOMAttr attr = firstAttr; attr != null; attr = attr.nextAttr()) {
+					count++;
+				}
+				return count;
+			}
+
+			@Override
+			public Iterator<DOMAttr> iterator() {
+				return new Iterator<DOMAttr>() {
+					DOMAttr current = firstAttr;
+
+					@Override
+					public boolean hasNext() {
+						return current != null;
+					}
+
+					@Override
+					public DOMAttr next() {
+						DOMAttr node = current;
+						current = current.nextAttr();
+						return node;
+					}
+				};
+			}
+		};
+	}
+
+	static NamedNodeMap createAttributeNamedNodeMap(DOMAttr firstAttr) {
+		if (firstAttr == null) {
+			return null;
+		}
+		return new NamedNodeMap() {
+			@Override
+			public int getLength() {
+				int count = 0;
+				for (DOMAttr attr = firstAttr; attr != null; attr = attr.nextAttr()) {
+					count++;
+				}
+				return count;
+			}
+
+			@Override
+			public Node getNamedItem(String name) {
+				for (DOMAttr attr = firstAttr; attr != null; attr = attr.nextAttr()) {
+					if (name.equals(attr.getNodeName())) {
+						return attr;
+					}
+				}
+				return null;
+			}
+
+			@Override
+			public Node getNamedItemNS(String ns, String local) throws DOMException {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public Node item(int index) {
+				int i = 0;
+				for (DOMAttr attr = firstAttr; attr != null; attr = attr.nextAttr()) {
+					if (i == index) {
+						return attr;
+					}
+					i++;
+				}
+				return null;
+			}
+
+			@Override
+			public Node removeNamedItem(String name) throws DOMException {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public Node removeNamedItemNS(String ns, String local) throws DOMException {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public Node setNamedItem(Node arg) throws DOMException {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public Node setNamedItemNS(Node arg) throws DOMException {
+				throw new UnsupportedOperationException();
+			}
+		};
+	}
+
+	/**
+	 * Returns the first child having an attribute with the given name and value,
+	 * or null if none found.
+	 *
+	 * @param name  name of attribute
+	 * @param value value of attribute
+	 * @return the first matching child, or null
+	 */
+	public DOMNode findChildWithAttributeValue(String name, String value) {
 		return null;
 	}
 
 	/**
-	 * Returns a list of children, each having an attribute called name, with a
-	 * value of value
-	 * 
-	 * @param name  name of attribute
-	 * @param value value of attribute
-	 * @return list of children, each having a specified attribute name and value
+	 * Returns an iterable over this node's children. Does not allocate a list.
+	 *
+	 * @return an iterable over the children.
 	 */
-	public List<DOMNode> getChildrenWithAttributeValue(String name, String value) {
-		List<DOMNode> result = new ArrayList<>();
-		for (DOMNode child : getChildren()) {
-			if (child.hasAttribute(name)) {
-				String attrValue = child.getAttribute(name);
-				if (Objects.equals(attrValue, value)) {
-					result.add(child);
-				}
-			}
-		}
-		return result;
+	public Iterable<DOMNode> children() {
+		return Collections.emptyList();
 	}
 
 	/**
-	 * Returns the node children.
-	 * 
+	 * Returns the node children as a list.
+	 *
 	 * @return the node children.
+	 * @deprecated Use {@link #children()} to traverse children without allocating a
+	 *             list.
 	 */
+	@Deprecated
 	public List<DOMNode> getChildren() {
-		if (children == null) {
-			return Collections.emptyList();
-		}
-		return children;
+		return Collections.emptyList();
 	}
 
 	/**
@@ -537,42 +611,27 @@ public abstract class DOMNode implements Node, DOMRange {
 	 */
 	public void addChild(DOMNode child) {
 		child.parent = this;
-		if (children == null) {
-			children = new XMLNodeList<>();
-		}
-		// Cache the index when adding
-		child.cachedIndexInParent = children.size();
-		children.add(child);
+		child.nextSibling = null;
 	}
 
 	/**
 	 * Returns node child at the given index.
-	 * 
+	 *
 	 * @param index
 	 * @return node child at the given index.
 	 */
 	public DOMNode getChild(int index) {
-		return getChildren().get(index);
-	}
-
-	boolean getFlag(byte flag) {
-		return (flags & flag) != 0;
-	}
-
-	void setFlag(byte flag, boolean value) {
-		if (value) {
-			flags |= flag;
-		} else {
-			flags &= ~flag;
-		}
+		return null;
 	}
 
 	public boolean isClosed() {
-		return getFlag(FLAG_CLOSED);
+		return false;
 	}
 
 	void setClosed(boolean closed) {
-		setFlag(FLAG_CLOSED, closed);
+	}
+
+	void setEnd(int end) {
 	}
 
 	public DOMElement getParentElement() {
@@ -657,12 +716,12 @@ public abstract class DOMNode implements Node, DOMRange {
 
 	@Override
 	public int getStart() {
-		return start;
+		return NULL_VALUE;
 	}
 
 	@Override
 	public int getEnd() {
-		return end;
+		return NULL_VALUE;
 	}
 
 	/*
@@ -692,17 +751,17 @@ public abstract class DOMNode implements Node, DOMRange {
 	 */
 	@Override
 	public DOMNode getFirstChild() {
-		return this.children != null && children.size() > 0 ? this.children.get(0) : null;
+		return null;
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.w3c.dom.Node#getLastChild()
 	 */
 	@Override
 	public DOMNode getLastChild() {
-		return this.children != null && this.children.size() > 0 ? this.children.get(this.children.size() - 1) : null;
+		return null;
 	}
 
 	/*
@@ -722,7 +781,7 @@ public abstract class DOMNode implements Node, DOMRange {
 	 */
 	@Override
 	public NodeList getChildNodes() {
-		return children != null ? children : EMPTY_CHILDREN;
+		return EMPTY_CHILDREN;
 	}
 
 	/*
@@ -731,7 +790,7 @@ public abstract class DOMNode implements Node, DOMRange {
 	 * @see org.w3c.dom.Node#appendChild(org.w3c.dom.Node)
 	 */
 	@Override
-	public org.w3c.dom.Node appendChild(org.w3c.dom.Node newChild) throws DOMException {
+	public Node appendChild(Node newChild) throws DOMException {
 		throw new UnsupportedOperationException();
 	}
 
@@ -741,7 +800,7 @@ public abstract class DOMNode implements Node, DOMRange {
 	 * @see org.w3c.dom.Node#cloneNode(boolean)
 	 */
 	@Override
-	public org.w3c.dom.Node cloneNode(boolean deep) {
+	public Node cloneNode(boolean deep) {
 		throw new UnsupportedOperationException();
 	}
 
@@ -751,7 +810,7 @@ public abstract class DOMNode implements Node, DOMRange {
 	 * @see org.w3c.dom.Node#compareDocumentPosition(org.w3c.dom.Node)
 	 */
 	@Override
-	public short compareDocumentPosition(org.w3c.dom.Node other) throws DOMException {
+	public short compareDocumentPosition(Node other) throws DOMException {
 		throw new UnsupportedOperationException();
 	}
 
@@ -787,22 +846,11 @@ public abstract class DOMNode implements Node, DOMRange {
 	 */
 	@Override
 	public DOMNode getNextSibling() {
-		DOMNode parentNode = getParentNode();
-		if (parentNode == null) {
-			return null;
-		}
-		List<DOMNode> children = parentNode.getChildren();
-		
-		// Use cached index if available to avoid O(n) indexOf() call
-		int currentIndex = cachedIndexInParent;
-		if (currentIndex == -1) {
-			// Cache miss - compute and cache the index
-			currentIndex = children.indexOf(this);
-			cachedIndexInParent = currentIndex;
-		}
-		
-		int nextIndex = currentIndex + 1;
-		return nextIndex < children.size() ? children.get(nextIndex) : null;
+		return nextSibling;
+	}
+
+	public boolean hasSiblings() {
+		return parent != null && parent.getFirstChild() != parent.getLastChild();
 	}
 
 	@Override
@@ -822,22 +870,17 @@ public abstract class DOMNode implements Node, DOMRange {
 	 */
 	@Override
 	public DOMNode getPreviousSibling() {
-		DOMNode parentNode = getParentNode();
-		if (parentNode == null) {
+		if (parent == null) {
 			return null;
 		}
-		List<DOMNode> children = parentNode.getChildren();
-		
-		// Use cached index if available to avoid O(n) indexOf() call
-		int currentIndex = cachedIndexInParent;
-		if (currentIndex == -1) {
-			// Cache miss - compute and cache the index
-			currentIndex = children.indexOf(this);
-			cachedIndexInParent = currentIndex;
+		DOMNode prev = null;
+		for (DOMNode child = parent.getFirstChild(); child != null; child = child.nextSibling) {
+			if (child == this) {
+				return prev;
+			}
+			prev = child;
 		}
-		
-		int previousIndex = currentIndex - 1;
-		return previousIndex >= 0 ? children.get(previousIndex) : null;
+		return null;
 	}
 
 	public DOMNode getPreviousNonTextSibling() {
@@ -923,12 +966,12 @@ public abstract class DOMNode implements Node, DOMRange {
 			return null;
 		// concatenation of the textContent attribute value of every child node
 		default:
-			if (this.children != null && children.size() > 0) {
+			DOMNode fc = getFirstChild();
+			if (fc != null) {
 				final StringBuilder builder = new StringBuilder();
-				for (DOMNode child : children) {
+				for (DOMNode child = fc; child != null; child = child.nextSibling) {
 					short nodeType = child.getNodeType();
 					if (nodeType == Node.COMMENT_NODE || nodeType == Node.PROCESSING_INSTRUCTION_NODE) {
-						// excluding COMMENT_NODE and PROCESSING_INSTRUCTION_NODE nodes.
 						continue;
 					}
 					String text = child.getTextContent();
@@ -938,7 +981,6 @@ public abstract class DOMNode implements Node, DOMRange {
 				}
 				return builder.toString();
 			}
-			// empty string if the node has no children
 			return "";
 		}
 	}
@@ -955,11 +997,11 @@ public abstract class DOMNode implements Node, DOMRange {
 	 */
 	@Override
 	public boolean hasChildNodes() {
-		return children != null && !children.isEmpty();
+		return false;
 	}
 
 	@Override
-	public org.w3c.dom.Node insertBefore(org.w3c.dom.Node arg0, org.w3c.dom.Node arg1) throws DOMException {
+	public Node insertBefore(Node arg0, Node arg1) throws DOMException {
 		return null;
 	}
 
@@ -969,12 +1011,12 @@ public abstract class DOMNode implements Node, DOMRange {
 	}
 
 	@Override
-	public boolean isEqualNode(org.w3c.dom.Node arg0) {
+	public boolean isEqualNode(Node arg0) {
 		return false;
 	}
 
 	@Override
-	public boolean isSameNode(org.w3c.dom.Node arg0) {
+	public boolean isSameNode(Node arg0) {
 		return false;
 	}
 
@@ -998,12 +1040,12 @@ public abstract class DOMNode implements Node, DOMRange {
 	}
 
 	@Override
-	public org.w3c.dom.Node removeChild(org.w3c.dom.Node arg0) throws DOMException {
+	public Node removeChild(Node arg0) throws DOMException {
 		return null;
 	}
 
 	@Override
-	public org.w3c.dom.Node replaceChild(org.w3c.dom.Node arg0, org.w3c.dom.Node arg1) throws DOMException {
+	public Node replaceChild(Node arg0, Node arg1) throws DOMException {
 		return null;
 	}
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMParser.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMParser.java
@@ -107,7 +107,7 @@ public class DOMParser {
 					 * Try to find a start element with no tag : <>
 					 */
 					while (!(curr.isElement() && ((DOMElement) curr).isSameTag(closeTag)) && curr.parent != null) {
-						curr.end = endTagOpenOffset;
+						curr.setEnd(endTagOpenOffset);
 						curr = curr.parent;
 					}
 					if (curr != xmlDocument) {
@@ -118,7 +118,7 @@ public class DOMParser {
 						} else if (curr.isProcessingInstruction() || curr.isProlog()) {
 							((DOMProcessingInstruction) curr).endTagOpenOffset = endTagOpenOffset;
 						}
-						curr.end = scanner.getTokenEnd();
+						curr.setEnd(scanner.getTokenEnd());
 					}
 				}
 				if (token != TokenType.EndTag && !linkToEmptyStartTag) {
@@ -134,7 +134,7 @@ public class DOMParser {
 						// The next node's parent (curr) is not closed at this point
 						// so the node's parent (curr) will have its end position updated
 						// to a newer end position.
-						curr.end = scanner.getTokenOffset();
+						curr.setEnd(scanner.getTokenOffset());
 					}
 					if ((curr.isClosed()) || curr.isDoctype()) {
 						// The next node being considered is a child of 'curr'
@@ -145,7 +145,7 @@ public class DOMParser {
 						inDTDInternalSubset = false; // In case it was previously in the internal subset
 					}
 					DOMElement child = xmlDocument.createElement(scanner.getTokenOffset(), scanner.getTokenEnd());
-					child.startTagOpenOffset = scanner.getTokenOffset();
+					child.setFlag(DOMTreeNode.FLAG_HAS_START_TAG, true);
 					curr.addChild(child);
 					curr = child;
 					break;
@@ -154,14 +154,14 @@ public class DOMParser {
 				case StartTag: {
 					DOMElement element = (DOMElement) curr;
 					element.tag = xmlDocument.internTag(scanner.getTokenText());
-					curr.end = scanner.getTokenEnd();
+					curr.setEnd(scanner.getTokenEnd());
 					break;
 				}
 
 				case StartTagClose:
 					if (curr.isElement()) {
 						DOMElement element = (DOMElement) curr;
-						curr.end = scanner.getTokenEnd(); // might be later set to end tag position
+						curr.setEnd(scanner.getTokenEnd()); // might be later set to end tag position
 						element.startTagCloseOffset = scanner.getTokenOffset();
 
 						// never enters isEmptyElement() is always false
@@ -171,14 +171,14 @@ public class DOMParser {
 						}
 					} else if (curr.isProcessingInstruction() || curr.isProlog()) {
 						DOMProcessingInstruction element = (DOMProcessingInstruction) curr;
-						curr.end = scanner.getTokenEnd(); // might be later set to end tag position
+						curr.setEnd(scanner.getTokenEnd()); // might be later set to end tag position
 						element.setStartTagClose(true);
 						if (element.getTarget() != null && isEmptyElement(element.getTarget()) && curr.parent != null) {
 							curr.setClosed(true);
 							curr = curr.parent;
 						}
 					}
-					curr.end = scanner.getTokenEnd();
+					curr.setEnd(scanner.getTokenEnd());
 					break;
 
 				case EndTagOpen:
@@ -187,7 +187,7 @@ public class DOMParser {
 						tempWhitespaceContent = null;
 					}
 					endTagOpenOffset = scanner.getTokenOffset();
-					curr.end = scanner.getTokenOffset();
+					curr.setEnd(scanner.getTokenOffset());
 					previousTokenWasEndTagOpen = true;
 					break;
 
@@ -200,7 +200,7 @@ public class DOMParser {
 					 * eg: <a><b><c></d> will set a,b,c end position to the start of |</d>
 					 */
 					while (!(curr.isElement() && ((DOMElement) curr).isSameTag(closeTag)) && curr.parent != null) {
-						curr.end = endTagOpenOffset;
+						curr.setEnd(endTagOpenOffset);
 						curr = curr.parent;
 					}
 					if (curr != xmlDocument) {
@@ -210,7 +210,7 @@ public class DOMParser {
 						} else if (curr.isProcessingInstruction() || curr.isProlog()) {
 							((DOMProcessingInstruction) curr).endTagOpenOffset = endTagOpenOffset;
 						}
-						curr.end = scanner.getTokenEnd();
+						curr.setEnd(scanner.getTokenEnd());
 					} else {
 						// element open tag not found (ex: <root>) add a fake element which only has an
 						// end tag (no start tag).
@@ -227,7 +227,7 @@ public class DOMParser {
 					if (curr.parent != null) {
 						curr.setClosed(true);
 						((DOMElement) curr).setSelfClosed(true);
-						curr.end = scanner.getTokenEnd();
+						curr.setEnd(scanner.getTokenEnd());
 						lastClosed = curr;
 						curr = curr.parent;
 					}
@@ -235,10 +235,10 @@ public class DOMParser {
 
 				case EndTagClose:
 					if (curr.parent != null) {
-						curr.end = scanner.getTokenEnd();
+						curr.setEnd(scanner.getTokenEnd());
 						lastClosed = curr;
 						if (lastClosed.isElement()) {
-							((DOMElement) curr).endTagCloseOffset = scanner.getTokenOffset();
+							((DOMElement) curr).setFlag(DOMTreeNode.FLAG_END_TAG_CLOSED, true);
 						}
 						if (curr.isDoctype()) {
 							curr.setClosed(true);
@@ -252,7 +252,7 @@ public class DOMParser {
 					attr = new DOMAttr(null, scanner.getTokenOffset(),
 							scanner.getTokenEnd(), curr);
 					curr.setAttributeNode(attr);
-					curr.end = scanner.getTokenEnd();
+					curr.setEnd(scanner.getTokenEnd());
 					break;
 				}
 
@@ -269,7 +269,7 @@ public class DOMParser {
 						attr.setValue(null, scanner.getTokenOffset(), scanner.getTokenEnd());
 					}
 					attr = null;
-					curr.end = scanner.getTokenEnd();
+					curr.setEnd(scanner.getTokenEnd());
 					break;
 				}
 
@@ -284,12 +284,12 @@ public class DOMParser {
 					DOMCDATASection cdataNode = (DOMCDATASection) curr;
 					cdataNode.startContent = scanner.getTokenOffset();
 					cdataNode.endContent = scanner.getTokenEnd();
-					curr.end = scanner.getTokenEnd();
+					curr.setEnd(scanner.getTokenEnd());
 					break;
 				}
 
 				case CDATATagClose: {
-					curr.end = scanner.getTokenEnd();
+					curr.setEnd(scanner.getTokenEnd());
 					curr.setClosed(true);
 					curr = curr.parent;
 					break;
@@ -326,7 +326,7 @@ public class DOMParser {
 
 				case PIEnd:
 				case PrologEnd: {
-					curr.end = scanner.getTokenEnd();
+					curr.setEnd(scanner.getTokenEnd());
 					curr.setClosed(true);
 					curr = curr.parent;
 					break;
@@ -346,9 +346,9 @@ public class DOMParser {
 					curr.addChild(comment);
 					curr = comment;
 					try {
-						int endLine = document.positionAt(lastClosed.end).getLine();
-						int startLine = document.positionAt(curr.start).getLine();
-						if (endLine == startLine && lastClosed.end <= curr.start) {
+						int endLine = document.positionAt(lastClosed.getEnd()).getLine();
+						int startLine = document.positionAt(curr.getStart()).getLine();
+						if (endLine == startLine && lastClosed.getEnd() <= curr.getStart()) {
 							comment.setCommentSameLineEndTag(true);
 						}
 					} catch (BadLocationException e) {
@@ -365,7 +365,7 @@ public class DOMParser {
 				}
 
 				case EndCommentTag: {
-					curr.end = scanner.getTokenEnd();
+					curr.setEnd(scanner.getTokenEnd());
 					curr.setClosed(true);
 					curr = curr.parent;
 					break;
@@ -374,7 +374,7 @@ public class DOMParser {
 				case Content: {
 					boolean currIsDeclNode = curr instanceof DTDDeclNode;
 					if (currIsDeclNode) {
-						curr.end = scanner.getTokenOffset() - 1;
+						curr.setEnd(scanner.getTokenOffset() - 1);
 						while (!curr.isDoctype()) {
 							curr = curr.getParentNode();
 						}
@@ -454,7 +454,7 @@ public class DOMParser {
 
 				case DTDEndInternalSubset: {
 					while (!curr.isDoctype()) {
-						curr.end = scanner.getTokenOffset() - 1;
+						curr.setEnd(scanner.getTokenOffset() - 1);
 						curr = curr.getParentNode();
 					}
 					inDTDInternalSubset = false;
@@ -466,7 +466,7 @@ public class DOMParser {
 				case DTDStartElement: {
 					// If previous 'curr' was an unclosed DTD Declaration
 					while (!curr.isDoctype()) {
-						curr.end = scanner.getTokenOffset();
+						curr.setEnd(scanner.getTokenOffset());
 						curr = curr.getParentNode();
 					}
 
@@ -508,7 +508,7 @@ public class DOMParser {
 
 				case DTDStartAttlist: {
 					while (!curr.isDoctype()) { // If previous DTD Decl was unclosed
-						curr.end = scanner.getTokenOffset();
+						curr.setEnd(scanner.getTokenOffset());
 						curr = curr.getParentNode();
 					}
 					DTDAttlistDecl child = new DTDAttlistDecl(scanner.getTokenOffset(), text.length());
@@ -560,7 +560,7 @@ public class DOMParser {
 
 				case DTDStartEntity: {
 					while (!curr.isDoctype()) { // If previous DTD Decl was unclosed
-						curr.end = scanner.getTokenOffset();
+						curr.setEnd(scanner.getTokenOffset());
 						curr = curr.getParentNode();
 					}
 					DTDEntityDecl child = new DTDEntityDecl(scanner.getTokenOffset(), text.length());
@@ -608,7 +608,7 @@ public class DOMParser {
 
 				case DTDStartNotation: {
 					while (!curr.isDoctype()) { // If previous DTD Decl was unclosed
-						curr.end = scanner.getTokenOffset();
+						curr.setEnd(scanner.getTokenOffset());
 						curr = curr.getParentNode();
 					}
 					DTDNotationDecl child = new DTDNotationDecl(scanner.getTokenOffset(), text.length());
@@ -654,7 +654,7 @@ public class DOMParser {
 						while (curr.parent != null && !curr.parent.isDoctype()) {
 							curr = curr.parent;
 						}
-						curr.end = scanner.getTokenEnd();
+						curr.setEnd(scanner.getTokenEnd());
 						curr.setClosed(true);
 						curr = curr.parent;
 					}
@@ -662,7 +662,7 @@ public class DOMParser {
 				}
 
 				case DTDEndDoctypeTag: {
-					((DOMDocumentType) curr).end = scanner.getTokenEnd();
+					curr.setEnd(scanner.getTokenEnd());
 					curr.setClosed(true);
 					curr = curr.parent;
 					break;
@@ -688,7 +688,7 @@ public class DOMParser {
 			}
 		}
 		while (curr.parent != null) {
-			curr.end = text.length();
+			curr.setEnd(text.length());
 			curr = curr.parent;
 		}
 		return xmlDocument;

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMProcessingInstruction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMProcessingInstruction.java
@@ -23,7 +23,7 @@ import org.w3c.dom.NamedNodeMap;
  */
 public class DOMProcessingInstruction extends DOMCharacterData implements org.w3c.dom.ProcessingInstruction {
 
-	private XMLNamedNodeMap<DOMAttr> attributeNodes;
+	DOMAttr firstAttr;
 
 	String target;
 	int startContent;
@@ -35,26 +35,23 @@ public class DOMProcessingInstruction extends DOMCharacterData implements org.w3
 	}
 
 	@Override
-	public boolean hasAttributes() {
-		return attributeNodes != null && !attributeNodes.isEmpty();
-	}
-
-	@Override
-	public List<DOMAttr> getAttributeNodes() {
-		return attributeNodes;
-	}
-
-	@Override
 	public NamedNodeMap getAttributes() {
-		return attributeNodes;
+		return createAttributeNamedNodeMap(firstAttr);
 	}
 
 	@Override
 	public void setAttributeNode(DOMAttr attr) {
-		if (attributeNodes == null) {
-			attributeNodes = new XMLNamedNodeMap<>();
-		}
-		attributeNodes.add(attr);
+		addAttribute(attr, this);
+	}
+
+	@Override
+	DOMAttr getFirstAttr() {
+		return firstAttr;
+	}
+
+	@Override
+	void setFirstAttr(DOMAttr attr) {
+		firstAttr = attr;
 	}
 
 	public boolean isProlog() {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMText.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMText.java
@@ -14,12 +14,13 @@ package org.eclipse.lemminx.dom;
 
 import org.eclipse.lemminx.utils.StringUtils;
 import org.w3c.dom.DOMException;
+import org.w3c.dom.Text;
 
 /**
  * A Text node.
  *
  */
-public class DOMText extends DOMCharacterData implements org.w3c.dom.Text {
+public class DOMText extends DOMCharacterData implements Text {
 
 	public DOMText(int start, int end) {
 		super(start, end);

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMTreeNode.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMTreeNode.java
@@ -1,0 +1,78 @@
+/**
+ *  Copyright (c) 2026 Red Hat Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v2.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ */
+package org.eclipse.lemminx.dom;
+
+/**
+ * Base class for DOM nodes that have a position range (start/end offsets) and
+ * flags in the parsed document. DOMAttr does not extend this class because it
+ * computes its own start/end from name/value offsets.
+ */
+public abstract class DOMTreeNode extends DOMNode {
+
+	static final byte FLAG_CLOSED = 0x01;
+	static final byte FLAG_SELF_CLOSED = 0x02;           // DOMElement
+	static final byte FLAG_START_TAG_CLOSE = 0x04;       // DOMProcessingInstruction
+	static final byte FLAG_PROLOG = 0x08;                // DOMProcessingInstruction
+	static final byte FLAG_PROCESSING_INSTRUCTION = 0x10;// DOMProcessingInstruction
+	static final byte FLAG_WHITESPACE = 0x20;            // DOMCharacterData
+	static final byte FLAG_COMMENT_SAME_LINE = 0x40;     // DOMComment
+	static final byte FLAG_HAS_START_TAG = 0x04;         // DOMElement (overlaps FLAG_START_TAG_CLOSE, different subclass)
+	static final byte FLAG_END_TAG_CLOSED = 0x08;        // DOMElement (overlaps FLAG_PROLOG, different subclass)
+
+	private byte flags = 0;
+
+	final int start;
+	int end;
+
+	public DOMTreeNode(int start, int end) {
+		this.start = start;
+		this.end = end;
+	}
+
+	@Override
+	public int getStart() {
+		return start;
+	}
+
+	@Override
+	public int getEnd() {
+		return end;
+	}
+
+	@Override
+	void setEnd(int end) {
+		this.end = end;
+	}
+
+	boolean getFlag(byte flag) {
+		return (flags & flag) != 0;
+	}
+
+	void setFlag(byte flag, boolean value) {
+		if (value) {
+			flags |= flag;
+		} else {
+			flags &= ~flag;
+		}
+	}
+
+	@Override
+	public boolean isClosed() {
+		return getFlag(FLAG_CLOSED);
+	}
+
+	@Override
+	void setClosed(boolean closed) {
+		setFlag(FLAG_CLOSED, closed);
+	}
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DTDDeclNode.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DTDDeclNode.java
@@ -21,7 +21,7 @@ import org.w3c.dom.Node;
 /**
  * DTDNode
  */
-public class DTDDeclNode extends DOMNode {
+public class DTDDeclNode extends DOMContainerNode {
 
 	/**
 	 * This class is the base for all declaration nodes for DTD's.
@@ -103,7 +103,7 @@ public class DTDDeclNode extends DOMNode {
 		}
 		DTDDeclParameter parameter = new DTDDeclParameter(this, start, end);
 		parameters.add(parameter);
-		this.end = end; // updates end position of the node.
+		setEnd(end); // updates end position of the node.
 		return parameter;
 	}
 
@@ -111,7 +111,7 @@ public class DTDDeclNode extends DOMNode {
 		if (parameters != null && parameters.size() > 0) {
 			DTDDeclParameter last = parameters.get(parameters.size() - 1);
 			last.end = end;
-			this.end = end;
+			setEnd(end);
 		}
 	}
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/XMLModel.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/XMLModel.java
@@ -15,9 +15,9 @@ import static org.eclipse.lemminx.extensions.xerces.xmlmodel.XMLModelDeclaration
 import static org.eclipse.lemminx.extensions.xerces.xmlmodel.XMLModelDeclaration.isApplicableForXSD;
 import static org.eclipse.lemminx.extensions.xerces.xmlmodel.XMLModelDeclaration.isApplicableForRelaxNG;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.eclipse.lemminx.extensions.xerces.xmlmodel.XMLModelDeclaration;
 import org.w3c.dom.ProcessingInstruction;
@@ -105,12 +105,16 @@ public class XMLModel {
 	 * @return the declared xml-model list.
 	 */
 	static List<XMLModel> createXMLModels(DOMDocument document) {
-		List<DOMNode> children = document.getChildren();
-		if (children != null && !children.isEmpty()) {
-			return children.stream().filter(XMLModel::isXMLModel)
-					.map(node -> new XMLModel((DOMProcessingInstruction) node)).collect(Collectors.toList());
+		List<XMLModel> result = null;
+		for (DOMNode child : document.children()) {
+			if (isXMLModel(child)) {
+				if (result == null) {
+					result = new ArrayList<>();
+				}
+				result.add(new XMLModel((DOMProcessingInstruction) child));
+			}
 		}
-		return Collections.emptyList();
+		return result != null ? result : Collections.emptyList();
 	}
 
 	/**

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/catalog/CatalogUtils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/catalog/CatalogUtils.java
@@ -66,7 +66,7 @@ public class CatalogUtils {
 		if (!DOMUtils.isCatalog(document)) {
 			return Collections.emptyList();
 		}
-		for (DOMNode n : document.getChildren()) {
+		for (DOMNode n : document.children()) {
 			if (n.isElement() && CATALOG_ENTITY_NAME.equals(n.getNodeName())) {
 				return collectCatalogEntries((DOMElement) n);
 			}
@@ -142,7 +142,7 @@ public class CatalogUtils {
 		List<CatalogEntry> entries = new ArrayList<>();
 		String baseURI = catalog.getAttribute(XML_BASE_ATTRIBUTE);
 		baseURI = baseURI == null ? "" : baseURI;
-		for (DOMNode node : catalog.getChildren()) {
+		for (DOMNode node : catalog.children()) {
 			if (node.isElement()) {
 				DOMElement element = (DOMElement) node;
 				CatalogEntry catalogEntry = createCatalogEntry(baseURI, element);
@@ -169,7 +169,7 @@ public class CatalogUtils {
 		if (groupSegment != null) {
 			baseURI = Paths.get(baseURI, groupSegment).toString();
 		}
-		for (DOMNode node : group.getChildren()) {
+		for (DOMNode node : group.children()) {
 			if (node.isElement()) {
 				DOMElement element = (DOMElement) node;
 				CatalogEntry catalogEntry = createCatalogEntry(baseURI, element);

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/colors/participants/XMLDocumentColorParticipant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/colors/participants/XMLDocumentColorParticipant.java
@@ -67,8 +67,7 @@ public class XMLDocumentColorParticipant implements IDocumentColorParticipant {
 		if (node.isElement()) {
 			DOMElement element = (DOMElement) node;
 			if (element.hasAttributes()) {
-				List<DOMAttr> attributes = element.getAttributeNodes();
-				for (DOMAttr attr : attributes) {
+				for (DOMAttr attr : element.attributes()) {
 					if (isColorNode(attr, expressions)) {
 						// The current attribute node matches an XML color expression declared in the
 						// "xml/colors"
@@ -100,8 +99,7 @@ public class XMLDocumentColorParticipant implements IDocumentColorParticipant {
 				}
 			}
 		}
-		List<DOMNode> children = node.getChildren();
-		for (DOMNode child : children) {
+		for (DOMNode child : node.children()) {
 			cancelChecker.checkCanceled();
 			doDocumentColor(child, expressions, colors, cancelChecker);
 		}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/ContentModelCompletionParticipant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/ContentModelCompletionParticipant.java
@@ -344,8 +344,7 @@ public class ContentModelCompletionParticipant extends CompletionParticipantAdap
 					if (documentElement.hasAttributes()) {
 						// Get the position after the last attributes
 						// <book xmlns="http://docbook.org/ns/docbook"| >
-						DOMAttr lastAttr = documentElement
-								.getAttributeAtIndex(documentElement.getAttributeNodes().size() - 1);
+						DOMAttr lastAttr = documentElement.getLastAttr();
 						offset = lastAttr.getEnd();
 					} else {
 						// No attributes, get the position after the start tag

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/XMLSyntaxErrorCode.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/XMLSyntaxErrorCode.java
@@ -206,7 +206,7 @@ public enum XMLSyntaxErrorCode implements IXMLErrorCode {
 				DOMElement tagElement = (DOMElement) node;
 				int endOffset = offset;
 				if (tagElement.hasChildNodes()) {
-					for (DOMNode child : tagElement.getChildren()) {
+					for (DOMNode child : tagElement.children()) {
 						if (child.isElement()) {
 							endOffset = child.getStart() - 1;
 							break;

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/XMLSyntaxRelatedInfoFinder.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/XMLSyntaxRelatedInfoFinder.java
@@ -53,11 +53,11 @@ public class XMLSyntaxRelatedInfoFinder implements IRelatedInfoFinder {
 			}
 
 			int closeTagOffset;
-			int numChildren = node.getChildren().size();
-			if (numChildren == 0) {
+			DOMNode lastChild = node.getLastChild();
+			if (lastChild == null) {
 				closeTagOffset = node.getEnd();
 			} else {
-				closeTagOffset = node.getChildren().get(numChildren - 1).getEnd();
+				closeTagOffset = lastChild.getEnd();
 			}
 
 			Range range = XMLPositionUtility.createRange(closeTagOffset, closeTagOffset, document);

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/CloseTagCodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/CloseTagCodeAction.java
@@ -173,8 +173,7 @@ public class CloseTagCodeAction implements ICodeActionParticipant {
 				// the element have some children(Text node, Element node, etc)
 				boolean hasChildWithNoTagName = false;
 				// Search orphan elements in the children to replace
-				List<DOMNode> children = element.getChildren();
-				for (DOMNode child : children) {
+				for (DOMNode child : element.children()) {
 					if (child.isElement()) {
 						DOMElement childElement = (DOMElement) child;
 						if (!childElement.hasTagName() || childElement.isOrphanEndTag()) {
@@ -221,8 +220,7 @@ public class CloseTagCodeAction implements ICodeActionParticipant {
 		} else {
 			// The element has an end tag
 			// Search orphan end tag elements in the children which breaks the XML.
-			List<DOMNode> children = element.getChildren();
-			for (DOMNode child : children) {
+			for (DOMNode child : element.children()) {
 				if (child.isElement()) {
 					DOMElement childElement = (DOMElement) child;
 					if (!childElement.hasTagName() || childElement.isOrphanEndTag()) {
@@ -309,7 +307,7 @@ public class CloseTagCodeAction implements ICodeActionParticipant {
 	 *         otherwise.
 	 */
 	private static boolean hasElements(DOMElement element) {
-		for (DOMNode node : element.getChildren()) {
+		for (DOMNode node : element.children()) {
 			if (node.isElement()) {
 				return true;
 			}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/EntityNotDeclaredCodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/EntityNotDeclaredCodeAction.java
@@ -183,7 +183,7 @@ public class EntityNotDeclaredCodeAction implements ICodeActionParticipant {
 		if (!document.hasProlog()) {
 			return new Position(0, 0);
 		}
-		int prologEnd = document.getChildren().get(0).getEnd();
+		int prologEnd = document.getFirstChild().getEnd();
 		return document.positionAt(prologEnd);
 	}
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/diagnostics/XMLValidator.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/diagnostics/XMLValidator.java
@@ -30,6 +30,7 @@ import org.eclipse.lemminx.dom.DOMAttr;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.dom.DOMDocumentType;
 import org.eclipse.lemminx.dom.DOMElement;
+import org.eclipse.lemminx.dom.DOMNode;
 import org.eclipse.lemminx.dom.NoNamespaceSchemaLocation;
 import org.eclipse.lemminx.dom.SchemaLocationHint;
 import org.eclipse.lemminx.dom.XMLModel;
@@ -346,7 +347,12 @@ public class XMLValidator {
 			return false;
 		}
 		// Disable the DTD validation only if there are not <!ELEMENT or an <!ATTRLIST
-		return !docType.getChildren().stream().anyMatch(node -> node.isDTDElementDecl() || node.isDTDAttListDecl());
+		for (DOMNode node : docType.children()) {
+			if (node.isDTDElementDecl() || node.isDTDAttListDecl()) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	/**

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/minify/XMLMinifierDocument.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/minify/XMLMinifierDocument.java
@@ -292,50 +292,22 @@ public class XMLMinifierDocument {
 			return;
 		}
 
-		List<DOMAttr> attributes = element.getAttributeNodes();
-
-		// Remove extra spaces between element name and first attribute
-		if (!attributes.isEmpty()) {
-			DOMAttr firstAttr = attributes.get(0);
-			int afterElementName = element.getStartTagOpenOffset() + element.getTagName().length() + 1;
-			int beforeFirstAttr = firstAttr.getStart();
-
-			if (afterElementName < beforeFirstAttr) {
-				int length = beforeFirstAttr - afterElementName;
-				if (StringUtils.isWhitespace(textDocument.getTextSequence(), afterElementName, beforeFirstAttr) && length > 1) {
-					// Replace multiple spaces with single space
+		int prevEnd = element.getStartTagOpenOffset() + element.getTagName().length() + 1;
+		for (DOMAttr attr : element.attributes()) {
+			int beforeAttr = attr.getStart();
+			if (prevEnd < beforeAttr) {
+				int length = beforeAttr - prevEnd;
+				if (StringUtils.isWhitespace(textDocument.getTextSequence(), prevEnd, beforeAttr) && length > 1) {
 					try {
-						Range range = new Range(textDocument.positionAt(afterElementName),
-								textDocument.positionAt(beforeFirstAttr));
+						Range range = new Range(textDocument.positionAt(prevEnd),
+								textDocument.positionAt(beforeAttr));
 						edits.add(new TextEdit(range, " "));
 					} catch (BadLocationException e) {
 						LOGGER.log(Level.SEVERE, e.getMessage(), e);
 					}
 				}
 			}
-		}
-
-		// Remove extra spaces between attributes, keep only one space
-		for (int i = 0; i < attributes.size() - 1; i++) {
-			DOMAttr attr = attributes.get(i);
-			DOMAttr nextAttr = attributes.get(i + 1);
-
-			int afterAttr = attr.getEnd();
-			int beforeNextAttr = nextAttr.getStart();
-
-			if (afterAttr < beforeNextAttr) {
-				int length = beforeNextAttr - afterAttr;
-				if (StringUtils.isWhitespace(textDocument.getTextSequence(), afterAttr, beforeNextAttr) && length > 1) {
-					// Replace multiple spaces with single space
-					try {
-						Range range = new Range(textDocument.positionAt(afterAttr),
-								textDocument.positionAt(beforeNextAttr));
-						edits.add(new TextEdit(range, " "));
-					} catch (BadLocationException e) {
-						LOGGER.log(Level.SEVERE, e.getMessage(), e);
-					}
-				}
-			}
+			prevEnd = attr.getEnd();
 		}
 	}
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/references/search/SearchEngine.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/references/search/SearchEngine.java
@@ -188,7 +188,7 @@ public class SearchEngine {
 		}
 		if (node.hasChildNodes()) {
 			// Search in the children
-			for (DOMNode child : node.getChildren()) {
+			for (DOMNode child : node.children()) {
 				searchInNode(child, query, collector, externalURIs, cancelChecker);
 			}
 		}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/relaxng/grammar/rng/RNGDocumentLinkParticipant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/relaxng/grammar/rng/RNGDocumentLinkParticipant.java
@@ -53,7 +53,7 @@ public class RNGDocumentLinkParticipant implements IDocumentLinkParticipant {
 	}
 
 	public void findDocumentLinks(DOMNode parent, DOMDocument document, List<DocumentLink> links) {
-		for (DOMNode child : parent.getChildren()) {
+		for (DOMNode child : parent.children()) {
 			if (child.isElement()) {
 				DOMElement rngElement = (DOMElement) child;
 				if (RelaxNGUtils.isInclude(rngElement) || RelaxNGUtils.isExternalRef(rngElement)) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/relaxng/xml/validator/RelaxNGErrorCode.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/relaxng/xml/validator/RelaxNGErrorCode.java
@@ -241,7 +241,7 @@ public enum RelaxNGErrorCode implements IXMLErrorCode {
 	}
 
 	private static DOMAttr findRefByName(DOMNode parent, String refName) {
-		for (DOMNode child : parent.getChildren()) {
+		for (DOMNode child : parent.children()) {
 			if (child.isElement() && RelaxNGUtils.isRef((DOMElement) child)) {
 				DOMElement ref = (DOMElement) child;
 				DOMAttr attr = ref.getAttributeNode(RelaxNGUtils.NAME_ATTR);

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xinclude/XIncludeDocumentLinkParticipant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xinclude/XIncludeDocumentLinkParticipant.java
@@ -41,7 +41,7 @@ public class XIncludeDocumentLinkParticipant implements IDocumentLinkParticipant
 	}
 
 	public void findDocumentLinks(DOMNode parent, DOMDocument document, List<DocumentLink> links) {
-		for (DOMNode child : parent.getChildren()) {
+		for (DOMNode child : parent.children()) {
 			if (child.isElement()) {
 				DOMElement xincludeElement = (DOMElement) child;
 				if (XIncludeUtils.isInclude(xincludeElement)) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/participants/XSDDocumentLinkParticipant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/participants/XSDDocumentLinkParticipant.java
@@ -49,8 +49,7 @@ public class XSDDocumentLinkParticipant implements IDocumentLinkParticipant {
 			return;
 		}
 		String xmlSchemaPrefix = root.getPrefix();
-		List<DOMNode> children = root.getChildren();
-		for (DOMNode child : children) {
+		for (DOMNode child : root.children()) {
 			if (child.isElement() && Objects.equals(child.getPrefix(), xmlSchemaPrefix)) {
 				DOMElement xsdElement = (DOMElement) child;
 				if (XSDUtils.isXSInclude(xsdElement) || XSDUtils.isXSImport(xsdElement)) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/participants/XSDErrorCode.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/participants/XSDErrorCode.java
@@ -15,7 +15,7 @@ package org.eclipse.lemminx.extensions.xsd.participants;
 import static org.eclipse.lemminx.utils.StringUtils.getString;
 
 import java.util.HashMap;
-import java.util.List;
+
 import java.util.Map;
 
 import org.apache.xerces.xni.XMLLocator;
@@ -113,13 +113,13 @@ public enum XSDErrorCode implements IXMLErrorCode {
 		case cos_all_limited_2: {
 			String nameValue = getString(arguments[1]);
 			DOMNode parent = document.findNodeAt(offset);
-			List<DOMNode> children = parent.getChildrenWithAttributeValue("name", nameValue);
+			DOMNode child = parent.findChildWithAttributeValue("name", nameValue);
 
-			if (children.isEmpty()) {
+			if (child == null) {
 				return XMLPositionUtility.selectStartTagName(offset, document);
 			}
 
-			offset = children.get(0).getStart() + 1;
+			offset = child.getStart() + 1;
 			return XMLPositionUtility.selectAttributeValueAt("maxOccurs", offset, document);
 		}
 		case ct_props_correct_3: {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/utils/XSDUtils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/utils/XSDUtils.java
@@ -497,8 +497,7 @@ public class XSDUtils {
 	public static DOMAttr findSchemaLocationAttrByURI(DOMDocument document, String grammarURI) {
 		DOMElement documentElement = document.getDocumentElement();
 		if (documentElement != null) {
-			List<DOMNode> children = documentElement.getChildren();
-			for (DOMNode child : children) {
+			for (DOMNode child : documentElement.children()) {
 				if (child.isElement()) {
 					DOMElement xsdElement = (DOMElement) child;
 					if (XSDUtils.isXSInclude(xsdElement) || XSDUtils.isXSImport(xsdElement)) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLCompletions.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLCompletions.java
@@ -591,9 +591,8 @@ public class XMLCompletions {
 				Integer slashOffset = element1.endsWith('/', offset);
 				Position end = null;
 				if (!element1.isInEndTag(offset) && slashOffset != null) { // The typed characted was '/'
-					List<DOMAttr> attrList = element1.getAttributeNodes();
-					if (attrList != null) {
-						DOMAttr lastAttr = attrList.get(attrList.size() - 1);
+					DOMAttr lastAttr = element1.getLastAttr();
+					if (lastAttr != null) {
 						if (slashOffset < lastAttr.getEnd()) { // slash in attribute value
 							return null;
 						}
@@ -712,17 +711,17 @@ public class XMLCompletions {
 			// no grammar, collect similar tags from the parent node
 			Set<String> seenElements = new HashSet<>();
 			if (parentNode != null && parentNode.isElement() && parentNode.hasChildNodes()) {
-				parentNode.getChildren().forEach(node -> {
+				for (DOMNode node : parentNode.children()) {
 					DOMElement element = node.isElement() ? (DOMElement) node : null;
 					if (element == null || element.getTagName() == null
 							|| seenElements.contains(element.getTagName())) {
-						return;
+						continue;
 					}
 					String tag = element.getTagName();
 					seenElements.add(tag);
 					DOMElementCompletionItem item = new DOMElementCompletionItem(element, completionRequest);
 					completionResponse.addCompletionItem(item);
-				});
+				}
 			}
 		}
 	}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLRename.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLRename.java
@@ -252,13 +252,11 @@ class XMLRename {
 
 	private List<TextEdit> getXmlnsAttrRenameTextEdits(DOMDocument xmlDocument, DOMElement element, Position position,
 			String newText) {
-		List<DOMAttr> attributes = element.getAttributeNodes();
-
-		if (attributes == null) {
+		if (!element.hasAttributes()) {
 			return Collections.emptyList();
 		}
 
-		for (DOMAttr attr : attributes) {
+		for (DOMAttr attr : element.attributes()) {
 			DOMRange nameNode = attr.getNodeAttrName();
 
 			if (!attr.isXmlns()) {
@@ -349,7 +347,7 @@ class XMLRename {
 	 * @return
 	 */
 	private static List<TextEdit> renameElementsNamespace(DOMDocument document, List<TextEdit> edits,
-			List<DOMNode> elements, String oldNamespace, String newNamespace) {
+			Iterable<DOMNode> elements, String oldNamespace, String newNamespace) {
 		int oldNamespaceLength = oldNamespace.length();
 		for (DOMNode node : elements) {
 			if (node.isElement()) {
@@ -362,7 +360,7 @@ class XMLRename {
 				}
 
 				if (element.hasChildNodes()) {
-					renameElementsNamespace(document, edits, element.getChildren(), oldNamespace, newNamespace);
+					renameElementsNamespace(document, edits, element.children(), oldNamespace, newNamespace);
 				}
 			}
 		}
@@ -401,10 +399,9 @@ class XMLRename {
 	private static List<TextEdit> renameElementAttributeValueNamespace(DOMDocument document, DOMElement element,
 			String oldNamespace, String newNamespace) {
 
-		List<DOMAttr> attributes = element.getAttributeNodes();
 		List<TextEdit> edits = new ArrayList<>();
-		if (attributes != null) {
-			for (DOMAttr attr : attributes) {
+		if (element.hasAttributes()) {
+			for (DOMAttr attr : element.attributes()) {
 				DOMRange attrValue = attr.getNodeAttrValue();
 				if (attrValue != null) {
 					String attrValueText = attr.getValue();

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLSelectionRanges.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLSelectionRanges.java
@@ -75,7 +75,7 @@ class XMLSelectionRanges {
 		DOMNode node = DOMDocument.findNodeOrAttrAt(xmlDocument, offset);
 		if (node.isAttribute()) {
 			DOMAttr attr = (DOMAttr) node;
-			for (DOMNode attrChild : attr.getChildren()) {
+			for (DOMNode attrChild : attr.children()) {
 				if (attrChild.getStart() <= offset && offset <= attrChild.getEnd()) {
 					return attrChild;
 				}
@@ -84,7 +84,7 @@ class XMLSelectionRanges {
 			DOMDocumentType doctype = (DOMDocumentType) node;
 			DTDDeclParameter subset = doctype.getInternalSubsetNode();
 			if (subset != null && subset.getStart() < offset && offset < subset.getEnd()) {
-				for (DOMNode child : doctype.getChildren()) {
+				for (DOMNode child : doctype.children()) {
 					if (child.getStart() != -1 && child.getStart() <= offset && offset < child.getEnd()) {
 						return child;
 					}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLSymbolsProvider.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLSymbolsProvider.java
@@ -141,20 +141,20 @@ class XMLSymbolsProvider {
 				List<DOMNode> attrToIgnoreList = getFilteredNodeAttributes(node, filter, hasFilterForAttr);
 				// Convert to HashSet for O(1) lookup instead of O(n) with List.contains()
 				Set<DOMNode> attrToIgnore = attrToIgnoreList.isEmpty() ? Collections.emptySet() : new HashSet<>(attrToIgnoreList);
-				for (DOMAttr attr : node.getAttributeNodes()) {
+				for (DOMAttr attr : node.attributes()) {
 					findSymbolInformations(attr, containerName, symbols, attrToIgnore.contains(attr), filter, hasFilterForAttr,
 							cancelChecker);
 				}
 			}
 		}
-		node.getChildren().forEach(child -> {
+		for (DOMNode child : node.children()) {
 			try {
 				findSymbolInformations(child, containerName, symbols, false, filter, hasFilterForAttr, cancelChecker);
 			} catch (BadLocationException e) {
 				LOGGER.log(Level.SEVERE, "XMLSymbolsProvider was given a BadLocation by the provided 'node' variable",
 						e);
 			}
-		});
+		}
 	}
 
 	// -------------- Document symbols
@@ -177,7 +177,7 @@ class XMLSymbolsProvider {
 			boolean isDTD = xmlDocument.isDTD();
 			boolean hasFilterForAttr = filter.hasFilterFor(MatcherType.ATTRIBUTE);
 			Set<DOMNode> nodesToIgnore = new HashSet<>();
-			xmlDocument.getRoots().forEach(node -> {
+			for (DOMNode node : xmlDocument.getRoots()) {
 				try {
 					if ((node.isDoctype() && isDTD)) {
 						nodesToIgnore.add(node);
@@ -187,7 +187,7 @@ class XMLSymbolsProvider {
 					LOGGER.log(Level.SEVERE,
 							"XMLSymbolsProvider#findDocumentSymbols was given a BadLocation by a 'node' variable", e);
 				}
-			});
+			}
 		} catch (ResultLimitExceededException e) {
 			symbols.setResultLimitExceeded(true);
 		}
@@ -230,21 +230,20 @@ class XMLSymbolsProvider {
 					List<DOMNode> attrToIgnoreList = getFilteredNodeAttributes(node, filter, hasFilterForAttr);
 					// Convert to HashSet for O(1) lookup instead of O(n) with List.contains()
 					Set<DOMNode> attrToIgnore = attrToIgnoreList.isEmpty() ? Collections.emptySet() : new HashSet<>(attrToIgnoreList);
-					for (DOMAttr attr : node.getAttributeNodes()) {
+					for (DOMAttr attr : node.attributes()) {
 						findDocumentSymbols(attr, childrenSymbols, attrToIgnore, filter, hasFilterForAttr, cancelChecker);
 					}
 				}
 			} else {
 				if (node.isDTDElementDecl() || (nodesToIgnore != null && node.isDTDAttListDecl())) {
 					// In the case of DTD ELEMENT we try to add in the children the DTD ATTLIST
-					Collection<DOMNode> attlistDecls;
+					Iterable<DOMNode> attlistDecls;
 					if (node.isDTDElementDecl()) {
 						DTDElementDecl elementDecl = (DTDElementDecl) node;
 						String elementName = elementDecl.getName();
 						attlistDecls = node.getOwnerDocument().findDTDAttrList(elementName);
 					} else {
-						attlistDecls = new ArrayList<>();
-						attlistDecls.add(node);
+						attlistDecls = Collections.singletonList(node);
 					}
 
 					for (DOMNode attrDecl : attlistDecls) {
@@ -268,14 +267,14 @@ class XMLSymbolsProvider {
 			return;
 		}
 		final DocumentSymbolsResult childrenOfChild = childrenSymbols;
-		node.getChildren().forEach(child -> {
+		for (DOMNode child : node.children()) {
 			try {
 				findDocumentSymbols(child, childrenOfChild, nodesToIgnore, filter, hasFilterForAttr, cancelChecker);
 			} catch (BadLocationException e) {
 				LOGGER.log(Level.SEVERE, "XMLSymbolsProvider was given a BadLocation by the provided 'node' variable",
 						e);
 			}
-		});
+		}
 	}
 
 	private List<DOMNode> getFilteredNodeAttributes(DOMNode node, XMLSymbolFilter filter, boolean hasFilterForAttr){
@@ -284,7 +283,7 @@ class XMLSymbolsProvider {
 		}
 
 		List<DOMNode> attrNodesToIgnore = new ArrayList<DOMNode>();
-		for(DOMAttr attrNode : node.getAttributeNodes()){
+		for(DOMAttr attrNode : node.attributes()){
 			XMLSymbolExpressionFilter filterExpression = filter.getFilterForInlineAttr(attrNode);
 			if(filterExpression != null){
 				// prevent rendering the attribute as a child node if it's
@@ -356,7 +355,7 @@ class XMLSymbolsProvider {
 				if (firstChild != null && firstChild.isText() && filter.isNodeSymbol(firstChild)) {
 					return element.getTagName() + ": " + firstChild.getNodeValue();
 				} else if(hasFilterForAttr && node.hasAttributes()){
-					for(DOMAttr attrNode : node.getAttributeNodes()){
+					for(DOMAttr attrNode : node.attributes()){
 						XMLSymbolExpressionFilter inlineAttrfilter = filter.getFilterForInlineAttr(attrNode);
 						if(inlineAttrfilter != null){
 							if(!inlineAttrfilter.isShowAttributeName()){

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/DOMDocTypeFormatter.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/DOMDocTypeFormatter.java
@@ -97,7 +97,7 @@ public class DOMDocTypeFormatter {
 	private void formatDTD(DOMDocumentType docType, XMLFormattingConstraints parentConstraints, int start, int end,
 			List<TextEdit> edits) {
 		boolean addLineSeparator = !docType.getOwnerDocument().isDTD();
-		for (DOMNode child : docType.getChildren()) {
+		for (DOMNode child : docType.children()) {
 			switch (child.getNodeType()) {
 
 			case DOMNode.DTD_ELEMENT_DECL_NODE:

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/DOMElementFormatter.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/DOMElementFormatter.java
@@ -211,13 +211,12 @@ public class DOMElementFormatter {
 
 	private int formatAttributes(DOMElement element, XMLFormattingConstraints parentConstraints, List<TextEdit> edits) {
 		if (element.hasAttributes()) {
-			List<DOMAttr> attributes = element.getAttributeNodes();
 			// initialize the previous offset with the start tag:
 			// <foo| attr1="" attr2="">.
 			int prevOffset = element.getOffsetAfterStartTag();
-			boolean singleAttribute = attributes.size() == 1;
+			boolean singleAttribute = element.hasSingleAttribute();
 			boolean isFirstAttr = true;
-			for (DOMAttr attr : attributes) {
+			for (DOMAttr attr : element.attributes()) {
 				// Format current attribute
 				attributeFormatter.formatAttribute(attr, prevOffset, singleAttribute, true, isFirstAttr,
 						parentConstraints, edits);
@@ -388,10 +387,9 @@ public class DOMElementFormatter {
 	 * @return true if should format according to closingBracketNewLine setting.
 	 */
 	private boolean shouldFormatClosingBracketNewLine(DOMElement element) {
-		boolean isSingleAttribute = element.getAttributeNodes() != null ? element.getAttributeNodes().size() == 1
-				: true;
 		return (formatterDocument.getSharedSettings().getFormattingSettings().getClosingBracketNewLine()
-				&& getSplitAttributes() != SplitAttributes.preserve && !isSingleAttribute);
+				&& getSplitAttributes() != SplitAttributes.preserve
+				&& element.hasAttributes() && !element.hasSingleAttribute());
 	}
 
 	private void replaceLeftSpacesWith(int from, int to, String replace, List<TextEdit> edits) {
@@ -447,8 +445,7 @@ public class DOMElementFormatter {
 		if (!element.hasAttributes()) {
 			return null;
 		}
-		List<DOMAttr> attributes = element.getAttributeNodes();
-		return attributes.get(attributes.size() - 1);
+		return element.getLastAttr();
 	}
 
 	private boolean isPreserveAttributeLineBreaks() {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/DOMProcessingInstructionFormatter.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/DOMProcessingInstructionFormatter.java
@@ -54,9 +54,8 @@ public class DOMProcessingInstructionFormatter {
 		if (processingInstruction.hasAttributes()) {
 			// --- <?xml version = \"1.0\" encoding = \"UTF-8\"?>
 			// --> <?xml version=\"1.0\" encoding=\"UTF-8\"?>
-			List<DOMAttr> attributes = processingInstruction.getAttributeNodes();
-			boolean singleAttribute = attributes.size() == 1;
-			for (DOMAttr attr : attributes) {
+			boolean singleAttribute = processingInstruction.hasSingleAttribute();
+			for (DOMAttr attr : processingInstruction.attributes()) {
 				attributeFormatter.formatAttribute(attr, prevOffset, singleAttribute, false, false, parentConstraints, edits);
 				prevOffset = attr.getEnd();
 			}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/XMLFormatterDocument.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/XMLFormatterDocument.java
@@ -376,7 +376,7 @@ public class XMLFormatterDocument {
 
 	public void formatChildren(DOMNode currentDOMNode, XMLFormattingConstraints parentConstraints, int start, int end,
 			List<TextEdit> edits) {
-		for (DOMNode child : currentDOMNode.getChildren()) {
+		for (DOMNode child : currentDOMNode.children()) {
 			format(child, parentConstraints, start, end, edits);
 		}
 	}
@@ -626,7 +626,7 @@ public class XMLFormatterDocument {
 		boolean hasElement = false;
 		boolean hasText = false;
 		boolean onlySpaces = true;
-		for (DOMNode child : element.getChildren()) {
+		for (DOMNode child : element.children()) {
 			if (child.isElement() || child.isComment() || child.isProcessingInstruction()) {
 				hasElement = true;
 			} else if (child.isText()) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/XMLFormatterDocumentOld.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/XMLFormatterDocumentOld.java
@@ -137,7 +137,7 @@ public class XMLFormatterDocumentOld {
 
 	private boolean containsTextWithinStartTag() {
 
-		if (this.rangeDomDocument.getChildren().size() < 1) {
+		if (!this.rangeDomDocument.hasChildNodes()) {
 			return false;
 		}
 
@@ -325,7 +325,7 @@ public class XMLFormatterDocumentOld {
 			}
 		} else if (node.hasChildNodes()) {
 			// Other nodes kind like root
-			for (DOMNode child : node.getChildren()) {
+			for (DOMNode child : node.children()) {
 				format(child);
 			}
 		}
@@ -475,7 +475,7 @@ public class XMLFormatterDocumentOld {
 					// element has body
 
 					this.indentLevel++;
-					for (DOMNode child : element.getChildren()) {
+					for (DOMNode child : element.children()) {
 						hasElements = hasElements || !child.isText();
 						format(child);
 					}
@@ -547,10 +547,9 @@ public class XMLFormatterDocumentOld {
 	}
 
 	private void formatAttributes(DOMElement element) throws BadLocationException {
-		List<DOMAttr> attributes = element.getAttributeNodes();
 		boolean isSingleAttribute = hasSingleAttributeInFullDoc(element);
 		int prevOffset = element.getStart();
-		for (DOMAttr attr : attributes) {
+		for (DOMAttr attr : element.attributes()) {
 			formatAttribute(attr, isSingleAttribute, prevOffset);
 			prevOffset = attr.getEnd();
 		}
@@ -608,8 +607,7 @@ public class XMLFormatterDocumentOld {
 		if (!element.hasAttributes()) {
 			return null;
 		}
-		List<DOMAttr> attributes = element.getAttributeNodes();
-		return attributes.get(attributes.size() - 1);
+		return element.getLastAttr();
 	}
 
 	/**
@@ -622,7 +620,7 @@ public class XMLFormatterDocumentOld {
 	 */
 	private boolean hasSingleAttributeInFullDoc(DOMElement element) {
 		DOMElement fullElement = getFullDocElemFromRangeElem(element);
-		return fullElement.getAttributeNodes().size() == 1;
+		return fullElement.hasSingleAttribute();
 	}
 
 	/**
@@ -657,7 +655,7 @@ public class XMLFormatterDocumentOld {
 
 	private static boolean formatDTD(DOMDocumentType doctype, int level, int end, XMLBuilder xmlBuilder) {
 		DOMNode previous = null;
-		for (DOMNode node : doctype.getChildren()) {
+		for (DOMNode node : doctype.children()) {
 			if (previous != null) {
 				xmlBuilder.linefeed();
 			}
@@ -794,11 +792,10 @@ public class XMLFormatterDocumentOld {
 	 * Will add all attributes, to the given builder, on a single line
 	 */
 	private static void addPrologAttributes(DOMNode node, XMLBuilder xmlBuilder) {
-		List<DOMAttr> attrs = node.getAttributeNodes();
-		if (attrs == null) {
+		if (!node.hasAttributes()) {
 			return;
 		}
-		for (DOMAttr attr : attrs) {
+		for (DOMAttr attr : node.attributes()) {
 			xmlBuilder.addPrologAttribute(attr);
 		}
 	}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/snippets/NewFileSnippetContext.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/snippets/NewFileSnippetContext.java
@@ -87,7 +87,7 @@ public abstract class NewFileSnippetContext implements IXMLSnippetContext {
 		// - processing instruction
 		// - text
 		// - '<', '<!' characters
-		for (DOMNode child : document.getChildren()) {
+		for (DOMNode child : document.children()) {
 			if (child.isElement()) {
 				DOMElement first = (DOMElement) child;
 				// check if element is just '<' or '<!'

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/DOMUtils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/DOMUtils.java
@@ -268,7 +268,7 @@ public class DOMUtils {
 	}
 
 	public static DOMElement findFirstChildElementByTagName(DOMElement element, String tagName) {
-		for (DOMNode child : element.getChildren()) {
+		for (DOMNode child : element.children()) {
 			if (isDOMElement(child, tagName)) {
 				return (DOMElement) child;
 			}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/XMLPositionUtility.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/XMLPositionUtility.java
@@ -140,12 +140,14 @@ public class XMLPositionUtility {
 	public static Range selectAttributeValueFromGivenValue(String attrValue, int offset, DOMDocument document) {
 		DOMNode element = document.findNodeAt(offset);
 		if (element != null && element.hasAttributes()) {
-			List<DOMAttr> attribues = element.getAttributeNodes();
-			for (int i = attribues.size() - 1; i >= 0; i--) {
-				DOMAttr attr = attribues.get(i);
+			DOMAttr found = null;
+			for (DOMAttr attr : element.attributes()) {
 				if (offset > attr.getStart() && attrValue.equals(attr.getValue())) {
-					return createAttrValueRange(attr, document);
+					found = attr;
 				}
+			}
+			if (found != null) {
+				return createAttrValueRange(found, document);
 			}
 		}
 		return null;
@@ -169,8 +171,7 @@ public class XMLPositionUtility {
 	public static Range selectAttributeValueByGivenValueAt(String attrValue, int offset, DOMDocument document) {
 		DOMNode element = document.findNodeAt(offset);
 		if (element != null && element.hasAttributes()) {
-			List<DOMAttr> attributes = element.getAttributeNodes();
-			for (DOMAttr attr : attributes) {
+			for (DOMAttr attr : element.attributes()) {
 				if (attrValue.equals(attr.getValue())) {
 					return createAttrValueRange(attr, document);
 				}
@@ -242,14 +243,13 @@ public class XMLPositionUtility {
 	 */
 	public static Range selectChildNodeAttributeValueFromGivenNameAt(String childNodeName, String attrName, int offset,
 			DOMDocument document) {
-		List<DOMNode> childNodes = document.findNodeAt(offset).getChildren();
-		if (childNodes.size() == 0) {
+		DOMNode parent = document.findNodeAt(offset);
+		if (!parent.hasChildNodes()) {
 			return null;
 		}
-		for (DOMNode domNode : childNodes) {
+		for (DOMNode domNode : parent.children()) {
 			if (domNode.getNodeName().equals(childNodeName) && domNode.hasAttributes()) {
-				List<DOMAttr> attributes = domNode.getAttributeNodes();
-				for (DOMAttr attr : attributes) {
+				for (DOMAttr attr : domNode.attributes()) {
 					if (attrName.equals(attr.getName())) {
 						return createAttrValueRange(attr, document);
 					}
@@ -264,8 +264,7 @@ public class XMLPositionUtility {
 		if (element != null && element.hasAttributes()) {
 			int startOffset = -1;
 			int endOffset = 0;
-			List<DOMAttr> attributes = element.getAttributeNodes();
-			for (DOMAttr attr : attributes) {
+			for (DOMAttr attr : element.attributes()) {
 				if (startOffset == -1) {
 					startOffset = attr.getStart();
 					endOffset = attr.getEnd();
@@ -379,9 +378,9 @@ public class XMLPositionUtility {
 		DOMNode curr = parent;
 		DOMNode child;
 		while (curr != null) {
-			child = findUnclosedChildNode(childTag, curr.getChildren());
+			child = findUnclosedChildNode(childTag, curr.children());
 			if (child == null) {
-				curr = findUnclosedChildNode(curr.getChildren());
+				curr = findUnclosedChildNode(curr.children());
 			} else {
 				return createRange(child.getStart() + 1, child.getStart() + 1 + childTag.length(), document);
 			}
@@ -391,7 +390,7 @@ public class XMLPositionUtility {
 		return createRange(parent.getStart() + 2, parent.getStart() + 2 + parentName.length(), document);
 	}
 
-	private static DOMNode findUnclosedChildNode(List<DOMNode> children) {
+	private static DOMNode findUnclosedChildNode(Iterable<DOMNode> children) {
 		for (DOMNode child : children) {
 			if (!child.isClosed()) {
 				return child;
@@ -400,7 +399,7 @@ public class XMLPositionUtility {
 		return null;
 	}
 
-	private static DOMNode findUnclosedChildNode(String childTag, List<DOMNode> children) {
+	private static DOMNode findUnclosedChildNode(String childTag, Iterable<DOMNode> children) {
 		for (DOMNode child : children) {
 			if (child.isElement() && childTag != null && childTag.equals(((DOMElement) child).getTagName())
 					&& !child.isClosed()) {
@@ -716,7 +715,7 @@ public class XMLPositionUtility {
 	public static Range selectFirstNonWhitespaceText(int offset, DOMDocument document) {
 		DOMNode element = document.findNodeAt(offset);
 		if (element != null) {
-			for (DOMNode node : element.getChildren()) {
+			for (DOMNode node : element.children()) {
 				if (node.isText() || node.isCDATA()) {
 					DOMCharacterData data = (DOMCharacterData) node;
 					int start = data.getStartContent();

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/dom/DOMParserTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/dom/DOMParserTest.java
@@ -15,6 +15,7 @@ package org.eclipse.lemminx.dom;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -1182,7 +1183,7 @@ public class DOMParserTest {
 		}
 	}
 
-	private static class MockNode extends DOMNode {
+	private static class MockNode extends DOMTreeNode {
 
 		public MockNode(int start, int end) {
 			super(start, end);
@@ -1250,8 +1251,8 @@ public class DOMParserTest {
 			assertEquals(((DOMProcessingInstruction) expectedNode).getEndTagStart(),
 					((DOMProcessingInstruction) actualNode).getEndTagStart());
 		}
-		assertEquals(expectedNode.start, actualNode.start);
-		assertEquals(expectedNode.end, actualNode.end);
+		assertEquals(expectedNode.getStart(), actualNode.getStart());
+		assertEquals(expectedNode.getEnd(), actualNode.getEnd());
 		assertEquals(expectedNode.getAttributeNodes(), actualNode.getAttributeNodes());
 
 		if (expectedNode.isCharacterData()) {
@@ -1396,6 +1397,238 @@ public class DOMParserTest {
 		DOMNode text = document.getDocumentElement().getFirstChild();
 		assertTrue(text.isText());
 		assertFalse(text.hasAttributes());
+	}
+
+	// --- Linked list children tests ---
+
+	@Test
+	public void testChildrenIterable() {
+		DOMDocument document = DOMParser.getInstance().parse(
+				"<root><a/><b/><c/></root>", "", null);
+		DOMElement root = document.getDocumentElement();
+		int count = 0;
+		String[] expected = { "a", "b", "c" };
+		for (DOMNode child : root.children()) {
+			assertTrue(child.isElement());
+			assertEquals(expected[count], ((DOMElement) child).getTagName());
+			count++;
+		}
+		assertEquals(3, count);
+	}
+
+	@Test
+	public void testChildrenIterableEmpty() {
+		DOMDocument document = DOMParser.getInstance().parse(
+				"<root/>", "", null);
+		DOMElement root = document.getDocumentElement();
+		int count = 0;
+		for (DOMNode child : root.children()) {
+			count++;
+		}
+		assertEquals(0, count);
+	}
+
+	@Test
+	public void testSiblingNavigation() {
+		DOMDocument document = DOMParser.getInstance().parse(
+				"<root><a/><b/><c/></root>", "", null);
+		DOMElement root = document.getDocumentElement();
+		DOMNode first = root.getFirstChild();
+		assertNotNull(first);
+		assertEquals("a", first.getNodeName());
+
+		DOMNode second = first.getNextSibling();
+		assertNotNull(second);
+		assertEquals("b", second.getNodeName());
+
+		DOMNode third = second.getNextSibling();
+		assertNotNull(third);
+		assertEquals("c", third.getNodeName());
+		assertSame(root.getLastChild(), third);
+
+		assertEquals(null, third.getNextSibling());
+
+		assertSame(second, third.getPreviousSibling());
+		assertSame(first, second.getPreviousSibling());
+		assertEquals(null, first.getPreviousSibling());
+	}
+
+	@Test
+	public void testLeafNodeHasNoChildren() {
+		DOMDocument document = DOMParser.getInstance().parse(
+				"<root>hello</root>", "", null);
+		DOMNode text = document.getDocumentElement().getFirstChild();
+		assertTrue(text.isText());
+		assertFalse(text.hasChildNodes());
+		assertEquals(null, text.getFirstChild());
+		assertEquals(null, text.getLastChild());
+		assertEquals(0, text.getChildNodes().getLength());
+	}
+
+	@Test
+	public void testContainerNodeHasChildren() {
+		DOMDocument document = DOMParser.getInstance().parse(
+				"<root><child/></root>", "", null);
+		DOMElement root = document.getDocumentElement();
+		assertTrue(root instanceof DOMContainerNode);
+		assertTrue(root.hasChildNodes());
+		assertNotNull(root.getFirstChild());
+		assertSame(root.getFirstChild(), root.getLastChild());
+	}
+
+	// --- Attribute linked list tests ---
+
+	@Test
+	public void testAttributeLinkedListOrder() {
+		DOMDocument document = DOMParser.getInstance().parse(
+				"<root a=\"1\" b=\"2\" c=\"3\"/>", "", null);
+		DOMElement root = document.getDocumentElement();
+		List<DOMAttr> attrs = root.getAttributeNodes();
+		assertEquals(3, attrs.size());
+		assertEquals("a", attrs.get(0).getName());
+		assertEquals("b", attrs.get(1).getName());
+		assertEquals("c", attrs.get(2).getName());
+	}
+
+	@Test
+	public void testAttributeNextSibling() {
+		DOMDocument document = DOMParser.getInstance().parse(
+				"<root x=\"1\" y=\"2\" z=\"3\"/>", "", null);
+		DOMElement root = document.getDocumentElement();
+		List<DOMAttr> attrs = root.getAttributeNodes();
+		DOMAttr x = attrs.get(0);
+		DOMAttr y = attrs.get(1);
+		DOMAttr z = attrs.get(2);
+		assertSame(y, x.getNextSibling());
+		assertSame(z, y.getNextSibling());
+		assertEquals(null, z.getNextSibling());
+	}
+
+	@Test
+	public void testFindChildWithAttributeValue() {
+		DOMDocument document = DOMParser.getInstance().parse(
+				"<root><a name=\"foo\"/><b name=\"bar\"/></root>", "", null);
+		DOMElement root = document.getDocumentElement();
+		DOMNode found = root.findChildWithAttributeValue("name", "bar");
+		assertNotNull(found);
+		assertEquals("b", found.getNodeName());
+		assertEquals(null, root.findChildWithAttributeValue("name", "baz"));
+	}
+
+	@Test
+	public void testHasSingleAttributeNone() {
+		DOMDocument document = DOMParser.getInstance().parse(
+				"<root/>", "", null);
+		DOMElement root = document.getDocumentElement();
+		assertFalse(root.hasSingleAttribute());
+	}
+
+	@Test
+	public void testHasSingleAttributeOne() {
+		DOMDocument document = DOMParser.getInstance().parse(
+				"<root a=\"1\"/>", "", null);
+		DOMElement root = document.getDocumentElement();
+		assertTrue(root.hasSingleAttribute());
+	}
+
+	@Test
+	public void testHasSingleAttributeTwo() {
+		DOMDocument document = DOMParser.getInstance().parse(
+				"<root a=\"1\" b=\"2\"/>", "", null);
+		DOMElement root = document.getDocumentElement();
+		assertFalse(root.hasSingleAttribute());
+	}
+
+	@Test
+	public void testGetLastAttrNone() {
+		DOMDocument document = DOMParser.getInstance().parse(
+				"<root/>", "", null);
+		DOMElement root = document.getDocumentElement();
+		assertNull(root.getLastAttr());
+	}
+
+	@Test
+	public void testGetLastAttrOne() {
+		DOMDocument document = DOMParser.getInstance().parse(
+				"<root a=\"1\"/>", "", null);
+		DOMElement root = document.getDocumentElement();
+		DOMAttr last = root.getLastAttr();
+		assertNotNull(last);
+		assertEquals("a", last.getName());
+	}
+
+	@Test
+	public void testGetLastAttrMultiple() {
+		DOMDocument document = DOMParser.getInstance().parse(
+				"<root a=\"1\" b=\"2\" c=\"3\"/>", "", null);
+		DOMElement root = document.getDocumentElement();
+		DOMAttr last = root.getLastAttr();
+		assertNotNull(last);
+		assertEquals("c", last.getName());
+	}
+
+	@Test
+	public void testGetAttributeAtIndex() {
+		DOMDocument document = DOMParser.getInstance().parse(
+				"<root a=\"1\" b=\"2\" c=\"3\"/>", "", null);
+		DOMElement root = document.getDocumentElement();
+		assertEquals("a", root.getAttributeAtIndex(0).getName());
+		assertEquals("b", root.getAttributeAtIndex(1).getName());
+		assertEquals("c", root.getAttributeAtIndex(2).getName());
+		assertNull(root.getAttributeAtIndex(3));
+		assertNull(root.getAttributeAtIndex(-1));
+	}
+
+	// --- DOMCharacterData tests ---
+
+	@Test
+	public void testHasMultiLine() {
+		DOMDocument document = DOMParser.getInstance().parse(
+				"<root>line1\nline2</root>", "", null);
+		DOMText text = (DOMText) document.getDocumentElement().getFirstChild();
+		assertTrue(text.hasMultiLine());
+	}
+
+	@Test
+	public void testHasMultiLineSingleLine() {
+		DOMDocument document = DOMParser.getInstance().parse(
+				"<root>single line</root>", "", null);
+		DOMText text = (DOMText) document.getDocumentElement().getFirstChild();
+		assertFalse(text.hasMultiLine());
+	}
+
+	@Test
+	public void testStartsWithNewLine() {
+		DOMDocument document = DOMParser.getInstance().parse(
+				"<root>\n  text</root>", "", null);
+		DOMText text = (DOMText) document.getDocumentElement().getFirstChild();
+		assertTrue(text.startsWithNewLine());
+	}
+
+	@Test
+	public void testEndsWithNewLine() {
+		DOMDocument document = DOMParser.getInstance().parse(
+				"<root>text  \n</root>", "", null);
+		DOMText text = (DOMText) document.getDocumentElement().getFirstChild();
+		assertTrue(text.endsWithNewLine());
+	}
+
+	@Test
+	public void testHasSiblings() {
+		DOMDocument document = DOMParser.getInstance().parse(
+				"<root><a/>text</root>", "", null);
+		DOMElement root = document.getDocumentElement();
+		DOMNode a = root.getFirstChild();
+		DOMNode text = a.getNextSibling();
+		assertTrue(text.hasSiblings());
+	}
+
+	@Test
+	public void testHasSiblingsAlone() {
+		DOMDocument document = DOMParser.getInstance().parse(
+				"<root>text</root>", "", null);
+		DOMNode text = document.getDocumentElement().getFirstChild();
+		assertFalse(text.hasSiblings());
 	}
 
 	public DOMDocument getXMLDocument(String input) {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLCompletionTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLCompletionTest.java
@@ -178,6 +178,12 @@ public class XMLCompletionTest {
 	}
 
 	@Test
+	public void testAutoCloseTagCompletionNoAttributes() {
+		assertAutoCloseEndTagCompletionWithRange("<a/|></a>", ">$0", r(0, 3, 0, 8));
+		assertAutoCloseEndTagCompletion("<a/|", ">$0");
+	}
+
+	@Test
 	public void testAutoCloseEnabledDisabled() throws BadLocationException {
 		testCompletionFor("<a><div|<a>", false, c("div", "<div>"));
 		testCompletionFor("<a><div|<a>", true, c("div", "<div></div>"));


### PR DESCRIPTION
## Reduce DOM memory usage with linked-list structure

### Summary

This PR replaces the internal `ArrayList`-based tree structure (`XMLNodeList` for children, `XMLNamedNodeMap` for attributes) with a **linked-list structure using sibling pointers** (`firstChild`/`nextSibling` for children, `firstAttr`/`nextAttr` for attributes).

This eliminates millions of `ArrayList` instances and their backing `Object[]` arrays when parsing large XML documents.

### What changed

- **Internal structure**: DOM nodes no longer store children in an `ArrayList` wrapped by `XMLNodeList`, nor attributes in `XMLNamedNodeMap`. Instead, nodes are linked via `firstChild`/`nextSibling` and `firstAttr`/`nextAttr` pointers.
- **New zero-allocation iterables**: `children()` and `attributes()` provide `Iterable<DOMNode>` / `Iterable<DOMAttr>`
that traverse the linked lists without alloction.
- **Deprecated methods**: `getChildren()` and `getAttributeNodes()` are marked `@Deprecated` because they instantiate
a `List` on each call. Callers should use `c instead.
- **Caller migration**: All `getChildren()` call sites in `src/main` have been migrated to `children()` (or to `getFirstChild()`/`getLastChild()`/`hasChildNodes()` where appropriate). `getAttributeNodes()` call sites have been migrated to `attributes()`.
- **`getRoots()`** return type changed from `List<DOMNode>` to `Iterable<DOMNode>`.

### Memory comparison

Tested with a [30 MB XML file](https://samplelib.com/xml/sample-30mb.xml) (~1.17M elements, ~975K text nodes, ~195K attributes).

Scenario: open the file, then type a character (triggers re-parse).

Heap histogram (`jcmd GC.class_histogram`):

| Class | `main` | PR |
|-------|--------|----|
| `DOMElement` (1,170,500) | 71.4 MB | 62.5
| `Object[]` backing arrays | 48.6 MB (1,369K) | 0.3 MB (6K) |
| `DOMText` (975,415) | 37.2 MB | 29.8 MB |
| `XMLNodeList` | 26.8 MB (1,170,500) | **eliminated** |
| `DOMAttr` (195,085) | 13.4 MB | 10.4 MB |
| `XMLNamedNodeMap` | 4.5 MB (195,084) | **eliminated** |
| **Total** | **201.9 MB** | **103.0 MB** |
| **Saved** | | **~99 MB (~49%)** |