### PR TITLE
Fix hover documentation for elements declared inside xs:group

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/contentmodel/CMXSDDocument.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/contentmodel/CMXSDDocument.java
@@ -44,12 +44,16 @@ import org.apache.xerces.xs.XSComplexTypeDefinition;
 import org.apache.xerces.xs.XSConstants;
 import org.apache.xerces.xs.XSElementDeclaration;
 import org.apache.xerces.xs.XSModel;
+import org.apache.xerces.xs.XSModelGroup;
+import org.apache.xerces.xs.XSModelGroupDefinition;
 import org.apache.xerces.xs.XSMultiValueFacet;
 import org.apache.xerces.xs.XSNamedMap;
 import org.apache.xerces.xs.XSNamespaceItem;
 import org.apache.xerces.xs.XSNamespaceItemList;
 import org.apache.xerces.xs.XSObject;
 import org.apache.xerces.xs.XSObjectList;
+import org.apache.xerces.xs.XSParticle;
+import org.apache.xerces.xs.XSTerm;
 import org.apache.xerces.xs.XSSimpleTypeDefinition;
 import org.apache.xerces.xs.XSTypeDefinition;
 import org.eclipse.lemminx.dom.DOMAttr;
@@ -340,6 +344,55 @@ public class CMXSDDocument implements CMDocument, XSElementDeclHelper {
 				return cmElement;
 			}
 		}
+		return findElementInModelGroups(tag, namespace);
+	}
+
+	/**
+	 * Fallback search for elements declared locally inside xs:group definitions.
+	 * This is needed when the element is not a global element declaration (e.g.
+	 * elements defined inside &lt;xs:group name="..."&gt;) and the parent element
+	 * in the XML document belongs to a different namespace, preventing the normal
+	 * DOM hierarchy walk from resolving the element.
+	 *
+	 * @param tag       the local name of the element to find.
+	 * @param namespace the namespace URI of the element to find.
+	 * @return the matching element declaration, or null if not found.
+	 *
+	 * @see <a href="https://github.com/redhat-developer/vscode-xml/issues/1129">vscode-xml#1129</a>
+	 */
+	private CMElementDeclaration findElementInModelGroups(String tag, String namespace) {
+		XSNamedMap groupMap = model.getComponents(XSConstants.MODEL_GROUP_DEFINITION);
+		for (int i = 0; i < groupMap.getLength(); i++) {
+			XSModelGroupDefinition groupDef = (XSModelGroupDefinition) groupMap.item(i);
+			if (namespace != null && !namespace.equals(groupDef.getNamespace())) {
+				continue;
+			}
+			XSModelGroup group = groupDef.getModelGroup();
+			CMElementDeclaration found = findElementInModelGroup(group, tag, namespace);
+			if (found != null) {
+				return found;
+			}
+		}
+		return null;
+	}
+
+	private CMElementDeclaration findElementInModelGroup(XSModelGroup group, String tag, String namespace) {
+		XSObjectList particles = group.getParticles();
+		for (int i = 0; i < particles.getLength(); i++) {
+			XSTerm term = ((XSParticle) particles.item(i)).getTerm();
+			if (term.getType() == XSConstants.ELEMENT_DECLARATION) {
+				XSElementDeclaration elemDecl = (XSElementDeclaration) term;
+				if (tag.equals(elemDecl.getName())
+						&& (namespace == null || namespace.equals(elemDecl.getNamespace()))) {
+					return getXSDElement(elemDecl);
+				}
+			} else if (term.getType() == XSConstants.MODEL_GROUP) {
+				CMElementDeclaration found = findElementInModelGroup((XSModelGroup) term, tag, namespace);
+				if (found != null) {
+					return found;
+				}
+			}
+		}
 		return null;
 	}
 
@@ -576,11 +629,21 @@ public class CMXSDDocument implements CMDocument, XSElementDeclHelper {
 			}
 		}
 
