### PR TITLE
Fix/relaxng required attribute codeaction

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/cvc_complex_type_4CodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/cvc_complex_type_4CodeAction.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.eclipse.lemminx.commons.CodeActionFactory;
+import org.eclipse.lemminx.dom.DOMAttr;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.dom.DOMElement;
 import org.eclipse.lemminx.dom.DOMNode;
@@ -29,6 +30,7 @@ import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionRequest;
 import org.eclipse.lemminx.settings.SharedSettings;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 
@@ -75,15 +77,34 @@ public class cvc_complex_type_4CodeAction implements ICodeActionParticipant {
 					XMLGenerator generator = new XMLGenerator(sharedSettings, "", "", supportSnippet, 0);
 					String xmlAttributes = generator.generate(requiredAttributes, element.getTagName());
 
-					// Insert required attributes
+					// Insert after the last existing attribute (if any),
+					// otherwise after the tag name.
+					Position insertPosition = getInsertAttrPosition(element, document, diagnosticRange);
 					CodeAction insertRequiredAttributesAction = CodeActionFactory.insert("Insert required attributes",
-							diagnosticRange.getEnd(), xmlAttributes, document.getTextDocument(), diagnostic);
+							insertPosition, xmlAttributes, document.getTextDocument(), diagnostic);
 					codeActions.add(insertRequiredAttributesAction);
 				}
 			}
 		} catch (Exception e) {
 			// Do nothing
 		}
+	}
+
+	private static Position getInsertAttrPosition(DOMElement element, DOMDocument document, Range diagnosticRange) {
+		if (element.hasAttributes()) {
+			DOMAttr lastAttr = null;
+			for (DOMAttr attr : element.attributes()) {
+				lastAttr = attr;
+			}
+			if (lastAttr != null) {
+				try {
+					return document.positionAt(lastAttr.getEnd());
+				} catch (Exception e) {
+					// Fall through to default
+				}
+			}
+		}
+		return diagnosticRange.getEnd();
 	}
 
 	private boolean codeAlreadyActionExists(List<CodeAction> codeActions, Diagnostic diagnostic) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/required_attribute_missingCodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/required_attribute_missingCodeAction.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2026 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Red Hat Inc. - initial API and implementation
