### PR TITLE
Fix RelaxNG completion not respecting choice tag for attributes

### DIFF
--- a/org.eclipse.lemminx/src/main/java/com/thaiopensource/relaxng/pattern/CMRelaxNGAttributeDeclaration.java
+++ b/org.eclipse.lemminx/src/main/java/com/thaiopensource/relaxng/pattern/CMRelaxNGAttributeDeclaration.java
@@ -11,6 +11,7 @@
 *******************************************************************************/
 package com.thaiopensource.relaxng.pattern;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -47,10 +48,31 @@ public class CMRelaxNGAttributeDeclaration implements CMAttributeDeclaration {
 	private boolean required;
 	private List<String> values;
 
+	// Additional patterns from other <choice> branches that declare the same
+	// attribute name. Their enumeration values and documentation are merged with
+	// the primary pattern so that completion shows all possible values.
+	private List<AttributePattern> mergedPatterns;
+
 	public CMRelaxNGAttributeDeclaration(CMRelaxNGElementDeclaration element, AttributePattern pattern) {
 		this.cmElement = element;
 		this.pattern = pattern;
 		this.computedPrefix = false;
+	}
+
+	/**
+	 * Merges an additional {@link AttributePattern} from another {@code <choice>}
+	 * branch that declares the same attribute name. The merged pattern's
+	 * enumeration values and documentation will be included in
+	 * {@link #getEnumerationValues()} and
+	 * {@link #getAttributeValueDocumentation(String, ISharedSettingsRequest)}.
+	 *
+	 * @param p the attribute pattern to merge.
+	 */
+	void addMergedPattern(AttributePattern p) {
+		if (mergedPatterns == null) {
+			mergedPatterns = new ArrayList<>();
+		}
+		mergedPatterns.add(p);
 	}
 
 	@Override
@@ -102,6 +124,16 @@ public class CMRelaxNGAttributeDeclaration implements CMAttributeDeclaration {
 	public Collection<String> getEnumerationValues() {
 		if (values == null) {
 			values = new CMRelaxNGAttributeValuesCollector(pattern.getContent()).getValues();
+			// Collect enumeration values from merged <choice> branch patterns
+			if (mergedPatterns != null) {
+				for (AttributePattern mp : mergedPatterns) {
+					for (String v : new CMRelaxNGAttributeValuesCollector(mp.getContent()).getValues()) {
+						if (!values.contains(v)) {
+							values.add(v);
+						}
+					}
+				}
+			}
 		}
 		return values;
 	}
@@ -117,6 +149,15 @@ public class CMRelaxNGAttributeDeclaration implements CMAttributeDeclaration {
 			String documentation = cmElement.getCMDocument().getDocumentation(pattern.getLocator(), value);
 			if (documentation != null) {
 				return documentation;
+			}
+			// Check merged <choice> branch patterns for value-specific documentation
+			if (mergedPatterns != null) {
+				for (AttributePattern mp : mergedPatterns) {
+					documentation = cmElement.getCMDocument().getDocumentation(mp.getLocator(), value);
+					if (documentation != null) {
+						return documentation;
+					}
+				}
 			}
 		}
 		// There was no specific documentation for the value, so use the general

--- a/org.eclipse.lemminx/src/main/java/com/thaiopensource/relaxng/pattern/CMRelaxNGAttributeDeclarationCollector.java
+++ b/org.eclipse.lemminx/src/main/java/com/thaiopensource/relaxng/pattern/CMRelaxNGAttributeDeclarationCollector.java
@@ -13,6 +13,8 @@ package com.thaiopensource.relaxng.pattern;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.lemminx.extensions.contentmodel.model.CMAttributeDeclaration;
@@ -23,7 +25,7 @@ import com.thaiopensource.xml.util.Name;
 /**
  * RelaxNG class used to collect content model attributes for a given
  * {@link ElementPattern}.
- * 
+ *
  * <p>
  * NOTE : this class is hosted in 'com.thaiopensource.relaxng.pattern' because
  * {@link Pattern} implementation like {@link ElementPattern} are not public.
@@ -31,7 +33,7 @@ import com.thaiopensource.xml.util.Name;
  * move this class in 'org.eclipse.lemminx.extensions.relaxng.contentmodel'
  * package.
  * </p>
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -39,21 +41,26 @@ public class CMRelaxNGAttributeDeclarationCollector extends AbstractCMRelaxNGCol
 
 	private final CMRelaxNGElementDeclaration elementDeclaration;
 
+	// Use a map keyed by attribute name to deduplicate attributes that appear
+	// in multiple branches of a <choice>. When the same attribute name is found
+	// in different branches, their enumeration values are merged via
+	// CMRelaxNGAttributeDeclaration#addMergedPattern.
+	private final Map<Name, CMRelaxNGAttributeDeclaration> attributeMap;
+
 	private final Collection<CMAttributeDeclaration> attributes;
 
 	public CMRelaxNGAttributeDeclarationCollector(CMRelaxNGElementDeclaration elementDeclaration, Pattern pattern) {
 		this.elementDeclaration = elementDeclaration;
-		this.attributes = new ArrayList<>();
+		this.attributeMap = new LinkedHashMap<>();
 		pattern.apply(this);
+		this.attributes = new ArrayList<>(attributeMap.values());
 		if (!attributes.isEmpty()) {
 			RequiredAttributesFunction attributesFunction = new RequiredAttributesFunction();
 			Set<Name> requiredAttributeNames = pattern.apply(attributesFunction);
 			for (Name requiredAttributeName : requiredAttributeNames) {
-				for (CMAttributeDeclaration attribute : attributes) {
-					CMRelaxNGAttributeDeclaration rngAttribute = (CMRelaxNGAttributeDeclaration) attribute;
-					if (requiredAttributeName.equals(rngAttribute.getJingName())) {
-						rngAttribute.setRequired(true);
-					}
+				CMRelaxNGAttributeDeclaration rngAttribute = attributeMap.get(requiredAttributeName);
+				if (rngAttribute != null) {
+					rngAttribute.setRequired(true);
 				}
 			}
 		}
@@ -63,9 +70,16 @@ public class CMRelaxNGAttributeDeclarationCollector extends AbstractCMRelaxNGCol
 	public VoidValue caseAttribute(AttributePattern p) {
 		NameClass nameClass = p.getNameClass();
 		if (nameClass instanceof SimpleNameClass) {
-			CMRelaxNGAttributeDeclaration attributeDeclaration = new CMRelaxNGAttributeDeclaration(elementDeclaration,
-					p);
-			attributes.add(attributeDeclaration);
+			Name name = ((SimpleNameClass) nameClass).getName();
+			CMRelaxNGAttributeDeclaration existing = attributeMap.get(name);
+			if (existing != null) {
+				// Same attribute name from another <choice> branch: merge its values
+				existing.addMergedPattern(p);
+			} else {
+				CMRelaxNGAttributeDeclaration attributeDeclaration = new CMRelaxNGAttributeDeclaration(
+						elementDeclaration, p);
+				attributeMap.put(name, attributeDeclaration);
+			}
 		}
 		return VoidValue.VOID;
 	}

--- a/org.eclipse.lemminx/src/main/java/com/thaiopensource/relaxng/pattern/CMRelaxNGElementDeclaration.java
+++ b/org.eclipse.lemminx/src/main/java/com/thaiopensource/relaxng/pattern/CMRelaxNGElementDeclaration.java
@@ -126,6 +126,46 @@ public class CMRelaxNGElementDeclaration implements CMElementDeclaration {
 		return attributes;
 	}
 
+	/**
+	 * Returns the possible attributes for the given parent element, using
+	 * {@link PatternMatcher} to narrow down the valid attributes based on
+	 * already-specified attributes. This respects {@code <choice>} groups:
+	 * e.g. if {@code Type="Bar"} is already set, only attributes from the
+	 * matching choice branch are returned.
+	 */
+	@Override
+	public Collection<CMAttributeDeclaration> getPossibleAttributes(DOMElement parentElement) {
+		if (parentElement == null || !parentElement.hasAttributes()) {
+			return getAttributes();
+		}
+		// Use the same PatternMatcher approach as getPossibleElements(),
+		// but for attributes: simulate the start tag and feed existing
+		// attributes to narrow the matcher's state.
+		PatternMatcher matcher = new PatternMatcher(pattern, new ValidatorPatternBuilder(new SchemaPatternBuilder()));
+		matcher.matchStartDocument();
+		Context context = new Context();
+		Name n = createName(parentElement);
+		matcher.matchStartTagOpen(n, n.getLocalName(), context);
+		// Feed already-specified attributes so the matcher selects the
+		// matching <choice> branch
+		for (DOMAttr attr : parentElement.attributes()) {
+			Name a = createName(attr);
+			matcher.matchAttributeName(a, a.getLocalName(), context);
+			matcher.matchAttributeValue(attr.getValue(), a, a.getLocalName(), context);
+		}
+		// Ask the matcher which attributes are still valid
+		com.thaiopensource.relaxng.match.NameClass nc = matcher.possibleAttributeNames();
+		Set<Name> allowed = nc.getIncludedNames();
+		List<CMAttributeDeclaration> possibleAttributes = new ArrayList<>();
+		for (Name name : allowed) {
+			CMAttributeDeclaration possible = findCMAttribute(name.getLocalName(), name.getNamespaceUri());
+			if (possible != null) {
+				possibleAttributes.add(possible);
+			}
+		}
+		return possibleAttributes;
+	}
+
 	@Override
 	public Collection<CMElementDeclaration> getElements() {
 		if (elements == null) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/model/CMElementDeclaration.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/model/CMElementDeclaration.java
@@ -66,10 +66,22 @@ public interface CMElementDeclaration {
 
 	/**
 	 * Returns the attributes of this declared element.
-	 * 
+	 *
 	 * @return the attributes element of this declared element.
 	 */
 	Collection<CMAttributeDeclaration> getAttributes();
+
+	/**
+	 * Returns the possible attributes for the given parent element, taking into
+	 * account already-specified attributes to narrow choices (e.g. in RelaxNG
+	 * choice groups).
+	 *
+	 * @param parentElement the DOM element being edited.
+	 * @return the possible attribute declarations.
+	 */
+	default Collection<CMAttributeDeclaration> getPossibleAttributes(DOMElement parentElement) {
+		return getAttributes();
+	}
 
 	/**
 	 * Returns the children declared element of this declared element.

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/ContentModelCompletionParticipant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/ContentModelCompletionParticipant.java
@@ -306,7 +306,7 @@ public class ContentModelCompletionParticipant extends CompletionParticipantAdap
 		if (parentElement == null) {
 			return;
 		}
-		Collection<CMAttributeDeclaration> attributes = elementDeclaration.getAttributes();
+		Collection<CMAttributeDeclaration> attributes = elementDeclaration.getPossibleAttributes(parentElement);
 		if (attributes == null) {
 			return;
 		}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/relaxng/xml/completion/XMLCompletionBasedOnRelaxNGTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/relaxng/xml/completion/XMLCompletionBasedOnRelaxNGTest.java
@@ -26,7 +26,10 @@ import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.extensions.contentmodel.BaseFileTempTest;
 import org.eclipse.lemminx.services.XMLLanguageService;
+import org.eclipse.lemminx.settings.SharedSettings;
+import org.eclipse.lsp4j.CompletionCapabilities;
 import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionItemCapabilities;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -237,12 +240,109 @@ public class XMLCompletionBasedOnRelaxNGTest extends BaseFileTempTest {
 				c("noupdate", te(1, 6, 1, 6, "noupdate=\"\""), "noupdate"));
 	}
 
+	// Tests for https://github.com/redhat-developer/vscode-xml/issues/1107
+
+	@Test
+	public void completionOnElementWithChoiceAttributeGroup() throws BadLocationException {
+		String xml = "<?xml-model href=\"choiceAttributeGroup.rng\" ?>\r\n" + //
+				"<root>\r\n" + //
+				"  <|\r\n" + //
+				"</root>";
+		// Without snippet
+		testCompletionFor(xml, //
+				null, //
+				c("key", te(2, 2, 2, 3, "<key name=\"\" type=\"\"></key>"), "<key"));
+		// With snippet
+		testCompletionSnippetSupportFor(xml, //
+				null, //
+				c("key", te(2, 2, 2, 3, "<key name=\"$1\" type=\"${2|dict,arr,str|}\">$3</key>$0"), "<key"));
+	}
+
+	@Test
+	public void completionOnAttributeNameWithChoiceAttributeGroup() throws BadLocationException {
+		String xml = "<?xml-model href=\"choiceAttributeGroup.rng\" ?>\r\n" + //
+				"<root>\r\n" + //
+				"  <key name=\"foo\" |></key>\r\n" + //
+				"</root>";
+		// Without snippet
+		testCompletionFor(xml, //
+				1, //
+				c("type", te(2, 18, 2, 18, "type=\"\""), "type"));
+		// With snippet
+		testCompletionSnippetSupportFor(xml, //
+				1, //
+				c("type", te(2, 18, 2, 18, "type=\"${1|dict,arr,str|}\"$0"), "type"));
+	}
+
+	@Test
+	public void completionOnAttributeValueWithChoiceAttributeGroup() throws BadLocationException {
+		String xml = "<?xml-model href=\"choiceAttributeGroup.rng\" ?>\r\n" + //
+				"<root>\r\n" + //
+				"  <key name=\"foo\" type=\"|\" />\r\n" + //
+				"</root>";
+		testCompletionFor(xml, //
+				3, //
+				c("dict", te(2, 24, 2, 24, "dict"), "dict"), //
+				c("arr", te(2, 24, 2, 24, "arr"), "arr"), //
+				c("str", te(2, 24, 2, 24, "str"), "str"));
+	}
+
+	@Test
+	public void completionOnAttributeNameWithChoiceAttributeGroupDistinct() throws BadLocationException {
+		// When Type="Bar" is set, only BarAttr should be offered (not FooAttr)
+		String xml = "<?xml-model href=\"choiceAttributeGroupDistinct.rng\" ?>\r\n" + //
+				"<Items>\r\n" + //
+				"  <Item Type=\"Bar\" |></Item>\r\n" + //
+				"</Items>";
+		testCompletionFor(xml, //
+				1, //
+				c("BarAttr", te(2, 19, 2, 19, "BarAttr=\"\""), "BarAttr"));
+	}
+
+	@Test
+	public void completionOnAttributeNameWithChoiceAttributeGroupDistinctFoo() throws BadLocationException {
+		// When Type="Foo" is set, only FooAttr should be offered (not BarAttr)
+		String xml = "<?xml-model href=\"choiceAttributeGroupDistinct.rng\" ?>\r\n" + //
+				"<Items>\r\n" + //
+				"  <Item Type=\"Foo\" |></Item>\r\n" + //
+				"</Items>";
+		testCompletionFor(xml, //
+				1, //
+				c("FooAttr", te(2, 19, 2, 19, "FooAttr=\"\""), "FooAttr"));
+	}
+
+	@Test
+	public void completionOnAttributeNameWithChoiceAttributeGroupDistinctNoContext() throws BadLocationException {
+		// When no attributes are set, all attributes should be offered
+		String xml = "<?xml-model href=\"choiceAttributeGroupDistinct.rng\" ?>\r\n" + //
+				"<Items>\r\n" + //
+				"  <Item |></Item>\r\n" + //
+				"</Items>";
+		testCompletionFor(xml, //
+				3, //
+				c("Type", te(2, 8, 2, 8, "Type=\"\""), "Type"), //
+				c("FooAttr", te(2, 8, 2, 8, "FooAttr=\"\""), "FooAttr"), //
+				c("BarAttr", te(2, 8, 2, 8, "BarAttr=\"\""), "BarAttr"));
+	}
+
 	// role,xml:id,version,xml:lang,xml:base,remap,xreflabel,revisionflag,dir,arch,audience,condition,conformance,os,revision,security,userlevel,vendor,wordsize,annotations,linkend,xlink:href,xlink:type,xlink:role,xlink:arcrole,xlink:title,xlink:show,xlink:actuate,label,status
 
 	private static void testCompletionFor(String value, Integer expectedCount, CompletionItem... expectedItems)
 			throws BadLocationException {
 		XMLAssert.testCompletionFor(new XMLLanguageService(), value, null, null, "src/test/resources/relaxng/test.xml",
 				expectedCount, true, expectedItems);
+	}
+
+	private static void testCompletionSnippetSupportFor(String value, Integer expectedCount,
+			CompletionItem... expectedItems) throws BadLocationException {
+		CompletionCapabilities completionCapabilities = new CompletionCapabilities();
+		CompletionItemCapabilities completionItem = new CompletionItemCapabilities(true);
+		completionCapabilities.setCompletionItem(completionItem);
+
+		SharedSettings sharedSettings = new SharedSettings();
+		sharedSettings.getCompletionSettings().setCapabilities(completionCapabilities);
+		XMLAssert.testCompletionFor(new XMLLanguageService(), value, null, null, "src/test/resources/relaxng/test.xml",
+				expectedCount, sharedSettings, expectedItems);
 	}
 
 }

--- a/org.eclipse.lemminx/src/test/resources/relaxng/choiceAttributeGroup.rng
+++ b/org.eclipse.lemminx/src/test/resources/relaxng/choiceAttributeGroup.rng
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+    <start>
+        <ref name="root"/>
+    </start>
+
+    <define name="keyname.type">
+        <data type="string"/>
+    </define>
+
+    <define name="root">
+        <element name="root">
+            <zeroOrMore>
+                <ref name="key.element"/>
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="key.element">
+        <element name="key">
+            <attribute name="name">
+                <ref name="keyname.type"/>
+            </attribute>
+            <ref name="structured.content"/>
+        </element>
+    </define>
+
+    <define name="structured.content">
+        <choice>
+            <group>
+                <attribute name="type">
+                    <value>dict</value>
+                </attribute>
+                <zeroOrMore>
+                    <element name="key">
+                        <attribute name="name">
+                            <ref name="keyname.type"/>
+                        </attribute>
+                        <ref name="structured.content"/>
+                    </element>
+                </zeroOrMore>
+            </group>
+            <group>
+                <attribute name="type">
+                    <value>arr</value>
+                </attribute>
+                <zeroOrMore>
+                    <element name="item">
+                        <ref name="structured.content"/>
+                    </element>
+                </zeroOrMore>
+            </group>
+            <group>
+                <attribute name="type">
+                    <value>str</value>
+                </attribute>
+                <data type="string"/>
+            </group>
+        </choice>
+    </define>
+</grammar>

--- a/org.eclipse.lemminx/src/test/resources/relaxng/choiceAttributeGroupDistinct.rng
+++ b/org.eclipse.lemminx/src/test/resources/relaxng/choiceAttributeGroupDistinct.rng
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+    <start>
+        <element name="Items">
+            <zeroOrMore>
+                <element name="Item">
+                    <choice>
+                        <group>
+                            <attribute name="Type">
+                                <value>Foo</value>
+                            </attribute>
+                            <attribute name="FooAttr">
+                                <data type="string"/>
+                            </attribute>
+                        </group>
+                        <group>
+                            <attribute name="Type">
+                                <value>Bar</value>
+                            </attribute>
+                            <attribute name="BarAttr">
+                                <data type="string"/>
+                            </attribute>
+                        </group>
+                    </choice>
+                </element>
+            </zeroOrMore>
+        </element>
+    </start>
+</grammar>


### PR DESCRIPTION
When a RelaxNG schema uses <choice> with multiple <group> elements that define the same attribute name (e.g. "type") with different values, the completion engine was generating duplicate attributes like type="dict" type="arr" type="str" instead of a single type="".

Additionally, when an attribute value was already specified (e.g. Type="Bar"), the completion was still offering attributes from all choice branches instead of only the matching branch.

Changes:
- Deduplicate attributes by name in CMRelaxNGAttributeDeclarationCollector, merging enumeration values from all choice branches
- Add context-aware attribute completion using PatternMatcher to filter attributes based on already-specified attributes
- Add getPossibleAttributes(DOMElement) to CMElementDeclaration interface

Fixes https://github.com/redhat-developer/vscode-xml/issues/1107 Fixes https://github.com/redhat-developer/vscode-xml/issues/1022

 * Given RNG `merge-attribute.rng` :

```xml
<grammar xmlns="http://relaxng.org/ns/structure/1.0">
  <start>
    <element name="Items">
      <element name="Item">
        <choice>
          <group>
            <attribute name="Type"><value>Foo</value></attribute>
            <attribute name="FooAttr"/>
          </group>
          <group>
            <attribute name="Type"><value>Bar</value></attribute>
            <attribute name="BarAttr"/>
          </group>
        </choice>
      </element>
    </element>
  </start>
</grammar>
```

 * Given XML:

```xml
<?xml-model href="merge-attribute.rng"?>
<Items>

</Items>
```

Here a demo:

<img width="939" height="525" alt="RNGMergeAttrDemo" src="https://github.com/user-attachments/assets/8c495864-1473-4088-a052-19bfc2f19225" />

