### PR TITLE
Fix RelaxNG child element documentation collision

### DIFF
--- a/org.eclipse.lemminx/src/main/java/com/thaiopensource/relaxng/pattern/MySchemaPatternBuilder.java
+++ b/org.eclipse.lemminx/src/main/java/com/thaiopensource/relaxng/pattern/MySchemaPatternBuilder.java
@@ -61,7 +61,11 @@ public class MySchemaPatternBuilder extends SchemaPatternBuilder {
 
 	@Override
 	Pattern makeElement(NameClass nameClass, Pattern content, Locator loc) {
-		return super.makeElement(nameClass, content, copy(loc));
+		// Don't call super.makeElement() which interns the pattern.
+		// Interning collapses ElementPatterns with the same name and content,
+		// losing the locator of subsequent definitions.
+		// See https://github.com/eclipse-lemminx/lemminx/issues/1745
+		return new ElementPattern(nameClass, content, copy(loc));
 	}
 
 	@Override

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/XMLAssert.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/XMLAssert.java
@@ -1289,11 +1289,13 @@ public class XMLAssert {
 		Position position = document.positionAt(offset);
 
 		DOMDocument htmlDoc = DOMParser.getInstance().parse(document, xmlLanguageService.getResolverExtensionManager());
+		xmlLanguageService.setDocumentProvider((uri) -> htmlDoc);
 		// Configure XML catalog for XML schema
 		if (catalogPath != null) {
 			settings.setCatalogs(new String[] { catalogPath });
 		}
 		xmlLanguageService.doSave(new SettingsSaveContext(settings));
+		xmlLanguageService.initializeIfNeeded();
 
 		Hover hover = xmlLanguageService.doHover(htmlDoc, position, sharedSettings);
 		if (expectedHoverLabel == null) {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/relaxng/xml/hover/RelaxNGHoverTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/relaxng/xml/hover/RelaxNGHoverTest.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.relaxng.xml.hover;
+
+import static org.eclipse.lemminx.XMLAssert.r;
+
+import org.apache.xerces.impl.XMLEntityManager;
+import org.apache.xerces.util.URI.MalformedURIException;
+import org.eclipse.lemminx.AbstractCacheBasedTest;
+import org.eclipse.lemminx.XMLAssert;
+import org.eclipse.lemminx.commons.BadLocationException;
+import org.eclipse.lemminx.services.XMLLanguageService;
+import org.eclipse.lsp4j.Range;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that RelaxNG documentation is resolved correctly when child elements
+ * with the same name appear under different parents.
+ *
+ * @see <a href="https://github.com/eclipse-lemminx/lemminx/issues/1745">issue
+ *      1745</a>
+ */
+public class RelaxNGHoverTest extends AbstractCacheBasedTest {
+
+	@Test
+	public void hoverOnFooDate() throws BadLocationException, MalformedURIException {
+		String schemaURI = getRelaxNGFileURI("docCollision.rng");
+		String xml = "<?xml-model href=\"docCollision.rng\" ?>\r\n" + //
+				"<root>\r\n" + //
+				"  <foo>\r\n" + //
+				"    <da|te>2024-01-01</date>\r\n" + //
+				"  </foo>\r\n" + //
+				"  <bar>\r\n" + //
+				"    <date>2024-06-15</date>\r\n" + //
+				"  </bar>\r\n" + //
+				"</root>";
+		assertHover(xml, "Date of a FOO object" + //
+				System.lineSeparator() + //
+				System.lineSeparator() + "Source: [docCollision.rng](" + schemaURI + ")", r(3, 5, 3, 9));
+	}
+
+	@Test
+	public void hoverOnBarDate() throws BadLocationException, MalformedURIException {
+		String schemaURI = getRelaxNGFileURI("docCollision.rng");
+		String xml = "<?xml-model href=\"docCollision.rng\" ?>\r\n" + //
+				"<root>\r\n" + //
+				"  <foo>\r\n" + //
+				"    <date>2024-01-01</date>\r\n" + //
+				"  </foo>\r\n" + //
+				"  <bar>\r\n" + //
+				"    <da|te>2024-06-15</date>\r\n" + //
+				"  </bar>\r\n" + //
+				"</root>";
+		assertHover(xml, "Date of a BAR object" + //
+				System.lineSeparator() + //
+				System.lineSeparator() + "Source: [docCollision.rng](" + schemaURI + ")", r(6, 5, 6, 9));
+	}
+
+	@Test
+	public void hoverOnFoo() throws BadLocationException, MalformedURIException {
+		String schemaURI = getRelaxNGFileURI("docCollision.rng");
+		String xml = "<?xml-model href=\"docCollision.rng\" ?>\r\n" + //
+				"<root>\r\n" + //
+				"  <fo|o>\r\n" + //
+				"    <date>2024-01-01</date>\r\n" + //
+				"  </foo>\r\n" + //
+				"  <bar>\r\n" + //
+				"    <date>2024-06-15</date>\r\n" + //
+				"  </bar>\r\n" + //
+				"</root>";
+		assertHover(xml, "A foo element" + //
+				System.lineSeparator() + //
+				System.lineSeparator() + "Source: [docCollision.rng](" + schemaURI + ")", r(2, 3, 2, 6));
+	}
+
+	@Test
+	public void hoverOnBar() throws BadLocationException, MalformedURIException {
+		String schemaURI = getRelaxNGFileURI("docCollision.rng");
+		String xml = "<?xml-model href=\"docCollision.rng\" ?>\r\n" + //
+				"<root>\r\n" + //
+				"  <foo>\r\n" + //
+				"    <date>2024-01-01</date>\r\n" + //
+				"  </foo>\r\n" + //
+				"  <ba|r>\r\n" + //
+				"    <date>2024-06-15</date>\r\n" + //
+				"  </bar>\r\n" + //
+				"</root>";
+		assertHover(xml, "A bar element" + //
+				System.lineSeparator() + //
+				System.lineSeparator() + "Source: [docCollision.rng](" + schemaURI + ")", r(5, 3, 5, 6));
+	}
+
+	private static void assertHover(String value, String expectedHoverLabel, Range expectedHoverRange)
+			throws BadLocationException {
+		XMLAssert.assertHover(new XMLLanguageService(), value, null, "src/test/resources/relaxng/test.xml",
+				expectedHoverLabel, expectedHoverRange);
+	}
+
+	private static String getRelaxNGFileURI(String schemaURI) throws MalformedURIException {
+		return XMLEntityManager
+				.expandSystemId("relaxng/" + schemaURI, "src/test/resources/test.xml", true)
+				.replace("///", "/");
+	}
+}

--- a/org.eclipse.lemminx/src/test/resources/relaxng/docCollision.rng
+++ b/org.eclipse.lemminx/src/test/resources/relaxng/docCollision.rng
@@ -1,0 +1,23 @@
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">
+  <start>
+    <element name="root">
+      <interleave>
+        <element name="foo">
+          <a:documentation>A foo element</a:documentation>
+          <element name="date">
+            <a:documentation>Date of a FOO object</a:documentation>
+            <text/>
+          </element>
+        </element>
+        <element name="bar">
+          <a:documentation>A bar element</a:documentation>
+          <element name="date">
+            <a:documentation>Date of a BAR object</a:documentation>
+            <text/>
+          </element>
+        </element>
+      </interleave>
+    </element>
+  </start>
+</grammar>


### PR DESCRIPTION
Fixes https://github.com/eclipse-lemminx/lemminx/issues/1745

## Problem

When a RelaxNG schema defines multiple parent elements each containing a child element with the **same name** but **different `a:documentation`**, hovering on any of these child elements always showed the documentation of the first definition.

## Fix

Skip `ElementPattern` interning in `MySchemaPatternBuilder.makeElement()` so each element definition preserves its own `Locator`.

Jing's `PatternInterner` collapses `ElementPattern` objects with the same name and content pattern into a single instance, losing the `Locator` of subsequent definitions. Since `a:documentation` annotations are not part of the pattern content, they don't prevent interning.

## Tests

Given `docCollision.rng`:
```xml
<grammar xmlns="http://relaxng.org/ns/structure/1.0"
         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">
  <start>
    <element name="root">
      <interleave>
        <element name="foo">
          <a:documentation>A foo element</a:documentation>
          <element name="date">
            <a:documentation>Date of a FOO object</a:documentation>
            <text/>
          </element>
        </element>
        <element name="bar">
          <a:documentation>A bar element</a:documentation>
          <element name="date">
            <a:documentation>Date of a BAR object</a:documentation>
            <text/>
          </element>
        </element>
      </interleave>
    </element>
  </start>
</grammar>
```

Given XML

```xml
<?xml-model href="docCollision.rng" ?>
<root>
  <foo>
    <date>...</date>
  </foo>
  <bar>
    <date>...</date>
  </bar>
</root>
```

<img width="754" height="366" alt="image" src="https://github.com/user-attachments/assets/638e80a4-40f7-473f-a5d6-5ee71107e0ec" />

- Hover on `<date>` inside `<foo>` → displays **"Date of a FOO object"**
- Hover on `<date>` inside `<bar>` → displays **"Date of a BAR object"**
- Hover on `<foo>` → displays **"A foo element"**
- Hover on `<bar>` → displays **"A bar element"**