+ */
+package org.eclipse.lemminx.extensions.contentmodel.participants.codeactions;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.lemminx.commons.CodeActionFactory;
+import org.eclipse.lemminx.dom.DOMAttr;
+import org.eclipse.lemminx.dom.DOMDocument;
+import org.eclipse.lemminx.dom.DOMElement;
+import org.eclipse.lemminx.dom.DOMNode;
+import org.eclipse.lemminx.extensions.contentmodel.model.CMAttributeDeclaration;
+import org.eclipse.lemminx.extensions.contentmodel.model.CMDocument;
+import org.eclipse.lemminx.extensions.contentmodel.model.CMElementDeclaration;
+import org.eclipse.lemminx.extensions.contentmodel.model.ContentModelManager;
+import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionParticipant;
+import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionRequest;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+
+/**
+ * Code action to fix RelaxNG required_attribute_missing,
+ * required_attributes_missing, and required_attributes_missing_expected errors.
+ *
+ * <p>
+ * Inserts missing required attributes on the element. First tries globally
+ * required attributes (required in all {@code <choice>} branches). If all
+ * globally required attributes are already present, falls back to
+ * context-aware lookup via {@code getPossibleAttributes(element)} which
+ * narrows to the matching choice branch based on existing attribute values.
+ * </p>
+ */
+public class required_attribute_missingCodeAction implements ICodeActionParticipant {
+
+	@Override
+	public void doCodeAction(ICodeActionRequest request, List<CodeAction> codeActions, CancelChecker cancelChecker) {
+		Diagnostic diagnostic = request.getDiagnostic();
+		DOMDocument document = request.getDocument();
+		Range range = request.getRange();
+		if (diagnostic == null) {
+			return;
+		}
+
+		Range diagnosticRange = diagnostic.getRange();
+		try {
+			int offset = document.offsetAt(range.getStart());
+			DOMNode node = document.findNodeAt(offset);
+			if (!node.isElement()) {
+				return;
+			}
+			DOMElement element = (DOMElement) node;
+			ContentModelManager contentModelManager = request.getComponent(ContentModelManager.class);
+			for (CMDocument cmDocument : contentModelManager.findCMDocument(element)) {
+				CMElementDeclaration elementDeclaration = cmDocument.findCMElement(element);
+				if (elementDeclaration != null) {
+					// First try globally required attributes (required in all choice branches)
+					List<CMAttributeDeclaration> requiredAttributes = elementDeclaration.getAttributes().stream()
+							.filter(CMAttributeDeclaration::isRequired)
+							.filter(cmAttr -> !element.hasAttribute(cmAttr.getLocalName()))
+							.collect(Collectors.toList());
+
+					if (requiredAttributes.isEmpty()) {
+						// All globally required attributes are present, but the validator
+						// still reports a missing attribute. This happens with <choice>
+						// groups: e.g. Type="Bar" selects the Bar branch, making BarAttr
+						// required in context. Fall back to context-aware lookup.
+						Collection<CMAttributeDeclaration> possibleAttributes = elementDeclaration
+								.getPossibleAttributes(element);
+						requiredAttributes = possibleAttributes.stream()
+								.filter(cmAttr -> !element.hasAttribute(cmAttr.getLocalName()))
+								.collect(Collectors.toList());
+					}
+
+					if (requiredAttributes.isEmpty()) {
+						return;
+					}
+
+					// Build the attribute insertion text. XMLGenerator.generate()
+					// filters by isRequired() internally, which drops context-aware
+					// attributes from choice branches. Build the text directly.
+					StringBuilder xmlAttributes = new StringBuilder();
+					for (CMAttributeDeclaration attr : requiredAttributes) {
+						xmlAttributes.append(' ');
+						xmlAttributes.append(attr.getLocalName());
+						xmlAttributes.append("=\"\"");
+					}
+
+					// Insert after the last existing attribute (if any),
+					// otherwise after the tag name.
+					Position insertPosition = getInsertAttrPosition(element, document, diagnosticRange);
+
+					CodeAction insertRequiredAttributesAction = CodeActionFactory.insert(
+							"Insert required attributes",
+							insertPosition, xmlAttributes.toString(), document.getTextDocument(), diagnostic);
+					codeActions.add(insertRequiredAttributesAction);
+				}
+			}
+		} catch (Exception e) {
+			// Do nothing
+		}
+	}
+
+	/**
+	 * Returns the position where new attributes should be inserted: after the
+	 * last existing attribute's closing quote, or after the tag name if no
+	 * attributes exist.
+	 */
+	private static Position getInsertAttrPosition(DOMElement element, DOMDocument document, Range diagnosticRange) {
+		if (element.hasAttributes()) {
+			DOMAttr lastAttr = null;
+			for (DOMAttr attr : element.attributes()) {
+				lastAttr = attr;
+			}
+			if (lastAttr != null) {
+				try {
+					return document.positionAt(lastAttr.getEnd());
+				} catch (Exception e) {
+					// Fall through to default
+				}
+			}
+		}
+		return diagnosticRange.getEnd();
+	}
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/relaxng/xml/validator/RelaxNGErrorCode.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/relaxng/xml/validator/RelaxNGErrorCode.java
@@ -23,6 +23,7 @@ import org.eclipse.lemminx.dom.DOMRange;
 import org.eclipse.lemminx.dom.DOMText;
 import org.eclipse.lemminx.extensions.contentmodel.participants.XMLModelUtils;
 import org.eclipse.lemminx.extensions.contentmodel.participants.codeactions.missingelement.required_element_missingCodeAction;
+import org.eclipse.lemminx.extensions.contentmodel.participants.codeactions.required_attribute_missingCodeAction;
 import org.eclipse.lemminx.extensions.contentmodel.participants.codeactions.missingelement.required_elements_missing_expectedCodeAction;
 import org.eclipse.lemminx.extensions.relaxng.utils.RelaxNGUtils;
 import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionParticipant;
@@ -238,6 +239,10 @@ public enum RelaxNGErrorCode implements IXMLErrorCode {
 			SharedSettings sharedSettings) {
 		codeActions.put(incomplete_element_required_element_missing.getCode(), new required_element_missingCodeAction());
 		codeActions.put(incomplete_element_required_elements_missing_expected.getCode(), new required_elements_missing_expectedCodeAction());
+		required_attribute_missingCodeAction requiredAttrCodeAction = new required_attribute_missingCodeAction();
+		codeActions.put(required_attribute_missing.getCode(), requiredAttrCodeAction);
+		codeActions.put(required_attributes_missing.getCode(), requiredAttrCodeAction);
+		codeActions.put(required_attributes_missing_expected.getCode(), requiredAttrCodeAction);
 	}
 
 	private static DOMAttr findRefByName(DOMNode parent, String refName) {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaDiagnosticsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaDiagnosticsTest.java
@@ -121,6 +121,27 @@ public class XMLSchemaDiagnosticsTest extends AbstractCacheBasedTest {
 	}
 
 	@Test
+	public void cvc_type_4_With_existing_attribute() throws Exception {
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + //
+				"<invoice xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				" xsi:noNamespaceSchemaLocation=\"src/test/resources/xsd/invoice.xsd\">\r\n" + //
+				"  <date>2017-11-30</date>\r\n" + //
+				"  <number>2</number>\r\n" + //
+				"  <products>\r\n" + //
+				"  	<product description=\"test\" />\r\n" + // <- error: missing 'price'
+				"  </products>\r\n" + //
+				"  <payments>\r\n" + //
+				"  	<payment amount=\"1\" method=\"credit\"/>\r\n" + //
+				"  </payments>\r\n" + //
+				"</invoice>";
+		Diagnostic d = d(6, 4, 6, 11, XMLSchemaErrorCode.cvc_complex_type_4,
+				"Attribute 'price' is missing from element 'product'.\n\nCode:");
+		testDiagnosticsFor(xml, d);
+		// Insert after the last existing attribute (description="test"), not after the tag name
+		testCodeActionsFor(xml, d, ca(d, te(6, 30, 6, 30, " price=\"\"")));
+	}
+
+	@Test
 	public void cvc_complex_type_2_4_a() throws Exception {
 		String xml = "<project xmlns=\"http://maven.apache.org/POM/4.0.0\"\r\n" + //
 				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/relaxng/xml/codeaction/MissingAttributeCodeActionTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/relaxng/xml/codeaction/MissingAttributeCodeActionTest.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.relaxng.xml.codeaction;
+
+import static org.eclipse.lemminx.XMLAssert.ca;
+import static org.eclipse.lemminx.XMLAssert.d;
+import static org.eclipse.lemminx.XMLAssert.te;
+import static org.eclipse.lemminx.XMLAssert.testCodeActionsFor;
+import static org.eclipse.lemminx.XMLAssert.testDiagnosticsFor;
+
+import org.eclipse.lemminx.AbstractCacheBasedTest;
+import org.eclipse.lemminx.extensions.relaxng.xml.validator.RelaxNGErrorCode;
+import org.eclipse.lsp4j.Diagnostic;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for code action to insert missing required attributes for RelaxNG.
+ */
+public class MissingAttributeCodeActionTest extends AbstractCacheBasedTest {
+
+	@Test
+	public void required_attribute_missing() throws Exception {
+		// <key> is missing both required attributes "name" and "type"
+		String xml = "<?xml-model href=\"src/test/resources/relaxng/choiceAttributeGroup.rng\" ?>\r\n" + //
+				"<root>\r\n" + //
+				"  <key></key>\r\n" + //
+				"</root>";
+		Diagnostic d = d(2, 3, 2, 6, RelaxNGErrorCode.required_attributes_missing);
+		testDiagnosticsFor(xml, d);
+		testCodeActionsFor(xml, d,
+				ca(d, te(2, 6, 2, 6, " name=\"\" type=\"\"")));
+	}
+
+	@Test
+	public void required_attribute_missing_with_existing() throws Exception {
+		// <key> has "name" but is missing "type"
+		String xml = "<?xml-model href=\"src/test/resources/relaxng/choiceAttributeGroup.rng\" ?>\r\n" + //
+				"<root>\r\n" + //
+				"  <key name=\"foo\"></key>\r\n" + //
+				"</root>";
+		Diagnostic d = d(2, 3, 2, 6, RelaxNGErrorCode.required_attribute_missing);
+		testDiagnosticsFor(xml, d);
+		testCodeActionsFor(xml, d,
+				ca(d, te(2, 17, 2, 17, " type=\"\"")));
+	}
+
+	@Test
+	public void required_attribute_missing_choice_branch() throws Exception {
+		// <Item Type="Bar"> selects the Bar branch, making BarAttr required in context
+		String xml = "<?xml-model href=\"src/test/resources/relaxng/choiceAttributeGroupDistinct.rng\" ?>\r\n" + //
+				"<Items>\r\n" + //
+				"  <Item Type=\"Bar\"></Item>\r\n" + //
+				"</Items>";
+		Diagnostic d = d(2, 3, 2, 7, RelaxNGErrorCode.required_attribute_missing);
+		testDiagnosticsFor(xml, d);
+		testCodeActionsFor(xml, d,
+				ca(d, te(2, 18, 2, 18, " BarAttr=\"\"")));
+	}
+
+	@Test
+	public void required_attribute_missing_TEI_tagUsage() throws Exception {
+		// TEI <tagUsage> is missing required attribute "gi"
+		String xml = "<?xml-model href=\"src/test/resources/relaxng/tei_all.rng\" ?>\r\n" + //
+				"<TEI xmlns=\"http://www.tei-c.org/ns/1.0\">\r\n" + //
+				"	<teiHeader>\r\n" + //
+				"		<fileDesc>\r\n" + //
+				"			<titleStmt>\r\n" + //
+				"				<title></title>\r\n" + //
+				"			</titleStmt>\r\n" + //
+				"			<publicationStmt>\r\n" + //
+				"				<ab></ab>\r\n" + //
+				"			</publicationStmt>\r\n" + //
+				"			<sourceDesc>\r\n" + //
+				"				<ab></ab>\r\n" + //
+				"			</sourceDesc>\r\n" + //
+				"		</fileDesc>\r\n" + //
+				"		<encodingDesc>\r\n" + //
+				"			<tagsDecl>\r\n" + //
+				"				<namespace name=\"http://www.tei-c.org/ns/1.0\">\r\n" + //
+				"					<tagUsage></tagUsage>\r\n" + //
+				"				</namespace>\r\n" + //
+				"			</tagsDecl>\r\n" + //
+				"		</encodingDesc>\r\n" + //
+				"	</teiHeader>\r\n" + //
+				"	<text>\r\n" + //
+				"		<body>\r\n" + //
+				"			<div></div>\r\n" + //
+				"		</body>\r\n" + //
+				"	</text>\r\n" + //
+				"</TEI>";
+		Diagnostic d = d(17, 6, 17, 14, RelaxNGErrorCode.required_attribute_missing);
+		testDiagnosticsFor(xml, d);
+		testCodeActionsFor(xml, d,
+				ca(d, te(17, 14, 17, 14, " gi=\"\"")));
+	}
+}


### PR DESCRIPTION
When a RelaxNG schema reports required_attribute_missing, required_attributes_missing, or required_attributes_missing_expected errors, a code action is now available to automatically insert all missing required attributes on the element.

The code action inspects the content model to find required attributes not yet present on the element, and generates an insert edit with empty attribute values at the end of the tag name.

Registered for RelaxNG error codes in RelaxNGErrorCode via the existing ICodeActionParticipant pattern.

Fixes https://github.com/eclipse-lemminx/lemminx/issues/1419

Here a demo:

<img width="939" height="525" alt="MissingAttrCodeAction3" src="https://github.com/user-attachments/assets/09aa224b-aaa2-4562-bbba-322c702b9f8d" />


