### PR TITLE
Fix autocomplete ignoring imported XSD namespace prefix

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/utils/XSDUtils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/utils/XSDUtils.java
@@ -13,8 +13,10 @@ package org.eclipse.lemminx.extensions.xsd.utils;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.Vector;
 import java.util.function.BiConsumer;
@@ -191,7 +193,8 @@ public class XSDUtils {
 			return;
 		}
 		visitedURIs.add(documentURI);
-		Set<String> externalURIS = null;
+		// Map of schemaLocation -> namespace prefix for external schemas (xs:include / xs:import)
+		Map<String, String> externalSchemas = null;
 		NodeList children = documentElement.getChildNodes();
 		for (int i = 0; i < children.getLength(); i++) {
 			Node node = children.item(i);
@@ -204,29 +207,53 @@ public class XSDUtils {
 					if (targetAttr != null && (!matchAttr || Objects.equal(originName, targetAttr.getValue()))) {
 						collector.accept(targetNamespacePrefix, targetAttr);
 					}
-				} else if (isXSInclude(targetElement) || isXSImport(targetElement)) {
-					// collect xs:include XML Schema location
+				} else if (isXSInclude(targetElement)) {
+					// xs:include shares the same targetNamespace, keep the current prefix
 					String schemaLocation = targetElement.getAttribute(SCHEMA_LOCATION_ATTR);
 					if (schemaLocation != null) {
-						if (externalURIS == null) {
-							externalURIS = new HashSet<>();
+						if (externalSchemas == null) {
+							externalSchemas = new HashMap<>();
 						}
-						externalURIS.add(schemaLocation);
+						externalSchemas.put(schemaLocation, targetNamespacePrefix);
+					}
+				} else if (isXSImport(targetElement)) {
+					// xs:import has a different namespace; resolve the xmlns prefix
+					// declared in the origin document for the imported namespace
+					String schemaLocation = targetElement.getAttribute(SCHEMA_LOCATION_ATTR);
+					if (schemaLocation != null) {
+						if (externalSchemas == null) {
+							externalSchemas = new HashMap<>();
+						}
+						String importPrefix = null;
+						String importedNamespace = targetElement.getAttribute(NAMESPACE_ATTR);
+						if (importedNamespace != null && !importedNamespace.isEmpty()) {
+							DOMElement originDocumentElement = originAttr.getOwnerDocument().getDocumentElement();
+							importPrefix = originDocumentElement.getPrefix(importedNamespace);
+						}
+						externalSchemas.put(schemaLocation, importPrefix);
 					}
 				}
 			}
 		}
