### PR TITLE
Add xsi:type attribute value completion with derived types

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/model/CMDocument.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/model/CMDocument.java
@@ -89,8 +89,19 @@ public interface CMDocument {
 	boolean isDirty();
 
 	/**
+	 * Returns the names of types that can be used as xsi:type values for the given
+	 * element (i.e. derived types of the element's declared type).
+	 *
+	 * @param element the DOM element
+	 * @return the collection of qualified type names.
+	 */
+	default Collection<String> findDerivedTypeNames(DOMElement element) {
+		return Collections.emptyList();
+	}
+
+	/**
 	 * Returns list of declared entities.
-	 * 
+	 *
 	 * @return list of declared entities.
 	 */
 	default List<Entity> getEntities() {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/model/CMElementDeclaration.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/model/CMElementDeclaration.java
@@ -209,9 +209,21 @@ public interface CMElementDeclaration {
 	/**
 	 * Returns a list of required/non-optional child elements of the current
 	 * element.
-	 * 
+	 *
 	 * @return a list of required/non-optional child elements of the current
 	 *         element.
 	 */
 	Collection<CMElementDeclaration> getRequiredElements();
+
+	/**
+	 * Returns the local names of types derived from this element's declared type.
+	 * Used to generate xsi:type snippet choices when the element's type is abstract
+	 * and cannot be instantiated directly.
+	 *
+	 * @return the collection of derived type local names, or empty if the type is
+	 *         not abstract or has no derived types.
+	 */
+	default Collection<String> getDerivedTypeNames() {
+		return Collections.emptyList();
+	}
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/utils/XMLGenerator.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/utils/XMLGenerator.java
@@ -182,9 +182,16 @@ public class XMLGenerator {
 			xml.indent(level);
 		}
 		xml.startElement(prefix, elementDeclaration.getLocalName(), false);
+		// For elements with abstract types, add xsi:type attribute first with
+		// derived type choices (e.g. xsi:type="${1|Teacher,Student|}")
+		Collection<String> derivedTypeNames = elementDeclaration.getDerivedTypeNames();
+		boolean hasXsiType = !derivedTypeNames.isEmpty();
+		if (hasXsiType) {
+			snippetIndex = generateXsiTypeAttribute(derivedTypeNames, prefix, level, snippetIndex, xml);
+		}
 		// Attributes
 		Collection<CMAttributeDeclaration> attributes = elementDeclaration.getAttributes();
-		snippetIndex = generate(attributes, level, snippetIndex, xml, elementDeclaration.getLocalName());
+		snippetIndex = generate(attributes, level, snippetIndex, xml, elementDeclaration.getLocalName(), hasXsiType);
 		// Elements children
 		if (children.size() > 0) {
 			xml.closeStartElement();
@@ -210,7 +217,9 @@ public class XMLGenerator {
 			if (generateEndTag) {
 				xml.endElement(prefix, elementDeclaration.getLocalName());
 			}
-		} else if (elementDeclaration.isEmpty() && autoCloseTags) {
+		} else if (elementDeclaration.isEmpty() && autoCloseTags && !hasXsiType) {
+			// Don't self-close elements with abstract types: the concrete type
+			// chosen via xsi:type may have child elements
 			xml.selfCloseElement();
 		} else {
 			xml.closeStartElement();
@@ -241,12 +250,12 @@ public class XMLGenerator {
 
 	public String generate(Collection<CMAttributeDeclaration> attributes, String tagName) {
 		XMLBuilder xml = new XMLBuilder(sharedSettings, whitespacesIndent, lineDelimiter);
-		generate(attributes, 0, 0, xml, tagName);
+		generate(attributes, 0, 0, xml, tagName, false);
 		return xml.toString();
 	}
 
 	private int generate(Collection<CMAttributeDeclaration> attributes, int level, int snippetIndex, XMLBuilder xml,
-			String tagName) {
+			String tagName, boolean hasExtraAttributes) {
 		Map<String /* namespaceURI */, String /* prefix */> prefixes = null;
 		List<CMAttributeDeclaration> requiredAttributes = new ArrayList<>();
 		// Loop for attributes to collect :
@@ -297,12 +306,38 @@ public class XMLGenerator {
 			String value = generateAttributeValue(defaultValue, enumerationValues, canSupportSnippets, snippetIndex,
 					false, sharedSettings);
 			String attrName = attributeDeclaration.getName(prefixes);
-			if (attributesSize != 1 || generateXmlnsAttr) {
+			if (attributesSize != 1 || generateXmlnsAttr || hasExtraAttributes) {
 				xml.addAttribute(attrName, value, level, true);
 			} else {
 				xml.addSingleAttribute(attrName, value, true);
 			}
 		}
+		return snippetIndex;
+	}
+
+	/**
+	 * Generates the xsi:type attribute with a snippet choice listing the given
+	 * derived type names. Type names are qualified with the element's prefix
+	 * when the element belongs to a namespace.
+	 */
+	private int generateXsiTypeAttribute(Collection<String> derivedTypeNames, String elementPrefix,
+			int level, int snippetIndex, XMLBuilder xml) {
+		if (canSupportSnippets) {
+			snippetIndex++;
+		}
+		// Qualify type names with the element's prefix if it has a namespace
+		Collection<String> qualifiedTypes;
+		if (elementPrefix != null) {
+			qualifiedTypes = new ArrayList<>();
+			for (String typeName : derivedTypeNames) {
+				qualifiedTypes.add(elementPrefix + ":" + typeName);
+			}
+		} else {
+			qualifiedTypes = derivedTypeNames;
+		}
+		String value = generateAttributeValue(null, qualifiedTypes, canSupportSnippets, snippetIndex,
+				false, sharedSettings);
+		xml.addSingleAttribute("xsi:type", value, true);
 		return snippetIndex;
 	}
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/contentmodel/CMXSDDocument.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/contentmodel/CMXSDDocument.java
@@ -241,6 +241,99 @@ public class CMXSDDocument implements CMDocument, XSElementDeclHelper {
 		return null;
 	}
 
+	@Override
+	public Collection<String> findDerivedTypeNames(DOMElement element) {
+		// Find the content model element declaration to get the element's declared type
+		CMXSDElementDeclaration cmElement = (CMXSDElementDeclaration) findCMElement(element,
+				element.getNamespaceURI());
+		if (cmElement == null) {
+			return Collections.emptyList();
+		}
+		// Get the base type declared for this element (e.g. BaseType in
+		// <xs:element name="item" type="tns:BaseType"/>)
+		XSTypeDefinition baseType = cmElement.getElementDeclaration().getTypeDefinition();
+		if (baseType == null) {
+			return Collections.emptyList();
+		}
+		// Iterate all type definitions in the schema and collect those that derive
+		// from the base type via extension or restriction (for use as xsi:type values)
+		XSNamedMap types = model.getComponents(XSConstants.TYPE_DEFINITION);
+		Collection<String> result = new ArrayList<>();
+		for (int i = 0; i < types.getLength(); i++) {
+			XSTypeDefinition type = (XSTypeDefinition) types.item(i);
+			if (type == baseType) {
+				// Skip the base type itself (it's already the element's declared type)
+				continue;
+			}
+			if ("http://www.w3.org/2001/XMLSchema".equals(type.getNamespace())) {
+				// Skip built-in XML Schema types (xs:anyType, xs:string, etc.)
+				continue;
+			}
+			if (type.getName() == null) {
+				// Skip anonymous types
+				continue;
+			}
+			if (type.derivedFromType(baseType,
+					(short) (XSConstants.DERIVATION_EXTENSION | XSConstants.DERIVATION_RESTRICTION))) {
+				String qualifiedName = getQualifiedTypeName(type, element);
+				if (qualifiedName != null) {
+					result.add(qualifiedName);
+				}
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * Returns the qualified type name for the given type definition, using the
+	 * appropriate prefix from the XML element context. If the type's namespace has
+	 * an explicit prefix (e.g. xmlns:tns), returns "tns:TypeName". If only the
+	 * default namespace matches, returns just "TypeName".
+	 */
+	private static String getQualifiedTypeName(XSTypeDefinition type, DOMElement element) {
+		String typeNamespace = type.getNamespace();
+		String typeName = type.getName();
+		if (typeNamespace != null) {
+			// Try to find an explicit prefix for the namespace (e.g. xmlns:tns="...")
+			String prefix = element.getPrefix(typeNamespace);
+			if (prefix != null) {
+				return prefix + ":" + typeName;
+			}
+			// Fallback: if the default namespace matches, use unprefixed name
+			String defaultNs = element.getNamespaceURI(null);
+			if (typeNamespace.equals(defaultNs)) {
+				return typeName;
+			}
+			// No prefix available for this namespace
+			return null;
+		}
+		return typeName;
+	}
+
+	/**
+	 * Returns the local names of all types that derive from the given base type
+	 * via extension or restriction. Used by {@link CMXSDElementDeclaration} to
+	 * provide xsi:type snippet choices for elements with abstract types.
+	 */
+	Collection<String> findDerivedTypeLocalNames(XSTypeDefinition baseType) {
+		XSNamedMap types = model.getComponents(XSConstants.TYPE_DEFINITION);
+		Collection<String> result = new ArrayList<>();
+		for (int i = 0; i < types.getLength(); i++) {
+			XSTypeDefinition type = (XSTypeDefinition) types.item(i);
+			if (type == baseType || type.getName() == null) {
+				continue;
+			}
+			if ("http://www.w3.org/2001/XMLSchema".equals(type.getNamespace())) {
+				continue;
+			}
+			if (type.derivedFromType(baseType,
+					(short) (XSConstants.DERIVATION_EXTENSION | XSConstants.DERIVATION_RESTRICTION))) {
+				result.add(type.getName());
+			}
+		}
+		return result;
+	}
+
 	private CMElementDeclaration findElementDeclaration(String tag, String namespace) {
 		for (CMElementDeclaration cmElement : getElements()) {
 			if (cmElement.getLocalName().equals(tag)) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/contentmodel/CMXSDElementDeclaration.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/contentmodel/CMXSDElementDeclaration.java
@@ -609,6 +609,16 @@ public class CMXSDElementDeclaration implements CMElementDeclaration {
 	}
 
 	@Override
+	public Collection<String> getDerivedTypeNames() {
+		// Only abstract complex types require xsi:type to specify a concrete derived type
+		if (!(typeDefinition instanceof XSComplexTypeDefinition)
+				|| !((XSComplexTypeDefinition) typeDefinition).getAbstract()) {
+			return Collections.emptyList();
+		}
+		return document.findDerivedTypeLocalNames(typeDefinition);
+	}
+
+	@Override
 	public Set<CMElementDeclaration> getRequiredElements() {
 		Set<CMElementDeclaration> requiredElements = new LinkedHashSet<>();
 		for (CMElementDeclaration element : elements) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsi/XSISchemaModel.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsi/XSISchemaModel.java
@@ -14,12 +14,15 @@ package org.eclipse.lemminx.extensions.xsi;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.dom.DOMAttr;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.dom.DOMElement;
 import org.eclipse.lemminx.dom.DOMNode;
+import org.eclipse.lemminx.extensions.contentmodel.model.CMDocument;
+import org.eclipse.lemminx.extensions.contentmodel.model.ContentModelManager;
 import org.eclipse.lemminx.services.extensions.completion.AttributeCompletionItem;
 import org.eclipse.lemminx.services.extensions.completion.ICompletionRequest;
 import org.eclipse.lemminx.services.extensions.completion.ICompletionResponse;
@@ -119,8 +122,13 @@ public class XSISchemaModel {
 		if (!hasAttribute(elementAtOffset, actualPrefix, "type")) {
 			documentation = TYPE_DOC;
 			name = actualPrefix + ":type";
-			createCompletionItem(name, isSnippetsSupported, generateValue, editRange, null, null, documentation,
-					response, sharedSettings);
+			// When the element has a declared type in the schema, provide the list of
+			// derived types as enumeration values so that inserting xsi:type shows a
+			// snippet choice (e.g. xsi:type="${1|DerivedType1,DerivedType2|}")
+			Collection<String> derivedTypes = findDerivedTypeNames(request, elementAtOffset);
+			String defaultValue = !derivedTypes.isEmpty() ? derivedTypes.iterator().next() : null;
+			createCompletionItem(name, isSnippetsSupported, generateValue, editRange, defaultValue,
+					!derivedTypes.isEmpty() ? derivedTypes : null, documentation, response, sharedSettings);
 		}
 
 		if (inRootElement) {
@@ -172,6 +180,16 @@ public class XSISchemaModel {
 			if (actualPrefix != null && attrName.equals(actualPrefix + ":nil")) {
 				// Value completion for 'nil' attribute
 				createCompletionItemsForValues(StringUtils.TRUE_FALSE_ARRAY, document, request, response);
+			} else if (actualPrefix != null && attrName.equals(actualPrefix + ":type")) {
+				// Value completion for 'type' attribute: propose all types derived from
+				// the element's declared type (via extension or restriction)
+				DOMElement parentElement = nodeAtOffset.isElement() ? (DOMElement) nodeAtOffset : null;
+				if (parentElement != null) {
+					Collection<String> derivedTypes = findDerivedTypeNames(request, parentElement);
+					if (!derivedTypes.isEmpty()) {
+						createCompletionItemsForValues(derivedTypes, document, request, response);
+					}
+				}
 			} else if (document.getDocumentElement() != null && document.getDocumentElement().equals(nodeAtOffset)) {
 				// if in the root element
 				if (attrName.equals("xmlns:xsi")) {
@@ -212,6 +230,27 @@ public class XSISchemaModel {
 
 	private static boolean hasAttribute(DOMElement root, String name) {
 		return hasAttribute(root, null, name);
+	}
+
+	/**
+	 * Returns the list of derived type names that can be used as xsi:type values
+	 * for the given element. Uses the content model to find the element's declared
+	 * type and enumerate all types that derive from it.
+	 */
+	private static Collection<String> findDerivedTypeNames(ICompletionRequest request, DOMElement element) {
+		try {
+			ContentModelManager contentModelManager = request.getComponent(ContentModelManager.class);
+			Collection<CMDocument> cmDocuments = contentModelManager.findCMDocument(element);
+			for (CMDocument cmDocument : cmDocuments) {
+				Collection<String> types = cmDocument.findDerivedTypeNames(element);
+				if (!types.isEmpty()) {
+					return types;
+				}
+			}
+		} catch (Exception e) {
+			// Content model not available (schema loading, no grammar, etc.), ignore
+		}
+		return Collections.emptyList();
 	}
 
 	public static Hover computeHoverResponse(DOMAttr attribute, IHoverRequest request) {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaCompletionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaCompletionExtensionsTest.java
@@ -1683,4 +1683,20 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				c("baseProp", "<baseProp></baseProp>"), //
 				c("derivedProp", "<derivedProp></derivedProp>"));
 	}
+
+	@Test
+	public void elementCompletionWithAbstractTypeGeneratesXsiType() throws BadLocationException {
+		// When completing an element whose type is abstract, the generated snippet
+		// should include xsi:type with derived types as a snippet choice
+		String xml = "<root\r\n" + //
+				"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"      xsi:noNamespaceSchemaLocation=\"xsd/xsitype-abstract.xsd\">\r\n" + //
+				"  <|" + //
+				"</root>";
+		testCompletionSnippetSupportFor(xml, "src/test/resources/xsitype-abstract.xml",
+				1 + 2 /* CDATA and Comments */, //
+				c("Character",
+						"<Character xsi:type=\"${1|Student,Teacher|}\" Name=\"$2\">$3</Character>$0",
+						r(3, 2, 3, 3), "<Character"));
+	}
 }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsi/XSICompletionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsi/XSICompletionExtensionsTest.java
@@ -153,6 +153,46 @@ public class XSICompletionExtensionsTest extends AbstractCacheBasedTest {
 				); // coming from stylesheet children
 	}
 
+	@Test
+	public void xsiTypeValueCompletionWithPrefix() throws BadLocationException {
+		String xml = "<root xmlns=\"http://example.com/test\"\r\n" + //
+				"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"      xmlns:tns=\"http://example.com/test\"\r\n" + //
+				"      xsi:schemaLocation=\"http://example.com/test xsd/xsitype-ns.xsd\">\r\n" + //
+				"  <item xsi:type=\"|\">\r\n" + //
+				"  </item>\r\n" + //
+				"</root>";
+		testCompletionFor(xml, "src/test/resources/xsitype-ns.xml",
+				c("tns:DerivedType", te(4, 18, 4, 18, "tns:DerivedType"), "tns:DerivedType"));
+	}
+
+	@Test
+	public void xsiTypeValueCompletionWithDefaultNamespace() throws BadLocationException {
+		String xml = "<root xmlns=\"http://example.com/test\"\r\n" + //
+				"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"      xsi:schemaLocation=\"http://example.com/test xsd/xsitype-ns.xsd\">\r\n" + //
+				"  <item xsi:type=\"|\">\r\n" + //
+				"  </item>\r\n" + //
+				"</root>";
+		testCompletionFor(xml, "src/test/resources/xsitype-ns.xml",
+				c("DerivedType", te(3, 18, 3, 18, "DerivedType"), "DerivedType"));
+	}
+
+	@Test
+	public void xsiTypeValueCompletionWithAbstractType() throws BadLocationException {
+		// Schema with no namespace, abstract base type 'Character',
+		// and two derived types 'Teacher' and 'Student'
+		String xml = "<root\r\n" + //
+				"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"      xsi:noNamespaceSchemaLocation=\"xsd/xsitype-abstract.xsd\">\r\n" + //
+				"  <Character xsi:type=\"|\" Name=\"test\">\r\n" + //
+				"  </Character>\r\n" + //
+				"</root>";
+		testCompletionFor(xml, "src/test/resources/xsitype-abstract.xml",
+				c("Teacher", te(3, 23, 3, 23, "Teacher"), "Teacher"),
+				c("Student", te(3, 23, 3, 23, "Student"), "Student"));
+	}
+
 	private SharedSettings singleQuotesSharedSettings() {
 		SharedSettings settings = new SharedSettings();
 		settings.getPreferences().setQuoteStyle(QuoteStyle.singleQuotes);
@@ -162,6 +202,11 @@ public class XSICompletionExtensionsTest extends AbstractCacheBasedTest {
 
 	private void testCompletionFor(String xml, CompletionItem... expectedItems) throws BadLocationException {
 		XMLAssert.testCompletionFor(xml, null, expectedItems);
+	}
+
+	private void testCompletionFor(String xml, String fileURI, CompletionItem... expectedItems)
+			throws BadLocationException {
+		XMLAssert.testCompletionFor(xml, null, fileURI, null, expectedItems);
 	}
 
 	private void testCompletionFor(String xml, SharedSettings sharedSettings, CompletionItem... expectedItems) throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/resources/xsd/xsitype-abstract.xsd
+++ b/org.eclipse.lemminx/src/test/resources/xsd/xsitype-abstract.xsd
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <xs:element name="root">
+        <xs:complexType>
+            <xs:sequence maxOccurs="unbounded">
+                <xs:element name="Character" type="Character" />
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="Character" abstract="true">
+        <xs:attribute name="Name" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="Teacher">
+        <xs:complexContent>
+            <xs:extension base="Character">
+                <xs:sequence>
+                    <xs:element name="Secret" type="xs:string" maxOccurs="unbounded" />
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="Student">
+        <xs:complexContent>
+            <xs:extension base="Character">
+                <xs:sequence>
+                    <xs:element name="School" type="xs:string" />
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+</xs:schema>


### PR DESCRIPTION
When completing xsi:type attribute values, list all types derived from the element's declared type. Also provide derived types as choices in the xsi:type attribute name completion snippet.

Here a demo with https://github.com/redhat-developer/vscode-xml/issues/920:

<img width="939" height="525" alt="XsiTypeAttrCompletion" src="https://github.com/user-attachments/assets/712734ac-196c-4a17-bf48-754948a1e0d9" />

