### PR TITLE
Fix "Insert only required elements" adding optional elements from extended types

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/contentmodel/CMXSDElementDeclaration.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/contentmodel/CMXSDElementDeclaration.java
@@ -359,21 +359,24 @@ public class CMXSDElementDeclaration implements CMElementDeclaration {
 			case XSTypeDefinition.COMPLEX_TYPE:
 				XSParticle particle = ((XSComplexTypeDefinition) typeDefinition).getParticle();
 				if (particle != null) {
-					XSObjectList objectList = ((XSModelGroup) particle.getTerm()).getParticles();
-					for (int i = 0; i < objectList.getLength(); i++) {
-						XSParticle xp = (XSParticle) objectList.item(i);
-						XSTerm t = xp.getTerm();
-						if (t instanceof XSElementDeclaration) {
-							if (xp != null) {
-								elementOptionality.put(t.getName(), xp.getMinOccurs() == 0);
-							}
-						}
-					}
+					collectElementOptionality(particle);
 				}
 			}
 		}
 		Boolean isOptional = elementOptionality.get(childElementName);
 		return (isOptional != null) ? isOptional : false;
+	}
+
+	private void collectElementOptionality(XSParticle particle) {
+		XSTerm term = particle.getTerm();
+		if (term instanceof XSElementDeclaration) {
+			elementOptionality.put(term.getName(), particle.getMinOccurs() == 0);
+		} else if (term instanceof XSModelGroup) {
+			XSObjectList particles = ((XSModelGroup) term).getParticles();
+			for (int i = 0; i < particles.getLength(); i++) {
+				collectElementOptionality((XSParticle) particles.item(i));
+			}
+		}
 	}
 
 	@SuppressWarnings("unchecked")

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaDiagnosticsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaDiagnosticsTest.java
@@ -368,6 +368,23 @@ public class XMLSchemaDiagnosticsTest extends AbstractCacheBasedTest {
 	}
 
 	@Test
+	public void cvc_complex_type_2_4_bCodeAction_Only_Required_Extension() throws Exception {
+		String xml = "<root xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"xsi:noNamespaceSchemaLocation=\"src/test/resources/xsd/order_extension.xsd\"></root>";
+		Diagnostic d = d(0, 1, 0, 5, XMLSchemaErrorCode.cvc_complex_type_2_4_b);
+		testDiagnosticsFor(xml, d);
+		testCodeActionsFor(xml, d, ca(d, te(1, 75, 1, 75, //
+				"\r\n" + //
+						"\t<episode></episode>\r\n" + //
+						"\t<episodeType></episodeType>\r\n" + //
+						"\t<episodeTime></episodeTime>\r\n")),
+				ca(d, te(1, 75, 1, 75, //
+						"\r\n" + //
+								"\t<episode></episode>\r\n" + //
+								"\t<episodeTime></episodeTime>\r\n")));
+	}
+
+	@Test
 	public void cvc_attribute_3() throws Exception {
 		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + //
 				"<beans xmlns=\"http://www.springframework.org/schema/beans\" xsi:schemaLocation=\"http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\r\n"

--- a/org.eclipse.lemminx/src/test/resources/xsd/order_extension.xsd
+++ b/org.eclipse.lemminx/src/test/resources/xsd/order_extension.xsd
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+	<xs:complexType name="EpisodeID">
+		<xs:sequence>
+			<xs:element name="episode" type="xs:string" />
+			<xs:element name="episodeType" type="xs:string" minOccurs="0" />
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Timestamp">
+		<xs:complexContent>
+			<xs:extension base="EpisodeID">
+				<xs:sequence>
+					<xs:element name="episodeTime" type="xs:string" />
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+
+	<xs:element name="root" type="Timestamp" />
+</xs:schema>


### PR DESCRIPTION
Fix "Insert only required elements" adding optional elements from extended types

isOptional() only traversed the top-level model group particles, missing elements inherited via xs:extension which are nested in sub-model groups.
Recurse into XSModelGroup terms like collectElementsDeclaration() already does.

Fixes redhat-developer/vscode-xml#993

With this fix, now code action add `episode `and `episodeTime` and not `episodeType`

```xml
<?xml version="1.0" encoding="UTF-8"?>
<root
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xmlns="testing" 
    xsi:schemaLocation="testing xsd/test.xsd">
  <episode></episode>
  <episodeTime></episodeTime>
</root>
```