-		// 2.2) XSD local element, get the parent xs:complexType of the XSD element and
-		// loop for each xs:complexType of the SchemaGrammar
+		// 2.2) XSD local element inside a group, find grammar by element namespace
 		if (enclosingType == null) {
+			String ns = elementDeclaration.getNamespace();
+			if (ns != null) {
+				for (int i = 0; i < namespaces.getLength(); i++) {
+					XSNamespaceItem namespace = namespaces.item(i);
+					if (namespace instanceof SchemaGrammar && ns.equals(namespace.getSchemaNamespace())) {
+						return (SchemaGrammar) namespace;
+					}
+				}
+			}
 			return null;
 		}
+		// 2.3) XSD local element, get the parent xs:complexType of the XSD element and
+		// loop for each xs:complexType of the SchemaGrammar
 		for (int i = 0; i < namespaces.getLength(); i++) {
 			XSNamespaceItem namespace = namespaces.item(i);
 			if (namespace instanceof SchemaGrammar) {
@@ -606,6 +669,30 @@ public class CMXSDDocument implements CMDocument, XSElementDeclHelper {
 	 */
 	private static SchemaGrammar getSchemaGrammar(XSNamespaceItem namespaceItem) {
 		return (namespaceItem != null && namespaceItem instanceof SchemaGrammar) ? (SchemaGrammar) namespaceItem : null;
+	}
+
+	/**
+	 * Returns the schema grammar matching the given namespace URI. Used as a
+	 * fallback when the standard grammar resolution (via enclosing type or
+	 * namespace item) fails for local elements inside xs:group definitions,
+	 * where Xerces may resolve to the BuiltinSchemaGrammar instead of the
+	 * user's schema grammar.
+	 *
+	 * @param namespace the namespace URI to search for.
+	 * @return the matching schema grammar, or null if not found.
+	 */
+	SchemaGrammar findSchemaGrammarByNamespace(String namespace) {
+		if (namespace == null) {
+			return null;
+		}
+		XSNamespaceItemList namespaces = model.getNamespaceItems();
+		for (int i = 0; i < namespaces.getLength(); i++) {
+			XSNamespaceItem namespaceItem = namespaces.item(i);
+			if (namespaceItem instanceof SchemaGrammar && namespace.equals(namespaceItem.getSchemaNamespace())) {
+				return (SchemaGrammar) namespaceItem;
+			}
+		}
+		return null;
 	}
 
 	/**

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/contentmodel/CMXSDElementDeclaration.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/contentmodel/CMXSDElementDeclaration.java
@@ -580,7 +580,16 @@ public class CMXSDElementDeclaration implements CMElementDeclaration {
 	@Override
 	public String getDocumentURI() {
 		SchemaGrammar schemaGrammar = document.getOwnerSchemaGrammar(elementDeclaration);
-		return CMXSDDocument.getSchemaURI(schemaGrammar);
+		String uri = CMXSDDocument.getSchemaURI(schemaGrammar);
+		if (uri == null) {
+			// For local elements inside xs:group, getOwnerSchemaGrammar may resolve to
+			// BuiltinSchemaGrammar (which has no document URI) because the element's type
+			// (e.g. xsd:dateTime) belongs to the XSD namespace. Fall back to finding the
+			// grammar by the element's own namespace.
+			schemaGrammar = document.findSchemaGrammarByNamespace(elementDeclaration.getNamespace());
+			uri = CMXSDDocument.getSchemaURI(schemaGrammar);
+		}
+		return uri;
 	}
 
 	@Override

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaHoverGroupTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaHoverGroupTest.java
@@ -1,0 +1,192 @@
+/**
+ *  Copyright (c) 2026 Red Hat Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v2.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *  Red Hat Inc. - initial API and implementation
+ */
+package org.eclipse.lemminx.extensions.contentmodel;
+
+import static org.eclipse.lemminx.XMLAssert.c;
+import static org.eclipse.lemminx.XMLAssert.ll;
+import static org.eclipse.lemminx.XMLAssert.r;
+import static org.eclipse.lemminx.XMLAssert.testCompletionFor;
+import static org.eclipse.lemminx.XMLAssert.testTypeDefinitionFor;
+
+import org.apache.xerces.impl.XMLEntityManager;
+import org.apache.xerces.util.URI.MalformedURIException;
+import org.eclipse.lemminx.AbstractCacheBasedTest;
+import org.eclipse.lemminx.XMLAssert;
+import org.eclipse.lemminx.commons.BadLocationException;
+import org.eclipse.lemminx.services.XMLLanguageService;
+import org.junit.jupiter.api.Test;
+
+/**
+ * XML hover, completion, and type definition tests for elements declared inside
+ * xs:group.
+ *
+ * @see <a href=
+ *      "https://github.com/redhat-developer/vscode-xml/issues/1129">vscode-xml#1129</a>
+ */
+public class XMLSchemaHoverGroupTest extends AbstractCacheBasedTest {
+
+	// ------------------- Hover -------------------
+
+	@Test
+	public void testHoverOnGlobalElement() throws BadLocationException, MalformedURIException {
+		String schemaURI = getSchemaURI("group.xsd");
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+				"<root xmlns:g=\"http://group-test\"\r\n" +
+				"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+				"      xsi:schemaLocation=\"http://group-test xsd/group.xsd\">\r\n" +
+				"    <g:resu|lt>Test</g:result>\r\n" +
+				"</root>";
+		XMLAssert.assertHover(new XMLLanguageService(), xml, null, "src/test/resources/group.xml",
+				"Result documentation" +
+						System.lineSeparator() +
+						System.lineSeparator() + "Source: [group.xsd](" + schemaURI + ")",
+				r(4, 5, 4, 13));
+	}
+
+	@Test
+	public void testHoverOnElementInGroup() throws BadLocationException, MalformedURIException {
+		String schemaURI = getSchemaURI("group.xsd");
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+				"<root xmlns:g=\"http://group-test\"\r\n" +
+				"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+				"      xsi:schemaLocation=\"http://group-test xsd/group.xsd\">\r\n" +
+				"    <g:result|Time>2024-01-01</g:resultTime>\r\n" +
+				"</root>";
+		XMLAssert.assertHover(new XMLLanguageService(), xml, null, "src/test/resources/group.xml",
+				"Result time documentation" +
+						System.lineSeparator() +
+						System.lineSeparator() + "Source: [group.xsd](" + schemaURI + ")",
+				r(4, 5, 4, 17));
+	}
+
+	@Test
+	public void testHoverOnAnotherElementInGroup() throws BadLocationException, MalformedURIException {
+		String schemaURI = getSchemaURI("group.xsd");
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+				"<root xmlns:g=\"http://group-test\"\r\n" +
+				"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+				"      xsi:schemaLocation=\"http://group-test xsd/group.xsd\">\r\n" +
+				"    <g:proce|dure>test</g:procedure>\r\n" +
+				"</root>";
+		XMLAssert.assertHover(new XMLLanguageService(), xml, null, "src/test/resources/group.xml",
+				"Procedure documentation" +
+						System.lineSeparator() +
+						System.lineSeparator() + "Source: [group.xsd](" + schemaURI + ")",
+				r(4, 5, 4, 16));
+	}
+
+	@Test
+	public void testHoverOnElementInGroupWithSchemaParent() throws BadLocationException, MalformedURIException {
+		String schemaURI = getSchemaURI("group.xsd");
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+				"<g:observation xmlns:g=\"http://group-test\"\r\n" +
+				"               xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+				"               xsi:schemaLocation=\"http://group-test xsd/group.xsd\">\r\n" +
+				"    <g:result|Time>2024-01-01</g:resultTime>\r\n" +
+				"</g:observation>";
+		XMLAssert.assertHover(new XMLLanguageService(), xml, null, "src/test/resources/group.xml",
+				"Result time documentation" +
+						System.lineSeparator() +
+						System.lineSeparator() + "Source: [group.xsd](" + schemaURI + ")",
+				r(4, 5, 4, 17));
+	}
+
+	// ------------------- Completion -------------------
+
+	@Test
+	public void testCompletionOfFirstGroupElement() throws BadLocationException {
+		// Inside <g:observation>, the first expected element from the group sequence
+		// is g:resultTime
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+				"<g:observation xmlns:g=\"http://group-test\"\r\n" +
+				"               xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+				"               xsi:schemaLocation=\"http://group-test xsd/group.xsd\">\r\n" +
+				"    <|\r\n" +
+				"</g:observation>";
+		testCompletionFor(xml, null, "src/test/resources/group.xml", null,
+				c("g:resultTime", "<g:resultTime></g:resultTime>"));
+	}
+
+	@Test
+	public void testCompletionOfNextGroupElement() throws BadLocationException {
+		// After g:resultTime is present, the next expected element is g:procedure
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+				"<g:observation xmlns:g=\"http://group-test\"\r\n" +
+				"               xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+				"               xsi:schemaLocation=\"http://group-test xsd/group.xsd\">\r\n" +
+				"    <g:resultTime>2024-01-01</g:resultTime>\r\n" +
+				"    <|\r\n" +
+				"</g:observation>";
+		testCompletionFor(xml, null, "src/test/resources/group.xml", null,
+				c("g:procedure", "<g:procedure></g:procedure>"));
+	}
+
+	@Test
+	public void testCompletionOfGlobalElementAfterGroup() throws BadLocationException {
+		// After all group elements are present, the global element ref g:result
+		// should be offered
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+				"<g:observation xmlns:g=\"http://group-test\"\r\n" +
+				"               xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+				"               xsi:schemaLocation=\"http://group-test xsd/group.xsd\">\r\n" +
+				"    <g:resultTime>2024-01-01</g:resultTime>\r\n" +
+				"    <g:procedure>test</g:procedure>\r\n" +
+				"    <|\r\n" +
+				"</g:observation>";
+		testCompletionFor(xml, null, "src/test/resources/group.xml", null,
+				c("g:result", "<g:result></g:result>"));
+	}
+
+	// ------------------- Type definition -------------------
+
+	@Test
+	public void testTypeDefinitionOnGlobalElement() throws BadLocationException, MalformedURIException {
+		String xmlFile = "src/test/resources/group.xml";
+		String xsdFile = "xsd/group.xsd";
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+				"<root xmlns:g=\"http://group-test\"\r\n" +
+				"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+				"      xsi:schemaLocation=\"http://group-test xsd/group.xsd\">\r\n" +
+				"    <g:resu|lt>Test</g:result>\r\n" +
+				"</root>";
+		XMLLanguageService xmlLanguageService = new XMLLanguageService();
+		String targetSchemaURI = xmlLanguageService.getResolverExtensionManager().resolve(xmlFile, null, xsdFile);
+		// "result" is at line 6 (0-indexed), name="result" at columns 22-30
+		testTypeDefinitionFor(xmlLanguageService, xml, xmlFile,
+				ll(targetSchemaURI, r(4, 5, 4, 13), r(6, 22, 6, 30)));
+	}
+
+	@Test
+	public void testTypeDefinitionOnElementInGroupWithSchemaParent()
+			throws BadLocationException, MalformedURIException {
+		String xmlFile = "src/test/resources/group.xml";
+		String xsdFile = "xsd/group.xsd";
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+				"<g:observation xmlns:g=\"http://group-test\"\r\n" +
+				"               xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+				"               xsi:schemaLocation=\"http://group-test xsd/group.xsd\">\r\n" +
+				"    <g:result|Time>2024-01-01</g:resultTime>\r\n" +
+				"</g:observation>";
+		XMLLanguageService xmlLanguageService = new XMLLanguageService();
+		String targetSchemaURI = xmlLanguageService.getResolverExtensionManager().resolve(xmlFile, null, xsdFile);
+		// "resultTime" is at line 14 (0-indexed), name="resultTime" at columns 30-42
+		testTypeDefinitionFor(xmlLanguageService, xml, xmlFile,
+				ll(targetSchemaURI, r(4, 5, 4, 17), r(14, 30, 14, 42)));
+	}
+
+	private static String getSchemaURI(String schemaFileName) throws MalformedURIException {
+		return XMLEntityManager
+				.expandSystemId("xsd/" + schemaFileName, "src/test/resources/test.xml", true)
+				.replace("///", "/");
+	}
+}

--- a/org.eclipse.lemminx/src/test/resources/xsd/group.xsd
+++ b/org.eclipse.lemminx/src/test/resources/xsd/group.xsd
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="http://group-test"
+            xmlns:g="http://group-test"
+            elementFormDefault="qualified">
+
+    <xsd:element name="result" type="xsd:string">
+        <xsd:annotation>
+            <xsd:documentation>Result documentation</xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+
+    <xsd:group name="CommonProperties">
+        <xsd:sequence>
+            <xsd:element name="resultTime" type="xsd:dateTime">
+                <xsd:annotation>
+                    <xsd:documentation>Result time documentation</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="procedure" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:documentation>Procedure documentation</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+
+    <xsd:complexType name="ObservationType">
+        <xsd:sequence>
+            <xsd:group ref="g:CommonProperties"/>
+            <xsd:element ref="g:result"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="observation" type="g:ObservationType">
+        <xsd:annotation>
+            <xsd:documentation>Observation documentation</xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+
+</xsd:schema>


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-xml/issues/1129

## Summary

Elements declared locally inside `xs:group` definitions don't get hover documentation, completion, or type definition support.

### Given XSD

```xml
<?xml version="1.0" encoding="UTF-8"?>
<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
            targetNamespace="http://group-test"
            xmlns:g="http://group-test"
            elementFormDefault="qualified">

    <xsd:element name="result" type="xsd:string">
        <xsd:annotation>
            <xsd:documentation>Result documentation</xsd:documentation>
        </xsd:annotation>
    </xsd:element>

    <xsd:group name="CommonProperties">
        <xsd:sequence>
            <xsd:element name="resultTime" type="xsd:dateTime">
                <xsd:annotation>
                    <xsd:documentation>Result time documentation</xsd:documentation>
                </xsd:annotation>
            </xsd:element>
            <xsd:element name="procedure" type="xsd:string">
                <xsd:annotation>
                    <xsd:documentation>Procedure documentation</xsd:documentation>
                </xsd:annotation>
            </xsd:element>
        </xsd:sequence>
    </xsd:group>

    <xsd:complexType name="ObservationType">
        <xsd:sequence>
            <xsd:group ref="g:CommonProperties"/>
            <xsd:element ref="g:result"/>
        </xsd:sequence>
    </xsd:complexType>

    <xsd:element name="observation" type="g:ObservationType">
        <xsd:annotation>
            <xsd:documentation>Observation documentation</xsd:documentation>
        </xsd:annotation>
    </xsd:element>

</xsd:schema>
```

Given XML

```xml
<g:observation xmlns:g="http://group-test"
               xsi:schemaLocation="http://group-test group.xsd">
    <g:resultTime>2024-01-01</g:resultTime>  <!-- no hover, no completion, no go-to-definition -->
</g:observation>
```

Here a demo:

<img width="939" height="525" alt="XSDHoverGroup" src="https://github.com/user-attachments/assets/5867732a-90a8-464d-a2c7-b1640b8671c8" />
