### PR TITLE
Fix MissingResourceException for RelaxNG regex pattern validation

### DIFF
--- a/org.eclipse.lemminx/src/main/resources/META-INF/native-image/resource-config.json
+++ b/org.eclipse.lemminx/src/main/resources/META-INF/native-image/resource-config.json
@@ -57,6 +57,9 @@
 			"name": "com.thaiopensource.datatype.xsd.resources.Messages"
 		},
 		{
+			"name": "com.thaiopensource.datatype.xsd.regex.java.resources.Messages"
+		},
+		{
 			"name": "com.thaiopensource.relaxng.pattern.resources.Messages"
 		},
 		{

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/relaxng/xml/diagnostics/RelaxNGDiagnosticsV1Test.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/relaxng/xml/diagnostics/RelaxNGDiagnosticsV1Test.java
@@ -108,6 +108,25 @@ public class RelaxNGDiagnosticsV1Test extends AbstractCacheBasedTest {
 	}
 	
 	@Test
+	public void patternRegexValid() throws Exception {
+		String xml = "<?xml-model href=\"src/test/resources/relaxng/patternRegex.rng\" ?>\r\n" + //
+				"<root>\r\n" + //
+				"  <item lang=\"en\">text</item>\r\n" + //
+				"</root>";
+		testDiagnosticsFor(xml);
+	}
+
+	@Test
+	public void patternRegexInvalid() throws Exception {
+		String xml = "<?xml-model href=\"src/test/resources/relaxng/patternRegex.rng\" ?>\r\n" + //
+				"<root>\r\n" + //
+				"  <item lang=\"123\">text</item>\r\n" + //
+				"</root>";
+		testDiagnosticsFor(xml, //
+				d(2, 13, 18, RelaxNGErrorCode.invalid_attribute_value));
+	}
+
+	@Test
 	public void multiple_no_attributes_allowed() throws Exception {
 		String xml = "<?xml-model href=\"src/test/resources/relaxng/addressBook_v1.rng\" ?>\r\n" + //
 				"<addressBook id=\"\" name=\"\" >\r\n" + // no_attributes_allowed

--- a/org.eclipse.lemminx/src/test/resources/relaxng/patternRegex.rng
+++ b/org.eclipse.lemminx/src/test/resources/relaxng/patternRegex.rng
@@ -1,0 +1,15 @@
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+  datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <start>
+    <element name="root">
+      <element name="item">
+        <attribute name="lang">
+          <data type="string">
+            <param name="pattern">[a-zA-Z]{2,3}(-[a-zA-Z0-9]+)*</param>
+          </data>
+        </attribute>
+        <text/>
+      </element>
+    </element>
+  </start>
+</grammar>


### PR DESCRIPTION
Register com.thaiopensource.datatype.xsd.regex.java.resources.Messages bundle in native-image resource config. Without this, pattern param validation in RelaxNG schemas fails with MissingResourceException instead of producing proper diagnostics.

Fixes redhat-developer/vscode-xml#1095