### PR TITLE
Fix RelaxNG completion for elements with ChoiceNameClass names

### DIFF
--- a/org.eclipse.lemminx/src/main/java/com/thaiopensource/relaxng/pattern/CMRelaxNGDocument.java
+++ b/org.eclipse.lemminx/src/main/java/com/thaiopensource/relaxng/pattern/CMRelaxNGDocument.java
@@ -38,6 +38,8 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.xml.sax.Locator;
 
+import com.thaiopensource.xml.util.Name;
+
 /**
  * RelaxNG content document implementation.
  * 
@@ -103,6 +105,12 @@ public class CMRelaxNGDocument implements CMDocument {
 			element = new CMRelaxNGElementDeclaration(this, elementDeclaration);
 			elementMappings.put(elementDeclaration, element);
 		}
+		return element;
+	}
+
+	CMRelaxNGElementDeclaration createPatternElement(ElementPattern elementDeclaration, Name overrideName) {
+		CMRelaxNGElementDeclaration element = new CMRelaxNGElementDeclaration(this, elementDeclaration);
+		element.setOverrideName(overrideName);
 		return element;
 	}
 

--- a/org.eclipse.lemminx/src/main/java/com/thaiopensource/relaxng/pattern/CMRelaxNGElementDeclaration.java
+++ b/org.eclipse.lemminx/src/main/java/com/thaiopensource/relaxng/pattern/CMRelaxNGElementDeclaration.java
@@ -52,6 +52,8 @@ public class CMRelaxNGElementDeclaration implements CMElementDeclaration {
 
 	private final ElementPattern pattern;
 
+	private Name overrideName;
+
 	private Collection<CMElementDeclaration> elements;
 
 	private Collection<CMAttributeDeclaration> attributes;
@@ -65,6 +67,10 @@ public class CMRelaxNGElementDeclaration implements CMElementDeclaration {
 	CMRelaxNGElementDeclaration(CMRelaxNGDocument document, ElementPattern pattern) {
 		this.cmDocument = document;
 		this.pattern = pattern;
+	}
+
+	void setOverrideName(Name overrideName) {
+		this.overrideName = overrideName;
 	}
 
 	public ElementPattern getPattern() {
@@ -91,6 +97,9 @@ public class CMRelaxNGElementDeclaration implements CMElementDeclaration {
 	}
 
 	private Name getJingName() {
+		if (overrideName != null) {
+			return overrideName;
+		}
 		NameClass nameClass = pattern.getNameClass();
 		if (nameClass instanceof SimpleNameClass) {
 			return ((SimpleNameClass) nameClass).getName();
@@ -152,7 +161,9 @@ public class CMRelaxNGElementDeclaration implements CMElementDeclaration {
 		List<CMElementDeclaration> possibleElements = new ArrayList<>();
 		for (Name name : allowed) {
 			CMElementDeclaration possible = findCMElement(name.getLocalName(), name.getNamespaceUri());
-			possibleElements.add(possible);
+			if (possible != null) {
+				possibleElements.add(possible);
+			}
 		}
 		return possibleElements;
 	}

--- a/org.eclipse.lemminx/src/main/java/com/thaiopensource/relaxng/pattern/CMRelaxNGElementDeclarationCollector.java
+++ b/org.eclipse.lemminx/src/main/java/com/thaiopensource/relaxng/pattern/CMRelaxNGElementDeclarationCollector.java
@@ -13,10 +13,12 @@ package com.thaiopensource.relaxng.pattern;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import org.eclipse.lemminx.extensions.contentmodel.model.CMElementDeclaration;
 
 import com.thaiopensource.util.VoidValue;
+import com.thaiopensource.xml.util.Name;
 
 /**
  * RelaxNG class used to collect content model elements children for a given
@@ -51,8 +53,54 @@ public class CMRelaxNGElementDeclarationCollector extends AbstractCMRelaxNGColle
 		if (nameClass instanceof SimpleNameClass) {
 			CMRelaxNGElementDeclaration elementDeclaration = document.getPatternElement(p);
 			elements.add(elementDeclaration);
+		} else {
+			List<Name> names = new ArrayList<>();
+			collectSimpleNames(nameClass, names);
+			for (Name name : names) {
+				CMRelaxNGElementDeclaration elementDeclaration = document.createPatternElement(p, name);
+				elements.add(elementDeclaration);
+			}
 		}
 		return VoidValue.VOID;
+	}
+
+	private static void collectSimpleNames(NameClass nameClass, List<Name> names) {
+		nameClass.accept(new NameClassVisitor() {
+			@Override
+			public void visitChoice(NameClass nc1, NameClass nc2) {
+				collectSimpleNames(nc1, names);
+				collectSimpleNames(nc2, names);
+			}
+
+			@Override
+			public void visitName(Name name) {
+				names.add(name);
+			}
+
+			@Override
+			public void visitNsName(String ns) {
+			}
+
+			@Override
+			public void visitNsNameExcept(String ns, NameClass nc) {
+			}
+
+			@Override
+			public void visitAnyName() {
+			}
+
+			@Override
+			public void visitAnyNameExcept(NameClass nc) {
+			}
+
+			@Override
+			public void visitNull() {
+			}
+
+			@Override
+			public void visitError() {
+			}
+		});
 	}
 
 	public Collection<CMElementDeclaration> getElements() {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/relaxng/xml/completion/XMLCompletionBasedOnRelaxNGTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/relaxng/xml/completion/XMLCompletionBasedOnRelaxNGTest.java
@@ -206,6 +206,37 @@ public class XMLCompletionBasedOnRelaxNGTest extends BaseFileTempTest {
 						"xlink:actuate"));
 	}
 
+	@Test
+	public void completionOnRootWithChoiceNameClass() throws BadLocationException {
+		String xml = "<?xml-model href=\"choiceNameElement.rng\" ?>\r\n" + //
+				"<|";
+		testCompletionFor(xml, //
+				null, //
+				c("odoo", te(1, 0, 1, 1, "<odoo></odoo>"), "<odoo"), //
+				c("openerp", te(1, 0, 1, 1, "<openerp></openerp>"), "<openerp"), //
+				c("data", te(1, 0, 1, 1, "<data></data>"), "<data"));
+	}
+
+	@Test
+	public void completionInElementWithChoiceNameClass() throws BadLocationException {
+		String xml = "<?xml-model href=\"choiceNameElement.rng\" ?>\r\n" + //
+				"<odoo>\r\n" + //
+				"  <|\r\n" + //
+				"</odoo>";
+		testCompletionFor(xml, //
+				null, //
+				c("record", te(2, 2, 2, 3, "<record model=\"\"></record>"), "<record"));
+	}
+
+	@Test
+	public void completionOnAttributesWithChoiceNameClass() throws BadLocationException {
+		String xml = "<?xml-model href=\"choiceNameElement.rng\" ?>\r\n" + //
+				"<odoo |></odoo>";
+		testCompletionFor(xml, //
+				null, //
+				c("noupdate", te(1, 6, 1, 6, "noupdate=\"\""), "noupdate"));
+	}
+
 	// role,xml:id,version,xml:lang,xml:base,remap,xreflabel,revisionflag,dir,arch,audience,condition,conformance,os,revision,security,userlevel,vendor,wordsize,annotations,linkend,xlink:href,xlink:type,xlink:role,xlink:arcrole,xlink:title,xlink:show,xlink:actuate,label,status
 
 	private static void testCompletionFor(String value, Integer expectedCount, CompletionItem... expectedItems)

--- a/org.eclipse.lemminx/src/test/resources/relaxng/choiceNameElement.rng
+++ b/org.eclipse.lemminx/src/test/resources/relaxng/choiceNameElement.rng
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+    <define name="record">
+        <element name="record">
+            <attribute name="model" />
+            <optional><attribute name="id" /></optional>
+            <zeroOrMore>
+                <element name="field">
+                    <attribute name="name" />
+                    <text/>
+                </element>
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="root_element">
+        <element>
+            <choice>
+                <name>odoo</name>
+                <name>openerp</name>
+                <name>data</name>
+            </choice>
+            <optional><attribute name="noupdate" /></optional>
+            <zeroOrMore>
+                <choice>
+                    <text/>
+                    <ref name="record"/>
+                </choice>
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <start>
+        <ref name="root_element"/>
+    </start>
+</grammar>


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-xml/issues/1119

Fix RelaxNG completion for elements defined with `ChoiceNameClass` names (e.g. `<choice><name>odoo</name><name>openerp</name></choice>`).

When a RelaxNG schema uses `<rng:choice>` to define multiple possible names for an element, the name class is a `ChoiceNameClass` instead of a `SimpleNameClass`. The element declaration collector was silently ignoring these elements, causing **empty completion results** even though validation works correctly.

The fix recursively extracts simple names from `ChoiceNameClass` via the Jing `NameClassVisitor` and creates a `CMElementDeclaration` for each name. Also fixes a potential NPE in `getPossibleElements` when `findCMElement` returns null.

## How to test

### Given this RelaxNG schema (`test.rng`)

```xml
<?xml version="1.0" encoding="UTF-8"?>
<grammar xmlns="http://relaxng.org/ns/structure/1.0">

    <define name="record">
        <element name="record">
            <attribute name="model" />
            <optional><attribute name="id" /></optional>
            <zeroOrMore>
                <element name="field">
                    <attribute name="name" />
                    <text/>
                </element>
            </zeroOrMore>
        </element>
    </define>

    <define name="root_element">
        <element>
            <choice>
                <name>odoo</name>
                <name>openerp</name>
                <name>data</name>
            </choice>
            <optional><attribute name="noupdate" /></optional>
            <zeroOrMore>
                <choice>
                    <text/>
                    <ref name="record"/>
                </choice>
            </zeroOrMore>
        </element>
    </define>

    <start>
        <ref name="root_element"/>
    </start>
</grammar>
```

Given this XML file (test.xml)

```xml
<?xml-model href="test.rng"?>
<odoo>
    <record model="res.partner">
        <field name="name">Test</field>
    </record>
</odoo>
```

## Test 1 — Root element completion

Open completion on an empty document after the <?xml-model?> PI:

```xml
<?xml-model href="test.rng"?>
<|

```
Expected: completion proposes odoo, openerp, data.

Before fix: empty completion list.

## Test 2 — Child element completion

Open completion inside <odoo>:

```xml
<?xml-model href="test.rng"?>
<odoo>
    <|
</odoo>
```

Expected: completion proposes record.

Before fix: empty completion list.

## Test 3 — Attribute completion

Open completion on the <odoo> tag:

```xml
<?xml-model href="test.rng"?>
<odoo |></odoo>
```

Expected: completion proposes noupdate.

Before fix: empty completion list.

## Test 4 — Nested attribute completion

Open completion on a <record> tag:

```xml
<?xml-model href="test.rng"?>
<odoo>
    <record |></record>
</odoo>
```

Expected: completion proposes model (required), id (optional).

Before fix: empty completion list.