### PR TITLE
Fix codeAction/resolve returning null for already-resolved code actions

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLCodeActions.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLCodeActions.java
@@ -97,7 +97,7 @@ public class XMLCodeActions {
 				sharedSettings);
 		String participantId = request.getParticipantId();
 		if (StringUtils.isEmpty(participantId)) {
-			return null;
+			return unresolved;
 		}
 		for (ICodeActionParticipant codeActionParticipant : extensionsRegistry.getCodeActionsParticipants()) {
 			try {
@@ -114,6 +114,6 @@ public class XMLCodeActions {
 						+ codeActionParticipant.getClass().getName() + "'.", e);
 			}
 		}
-		return null;
+		return unresolved;
 	}
 }


### PR DESCRIPTION
Fixes eclipse-lemminx/lemminx#1796

When a client (e.g. Neovim) calls codeAction/resolve on a code action that already has its `edit` field populated (such as "Insert all expected elements"), the resolveCodeAction method returned null because:

1. The code action has no `data` field with a `participantId` (it doesn't need resolution), so getParticipantId() returns empty and the method returned null immediately.
2. Even if it reached the loop, no participant would match, and the fallback also returned null.

Per the LSP specification, codeAction/resolve must return the code action passed as parameter when it is already fully resolved. Returning null causes clients like Neovim to fail with "action can't be nil".

Only "Minify XML" worked because it is the only action that genuinely needs resolution: it has a `data.participantId` but no `edit`, so it correctly finds its MinifyCodeActionResolver participant.

The fix replaces both `return null` with `return unresolved` so that already-complete code actions are returned as-is.