### PR TITLE
Fix xsi:type content model resolution for schemas with targetNamespace

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/contentmodel/CMXSDDocument.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/contentmodel/CMXSDDocument.java
@@ -219,9 +219,17 @@ public class CMXSDDocument implements CMDocument, XSElementDeclHelper {
 				String[] possiblyQualifiedType = attr.getNodeValue().split(":", 2);
 				javax.xml.namespace.QName qualifiedType;
 				if (possiblyQualifiedType.length == 1) {
-					qualifiedType = new javax.xml.namespace.QName(
-							null,
-							possiblyQualifiedType[0]);
+					String typeName = possiblyQualifiedType[0];
+					qualifiedType = new javax.xml.namespace.QName(null, typeName);
+					XSTypeDefinition result = (XSTypeDefinition) model
+							.getComponents(XSConstants.TYPE_DEFINITION).get(qualifiedType);
+					if (result != null) {
+						return result;
+					}
+					String defaultNs = element.getNamespaceURI(null);
+					if (defaultNs != null) {
+						qualifiedType = new javax.xml.namespace.QName(defaultNs, typeName);
+					}
 				} else {
 					qualifiedType = new javax.xml.namespace.QName(
 							element.getNamespaceURI(possiblyQualifiedType[0]),

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaCompletionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaCompletionExtensionsTest.java
@@ -1652,4 +1652,35 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 								"Source: attr-enum.xsd",
 						MarkupKind.PLAINTEXT));
 	}
+
+	@Test
+	public void xsiTypeWithNamespacePrefix() throws BadLocationException {
+		String xml = "<root xmlns=\"http://example.com/test\"\r\n" + //
+				"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"      xmlns:tns=\"http://example.com/test\"\r\n" + //
+				"      xsi:schemaLocation=\"http://example.com/test xsd/xsitype-ns.xsd\">\r\n" + //
+				"  <item xsi:type=\"tns:DerivedType\" name=\"test\">\r\n" + //
+				"    <|" + //
+				"  </item>\r\n" + //
+				"</root>";
+		testCompletionFor(xml, null, "src/test/resources/xsitype-ns.xml",
+				2 + 2 /* CDATA and Comments */, //
+				c("tns:baseProp", "<tns:baseProp></tns:baseProp>"), //
+				c("tns:derivedProp", "<tns:derivedProp></tns:derivedProp>"));
+	}
+
+	@Test
+	public void xsiTypeWithDefaultNamespaceNoPrefix() throws BadLocationException {
+		String xml = "<root xmlns=\"http://example.com/test\"\r\n" + //
+				"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"      xsi:schemaLocation=\"http://example.com/test xsd/xsitype-ns.xsd\">\r\n" + //
+				"  <item xsi:type=\"DerivedType\" name=\"test\">\r\n" + //
+				"    <|" + //
+				"  </item>\r\n" + //
+				"</root>";
+		testCompletionFor(xml, null, "src/test/resources/xsitype-ns.xml",
+				2 + 2 /* CDATA and Comments */, //
+				c("baseProp", "<baseProp></baseProp>"), //
+				c("derivedProp", "<derivedProp></derivedProp>"));
+	}
 }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaHoverExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaHoverExtensionsTest.java
@@ -425,6 +425,41 @@ public class XMLSchemaHoverExtensionsTest extends AbstractCacheBasedTest {
 		}));
 	}
 
+	@Test
+	public void testXsiTypeDerivedElementHoverWithNamespacePrefix() throws BadLocationException, MalformedURIException {
+		String schemaURI = getXMLSchemaFileURI("xsitype-ns.xsd");
+		String xml = "<root xmlns=\"http://example.com/test\"\r\n" + //
+				"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"      xmlns:tns=\"http://example.com/test\"\r\n" + //
+				"      xsi:schemaLocation=\"http://example.com/test xsd/xsitype-ns.xsd\">\r\n" + //
+				"  <item xsi:type=\"tns:DerivedType\" name=\"test\">\r\n" + //
+				"    <tns:derived|Prop></tns:derivedProp>\r\n" + //
+				"  </item>\r\n" + //
+				"</root>";
+		XMLAssert.assertHover(xml, "src/test/resources/xsitype-ns.xml",
+				"derived property documentation" + //
+						System.lineSeparator() + //
+						System.lineSeparator() + "Source: [xsitype-ns.xsd](" + schemaURI + ")", //
+				r(5, 5, 5, 20));
+	}
+
+	@Test
+	public void testXsiTypeDerivedElementHoverWithDefaultNamespace() throws BadLocationException, MalformedURIException {
+		String schemaURI = getXMLSchemaFileURI("xsitype-ns.xsd");
+		String xml = "<root xmlns=\"http://example.com/test\"\r\n" + //
+				"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"      xsi:schemaLocation=\"http://example.com/test xsd/xsitype-ns.xsd\">\r\n" + //
+				"  <item xsi:type=\"DerivedType\" name=\"test\">\r\n" + //
+				"    <derived|Prop></derivedProp>\r\n" + //
+				"  </item>\r\n" + //
+				"</root>";
+		XMLAssert.assertHover(xml, "src/test/resources/xsitype-ns.xml",
+				"derived property documentation" + //
+						System.lineSeparator() + //
+						System.lineSeparator() + "Source: [xsitype-ns.xsd](" + schemaURI + ")", //
+				r(4, 5, 4, 16));
+	}
+
 	private static void assertHover(String value, String expectedHoverLabel, Range expectedHoverRange)
 			throws BadLocationException {
 		XMLAssert.assertHover(new XMLLanguageService(), value, "src/test/resources/catalogs/catalog.xml", null,

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaTypeDefinitionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaTypeDefinitionExtensionsTest.java
@@ -176,4 +176,39 @@ public class XMLSchemaTypeDefinitionExtensionsTest extends AbstractCacheBasedTes
 				ll(targetSchemaURI, r(18, 13, 18, 25), r(268, 23, 268, 37)));
 	}
 
