### PR TITLE
Fix slash in content triggering erroneous end tag completion

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLCompletions.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLCompletions.java
@@ -796,7 +796,10 @@ public class XMLCompletions {
 		Range tagNameRange = request.getXMLDocument().getElementNameRangeAt(request.getOffset());
 		if (tagNameRange != null) {
 			collectOpenTagSuggestions(false, tagNameRange, request, response, cancelChecker);
-			collectCloseTagSuggestions(tagNameRange, true, true, false, request, response);
+			boolean isEmptyRange = tagNameRange.getStart().equals(tagNameRange.getEnd());
+			if (!isEmptyRange || !request.getNode().isText()) {
+				collectCloseTagSuggestions(tagNameRange, true, true, false, request, response);
+			}
 		}
 		// Adjust the range for covering the text node.
 		Range textRange = getTextRangeInsideContent(request.getNode());

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLCompletionTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLCompletionTest.java
@@ -92,6 +92,14 @@ public class XMLCompletionTest {
 	}
 
 	@Test
+	public void noEndTagCompletionAfterSlashContent() throws BadLocationException {
+		// See https://github.com/redhat-developer/vscode-xml/issues/1088
+		testCompletionFor("<a>/|", 0 + 2 /* CDATA and Comments */);
+		testCompletionFor("<a>\r\n/|", 0 + 2 /* CDATA and Comments */);
+		testCompletionFor("<a>some/|", 0 + 2 /* CDATA and Comments */);
+	}
+
+	@Test
 	public void unneededEndTagCompletion() throws BadLocationException {
 		testCompletionFor("<a>|</a>", 0 + 2 /* CDATA and Comments */);
 		testCompletionFor("<a><|</a>", 0 + 2 /* CDATA and Comments */);


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-xml/issues/1088

This PR fixes the slash usecases by avoiding opening the completion.

See the demo (note in the demo we see </Tag> which comes from the inline completion which generates </Tag> with Tab):

<img width="939" height="525" alt="SlashTag" src="https://github.com/user-attachments/assets/2587fb9c-d7c5-47cc-aa9d-3430da905d2d" />