-		if (searchInExternalSchema && externalURIS != null) {
-			// Search in xs:include XML Schema location
+		if (searchInExternalSchema && externalSchemas != null) {
+			// Search in xs:include / xs:import external schemas
 			URIResolverExtensionManager resolverExtensionManager = document.getResolverExtensionManager();
-			for (String externalURI : externalURIS) {
+			for (Map.Entry<String, String> entry : externalSchemas.entrySet()) {
+				String externalURI = entry.getKey();
+				String externalPrefix = entry.getValue();
 				String resourceURI = resolverExtensionManager.resolve(documentURI, null, externalURI);
 				if (URIUtils.isFileResource(resourceURI)) {
 					DOMDocument externalDocument = DOMUtils.loadDocument(resourceURI,
 							document.getResolverExtensionManager());
 					if (externalDocument != null) {
+						// Recompute originName for definition/highlighting (matchAttr=true),
+						// because the prefix in the typed value must match this schema's prefix
+						String externalOriginName = originName;
+						if (matchAttr) {
+							externalOriginName = getOriginName(originAttr.getValue(), externalPrefix);
+						}
 						searchXSTargetAttributes(originAttr, bindingType, matchAttr, collector,
-								externalDocument.getDocumentElement(), targetNamespacePrefix, originName, visitedURIs,
+								externalDocument.getDocumentElement(), externalPrefix, externalOriginName, visitedURIs,
 								searchInExternalSchema);
 					}
 				}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDCompletionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDCompletionExtensionsTest.java
@@ -186,6 +186,49 @@ public class XSDCompletionExtensionsTest extends AbstractCacheBasedTest {
 				c("TypeFromC", te(6, 20, 6, 20, "TypeFromC"), "TypeFromC"));
 	}
 
+	@Test
+	public void completionWithXSImportOnType() throws BadLocationException {
+		// SchemaA imports ImportedSchema (which defines 'ImportedType' complexType and
+		// 'ImportedSimpleType' simpleType in namespace "http://import")
+		String xml = "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\r\n" + //
+				"<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\r\n" + //
+				"           xmlns:imp=\"http://import\"\r\n" + //
+				"           targetNamespace=\"http://test\"\r\n" + //
+				"           xmlns:tns=\"http://test\">\r\n" + //
+				"	<xs:import schemaLocation=\"src/test/resources/xsd/ImportedSchema.xsd\" namespace=\"http://import\" />\r\n"
+				+ //
+				"	<xs:complexType name=\"LocalType\" />\r\n" + //
+				"	<xs:element name=\"elt\" type=\"|\" />\r\n" + //
+				"</xs:schema>";
+		XMLAssert.testCompletionFor(xml, null, "test.xml", null,
+				c("tns:LocalType", te(7, 30, 7, 30, "tns:LocalType"), "tns:LocalType"),
+				c("imp:ImportedType", te(7, 30, 7, 30, "imp:ImportedType"), "imp:ImportedType"),
+				c("imp:ImportedSimpleType", te(7, 30, 7, 30, "imp:ImportedSimpleType"), "imp:ImportedSimpleType"));
+	}
+
+	@Test
+	public void completionWithXSImportOnRef() throws BadLocationException {
+		// completion on xs:element/@ref should show elements from imported schema with
+		// correct namespace prefix
+		String xml = "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\r\n" + //
+				"<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\r\n" + //
+				"           xmlns:imp=\"http://import\"\r\n" + //
+				"           targetNamespace=\"http://test\"\r\n" + //
+				"           xmlns:tns=\"http://test\">\r\n" + //
+				"	<xs:import schemaLocation=\"src/test/resources/xsd/ImportedSchema.xsd\" namespace=\"http://import\" />\r\n"
+				+ //
+				"	<xs:element name=\"LocalElement\" />\r\n" + //
+				"	<xs:complexType name=\"MyType\">\r\n" + //
+				"		<xs:sequence>\r\n" + //
+				"			<xs:element ref=\"|\" />\r\n" + //
+				"		</xs:sequence>\r\n" + //
+				"	</xs:complexType>\r\n" + //
+				"</xs:schema>";
+		XMLAssert.testCompletionFor(xml, null, "test.xml", null,
+				c("tns:LocalElement", te(9, 20, 9, 20, "tns:LocalElement"), "tns:LocalElement"),
+				c("imp:ImportedElement", te(9, 20, 9, 20, "imp:ImportedElement"), "imp:ImportedElement"));
+	}
+
 	private void testCompletionFor(String xml, boolean enableItemDefaults, CompletionItem... expectedItems) throws BadLocationException {
 		XMLAssert.testCompletionFor(xml, null, enableItemDefaults, expectedItems);
 	}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDDefinitionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDDefinitionExtensionsTest.java
@@ -172,7 +172,7 @@ public class XSDDefinitionExtensionsTest extends AbstractCacheBasedTest {
 				"			<xs:element ref=\"TypeFr|omB\" />\r\n" + //
 				"		</xs:sequence>\r\n" + //
 				"	</xs:complexType>";
-		String schemaBPath = Paths.get("src/test/resources/xsd/SchemaB.xsd").toUri().toString();
+		String schemaBPath = getSchemaURI("src/test/resources/xsd/SchemaB.xsd");
 		testDefinitionFor(xml, ll(schemaBPath, r(6, 19, 6, 30), r(4, 18, 4, 29)));
 
 		// defintion from Schema A -> Schema C
@@ -186,7 +186,7 @@ public class XSDDefinitionExtensionsTest extends AbstractCacheBasedTest {
 				"			<xs:element ref=\"TypeFr|omC\" />\r\n" + //
 				"		</xs:sequence>\r\n" + //
 				"	</xs:complexType>";
-		String schemaCPath = Paths.get("src/test/resources/xsd/SchemaC.xsd").toUri().toString();
+		String schemaCPath = getSchemaURI("src/test/resources/xsd/SchemaC.xsd");
 		testDefinitionFor(xml, ll(schemaCPath, r(6, 19, 6, 30), r(3, 18, 3, 29)));
 
 	}
@@ -206,8 +206,48 @@ public class XSDDefinitionExtensionsTest extends AbstractCacheBasedTest {
 				"          <xs:element name=\"AdditionalField\" type=\"xs:string\" />\r\n" + //
 				"        </xs:sequence>\r\n" + "      </xs:extension>\r\n" + "    </xs:complexContent>\r\n" + //
 				"  </xs:complexType>\r\n" + "</xs:schema>";
-		String childPath = Paths.get("src/test/resources/xsd/Child.xsd").toUri().toString();
+		String childPath = getSchemaURI("src/test/resources/xsd/Child.xsd");
 		testDefinitionFor(xml, ll(childPath, r(10, 25, 10, 45), r(5, 23, 5, 40)));
+	}
+
+	@Test
+	public void definitionWithXSImportOnType() throws BadLocationException {
+		// definition on type="imp:Impor|tedType" should navigate to ImportedSchema.xsd
+		String xml = "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\r\n" + //
+				"<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\r\n" + //
+				"           xmlns:imp=\"http://import\"\r\n" + //
+				"           targetNamespace=\"http://test\"\r\n" + //
+				"           xmlns:tns=\"http://test\">\r\n" + //
+				"	<xs:import schemaLocation=\"src/test/resources/xsd/ImportedSchema.xsd\" namespace=\"http://import\" />\r\n"
+				+ //
+				"	<xs:element name=\"elt\" type=\"imp:Impor|tedType\" />\r\n" + //
+				"</xs:schema>";
+		String importedPath = getSchemaURI("src/test/resources/xsd/ImportedSchema.xsd");
+		testDefinitionFor(xml, ll(importedPath, r(6, 29, 6, 47), r(5, 22, 5, 36)));
+	}
+
+	@Test
+	public void definitionWithXSImportOnRef() throws BadLocationException {
+		// definition on ref="imp:Imported|Element" should navigate to ImportedSchema.xsd
+		String xml = "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\r\n" + //
+				"<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\r\n" + //
+				"           xmlns:imp=\"http://import\"\r\n" + //
+				"           targetNamespace=\"http://test\"\r\n" + //
+				"           xmlns:tns=\"http://test\">\r\n" + //
+				"	<xs:import schemaLocation=\"src/test/resources/xsd/ImportedSchema.xsd\" namespace=\"http://import\" />\r\n"
+				+ //
+				"	<xs:complexType name=\"MyType\">\r\n" + //
+				"		<xs:sequence>\r\n" + //
+				"			<xs:element ref=\"imp:Imported|Element\" />\r\n" + //
+				"		</xs:sequence>\r\n" + //
+				"	</xs:complexType>\r\n" + //
+				"</xs:schema>";
+		String importedPath = getSchemaURI("src/test/resources/xsd/ImportedSchema.xsd");
+		testDefinitionFor(xml, ll(importedPath, r(8, 19, 8, 40), r(11, 18, 11, 35)));
+	}
+
+	private static String getSchemaURI(String path) {
+		return Paths.get(path).toUri().toString();
 	}
 
 	private static void testDefinitionFor(String xml, LocationLink... expectedItems) throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/resources/xsd/ImportedSchema.xsd
+++ b/org.eclipse.lemminx/src/test/resources/xsd/ImportedSchema.xsd
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://import"
+           elementFormDefault="qualified">
+
+	<xs:complexType name="ImportedType" />
+
+	<xs:simpleType name="ImportedSimpleType">
+		<xs:restriction base="xs:string" />
+	</xs:simpleType>
+
+	<xs:element name="ImportedElement">
+		<xs:complexType />
+	</xs:element>
+
+</xs:schema>


### PR DESCRIPTION
## Fix autocomplete ignoring imported XSD namespace prefix

Fixes redhat-developer/vscode-xml#1000

<img width="1446" height="667" alt="image" src="https://github.com/user-attachments/assets/1eff2a9f-c2d6-4d6b-a99d-990f4516092e" />

### Problem

When editing an XSD file that imports another schema via `xs:import`, autocompletion does not use the correct namespace prefix for types and elements from the imported schema.

### Given XSD (ImportedSchema.xsd)

~~~xml
<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
           targetNamespace="http://import">
    <xs:complexType name="ImportedType" />
    <xs:simpleType name="ImportedSimpleType">
        <xs:restriction base="xs:string" />
    </xs:simpleType>
</xs:schema>
~~~

### Given XSD (Main schema being edited)

~~~xml
<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
           xmlns:imp="http://import"
           targetNamespace="http://test"
           xmlns:tns="http://test">
    <xs:import schemaLocation="ImportedSchema.xsd" namespace="http://import" />
    <xs:complexType name="LocalType" />
    <xs:element name="elt" type="|" />  <!-- completion here -->
</xs:schema>
~~~

### Before (bug)

Completion on `type="|"` produces:

| Item | Prefix |
|------|--------|
| `tns:LocalType` | `tns` (correct) |
| `tns:ImportedType` | `tns` (wrong) |
| `tns:ImportedSimpleType` | `tns` (wrong) |

All types use the same `targetNamespacePrefix` regardless of which schema they come from.

### After (fix)

Completion on `type="|"` produces:

| Item | Prefix |
|------|--------|
| `tns:LocalType` | `tns` (correct) |
| `imp:ImportedType` | `imp` (correct) |
| `imp:ImportedSimpleType` | `imp` (correct) |

Each imported type uses the prefix that maps to its namespace in the origin document.

### Root cause

`XSDUtils.searchXSTargetAttributes()` treated `xs:import` identically to `xs:include` — it collected only the `schemaLocation` and passed the same `targetNamespacePrefix` to all external schemas. For `xs:include` this is correct (shared namespace), but for `xs:import` the imported schema has a different `targetNamespace` requiring a different prefix.

### Fix

- `xs:import` is now handled separately from `xs:include`
- The `namespace` attribute is read from the `xs:import` element
- The correct `xmlns` prefix is resolved from the origin document via `DOMElement.getPrefix(importedNamespace)`
- The `originName` is recomputed per-import for definition and highlighting lookups (`matchAttr=true` case)

### Tests

- `completionWithXSImportOnType` — verifies `type` completion uses `imp:` prefix for imported types and `tns:` for local types
- `completionWithXSImportOnRef` — verifies `ref` completion uses `imp:` prefix for imported elements