+	@Test
+	public void xsiTypeWithNamespacePrefixTypeDefinition() throws BadLocationException, MalformedURIException {
+		String xmlFile = "src/test/resources/xsitype-ns.xml";
+		String targetSchemaURI = XMLEntityManager.expandSystemId("xsd/xsitype-ns.xsd", xmlFile, true);
+
+		String xml = "<root xmlns=\"http://example.com/test\"\r\n" + //
+				"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"      xmlns:tns=\"http://example.com/test\"\r\n" + //
+				"      xsi:schemaLocation=\"http://example.com/test xsd/xsitype-ns.xsd\">\r\n" + //
+				"  <item xsi:type=\"tns:DerivedType\" name=\"test\">\r\n" + //
+				"    <tns:derived|Prop></tns:derivedProp>\r\n" + //
+				"  </item>\r\n" + //
+				"</root>";
+		XMLLanguageService xmlLanguageService = new XMLLanguageService();
+		testTypeDefinitionFor(xmlLanguageService, xml, xmlFile,
+				ll(targetSchemaURI, r(5, 5, 5, 20), r(21, 37, 21, 50)));
+	}
+
+	@Test
+	public void xsiTypeWithDefaultNamespaceTypeDefinition() throws BadLocationException, MalformedURIException {
+		String xmlFile = "src/test/resources/xsitype-ns.xml";
+		String targetSchemaURI = XMLEntityManager.expandSystemId("xsd/xsitype-ns.xsd", xmlFile, true);
+
+		String xml = "<root xmlns=\"http://example.com/test\"\r\n" + //
+				"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"      xsi:schemaLocation=\"http://example.com/test xsd/xsitype-ns.xsd\">\r\n" + //
+				"  <item xsi:type=\"DerivedType\" name=\"test\">\r\n" + //
+				"    <derived|Prop></derivedProp>\r\n" + //
+				"  </item>\r\n" + //
+				"</root>";
+		XMLLanguageService xmlLanguageService = new XMLLanguageService();
+		testTypeDefinitionFor(xmlLanguageService, xml, xmlFile,
+				ll(targetSchemaURI, r(4, 5, 4, 16), r(21, 37, 21, 50)));
+	}
+
 }

--- a/org.eclipse.lemminx/src/test/resources/xsd/xsitype-ns.xsd
+++ b/org.eclipse.lemminx/src/test/resources/xsd/xsitype-ns.xsd
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://example.com/test"
+           xmlns:tns="http://example.com/test"
+           elementFormDefault="qualified">
+
+    <xs:complexType name="BaseType">
+        <xs:sequence>
+            <xs:element name="baseProp" type="xs:string" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>base property documentation</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="DerivedType">
+        <xs:complexContent>
+            <xs:extension base="tns:BaseType">
+                <xs:sequence>
+                    <xs:element name="derivedProp" type="xs:string" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>derived property documentation</xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attribute name="extra" type="xs:string"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:element name="root">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="item" type="tns:BaseType" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>


### PR DESCRIPTION
## Summary

Fixes https://github.com/redhat-developer/vscode-xml/issues/1126

When an XML Schema declares a `targetNamespace`, `xsi:type` polymorphism was not working for completion, hover, and type definition.

 * Given XSD

```xml
<?xml version="1.0" encoding="utf-8"?>
<xs:schema elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">

    <xs:element name="root">
        <xs:complexType>
            <xs:sequence maxOccurs="unbounded">
                <xs:element name="Character" type="Character" />
            </xs:sequence>
        </xs:complexType>
    </xs:element>

    <xs:complexType name="Character" abstract="true">
        <xs:attribute name="Name" type="xs:string" use="required" />
    </xs:complexType>

    <xs:complexType name="Teacher">
        <xs:complexContent>
            <xs:extension base="Character">
                <xs:sequence>
                    <xs:element name="Secret" type="xs:string" maxOccurs="unbounded" />
                </xs:sequence>
            </xs:extension>
        </xs:complexContent>
    </xs:complexType>

    <xs:complexType name="Student">
        <xs:complexContent>
            <xs:extension base="Character">
                <xs:sequence>
                    <xs:element name="School" type="xs:string" />
                </xs:sequence>
            </xs:extension>
        </xs:complexContent>
    </xs:complexType>
</xs:schema>
```

 * Given XML

```xml
<?xml version="1.0" encoding="utf-8" ?>
<root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="xsd/derivedType.xsd">

  <Character xsi:type="Teacher" Name="Remus">
    
  </Character>

  <Character xsi:type="Student" Name="Harry">
    
  </Character>
  
</root>
```

Here a demo:

<img width="939" height="525" alt="XSDDerivedTypeDemo" src="https://github.com/user-attachments/assets/3ab844ee-b947-4fc8-99ec-565084d03570" />
