### PR TITLE
Add RelaxNG Compact Syntax (.rnc) generator from XML

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/missinggrammar/AbstractFixMissingGrammarCodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/missinggrammar/AbstractFixMissingGrammarCodeAction.java
@@ -52,6 +52,10 @@ public abstract class AbstractFixMissingGrammarCodeAction implements ICodeAction
 				new GenerateDTDCodeActionResolver());
 		resolveCodeActionParticipants.put(GenerateXSDCodeActionResolver.PARTICIPANT_ID,
 				new GenerateXSDCodeActionResolver());
+		resolveCodeActionParticipants.put(GenerateRelaxNGCodeActionResolver.PARTICIPANT_ID,
+				new GenerateRelaxNGCodeActionResolver());
+		resolveCodeActionParticipants.put(GenerateRelaxNGCompactCodeActionResolver.PARTICIPANT_ID,
+				new GenerateRelaxNGCompactCodeActionResolver());
 	}
 
 	@Override

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/missinggrammar/GenerateRelaxNGCodeActionResolver.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/missinggrammar/GenerateRelaxNGCodeActionResolver.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.contentmodel.participants.codeactions.missinggrammar;
+
+import org.eclipse.lemminx.extensions.generators.FileContentGeneratorSettings;
+import org.eclipse.lemminx.extensions.generators.xml2relaxng.RelaxNGGeneratorSettings;
+
+/**
+ * Code action resolver participant to generate the missing RelaxNG (.rng) file
+ * which is declared in the XML as association via xml-model.
+ *
+ */
+public class GenerateRelaxNGCodeActionResolver extends AbstractGenerateGrammarCodeActionResolver {
+
+	public static final String PARTICIPANT_ID = GenerateRelaxNGCodeActionResolver.class.getName();
+
+	@Override
+	protected FileContentGeneratorSettings getFileContentGeneratorSettings() {
+		return new RelaxNGGeneratorSettings();
+	}
+
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/missinggrammar/GenerateRelaxNGCompactCodeActionResolver.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/missinggrammar/GenerateRelaxNGCompactCodeActionResolver.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.contentmodel.participants.codeactions.missinggrammar;
+
+import org.eclipse.lemminx.extensions.generators.FileContentGeneratorSettings;
+import org.eclipse.lemminx.extensions.generators.xml2rnc.RelaxNGCompactGeneratorSettings;
+
+/**
+ * Code action resolver participant to generate the missing RelaxNG Compact
+ * Syntax (.rnc) file which is declared in the XML as association via xml-model.
+ *
+ */
+public class GenerateRelaxNGCompactCodeActionResolver extends AbstractGenerateGrammarCodeActionResolver {
+
+	public static final String PARTICIPANT_ID = GenerateRelaxNGCompactCodeActionResolver.class.getName();
+
+	@Override
+	protected FileContentGeneratorSettings getFileContentGeneratorSettings() {
+		return new RelaxNGCompactGeneratorSettings();
+	}
+
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/nogrammarconstraints/GenerateRelaxNGCompactSchemaCodeActionResolver.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/nogrammarconstraints/GenerateRelaxNGCompactSchemaCodeActionResolver.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.contentmodel.participants.codeactions.nogrammarconstraints;
+
+import static org.eclipse.lemminx.extensions.contentmodel.participants.codeactions.nogrammarconstraints.NoGrammarConstraintsCodeAction.createXmlModelEdit;
+
+import org.eclipse.lemminx.commons.BadLocationException;
+import org.eclipse.lemminx.dom.DOMDocument;
+import org.eclipse.lemminx.extensions.generators.FileContentGeneratorSettings;
+import org.eclipse.lemminx.extensions.generators.xml2rnc.RelaxNGCompactGeneratorSettings;
+import org.eclipse.lemminx.settings.SharedSettings;
+import org.eclipse.lsp4j.TextDocumentEdit;
+
+/**
+ * Code action resolver participant used to:
+ *
+ * <ul>
+ * <li>generate the RelaxNG Compact Syntax file for the given DOM document</li>
+ * <li>generate the association in the XML to bind it with the generated RelaxNG
+ * Compact schema</li>
+ * </ul>
+ *
+ */
+public class GenerateRelaxNGCompactSchemaCodeActionResolver
+		extends AbstractGenerateGrammarAndAssociationResolveCodeActionParticipant {
+
+	public static final String PARTICIPANT_ID = GenerateRelaxNGCompactSchemaCodeActionResolver.class.getName();
+
+	@Override
+	protected TextDocumentEdit createFileEdit(String grammarFileName, DOMDocument document,
+			SharedSettings sharedSettings) throws BadLocationException {
+		return createXmlModelEdit(grammarFileName, null, document, sharedSettings);
+	}
+
+	@Override
+	protected FileContentGeneratorSettings getFileContentGeneratorSettings() {
+		return new RelaxNGCompactGeneratorSettings();
+	}
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/nogrammarconstraints/NoGrammarConstraintsCodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/nogrammarconstraints/NoGrammarConstraintsCodeAction.java
@@ -33,6 +33,7 @@ import org.eclipse.lemminx.dom.DOMElement;
 import org.eclipse.lemminx.extensions.generators.FileContentGeneratorManager;
 import org.eclipse.lemminx.extensions.generators.xml2dtd.DTDGeneratorSettings;
 import org.eclipse.lemminx.extensions.generators.xml2relaxng.RelaxNGGeneratorSettings;
+import org.eclipse.lemminx.extensions.generators.xml2rnc.RelaxNGCompactGeneratorSettings;
 import org.eclipse.lemminx.extensions.generators.xml2xsd.XMLSchemaGeneratorSettings;
 import org.eclipse.lemminx.services.data.DataEntryField;
 import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionParticipant;
@@ -74,6 +75,8 @@ public class NoGrammarConstraintsCodeAction implements ICodeActionParticipant {
 				new GenerateXMLModelWithDTDCodeActionResolver());
 		resolveCodeActionParticipants.put(GenerateRelaxNGSchemaCodeActionResolver.PARTICIPANT_ID,
 				new GenerateRelaxNGSchemaCodeActionResolver());
+		resolveCodeActionParticipants.put(GenerateRelaxNGCompactSchemaCodeActionResolver.PARTICIPANT_ID,
+				new GenerateRelaxNGCompactSchemaCodeActionResolver());
 	}
 
 	@Override
@@ -144,7 +147,24 @@ public class NoGrammarConstraintsCodeAction implements ICodeActionParticipant {
 			CodeAction relaxNGWithXmlModelAction = createRelaxNGCodeAction(rngURI, rngFileName, rngTemplate, request,
 					cancelChecker);
 			codeActions.add(relaxNGWithXmlModelAction);
-			
+
+			// ---------- Relax NG Compact
+
+			String rncURI = getGrammarURI(document.getDocumentURI(), "rnc");
+			String rncFileName = getFileName(rncURI);
+			String rncTemplate = null;
+			if (!request.canSupportResolve()) {
+				SharedSettings rncSharedSettings = request.getSharedSettings();
+				FileContentGeneratorManager rncGenerator = request.getComponent(FileContentGeneratorManager.class);
+				rncTemplate = rncGenerator.generate(document, rncSharedSettings, new RelaxNGCompactGeneratorSettings(),
+						cancelChecker);
+			}
+
+			// xml-model
+			CodeAction relaxNGCompactWithXmlModelAction = createRelaxNGCompactCodeAction(rncURI, rncFileName,
+					rncTemplate, request, cancelChecker);
+			codeActions.add(relaxNGCompactWithXmlModelAction);
+
 			// ---------- Open Binding Wizard
 			SharedSettings sharedSettings = request.getSharedSettings();
 			if (sharedSettings.isBindingWizardSupport()) {
@@ -224,6 +244,21 @@ public class NoGrammarConstraintsCodeAction implements ICodeActionParticipant {
 		SharedSettings sharedSettings = request.getSharedSettings();
 		TextDocumentEdit relaxNGWithXMLModelEdit = createXmlModelEdit(rngFileName, null, document, sharedSettings);
 		return createGrammarFileAndBindIt(title, rngURI, rngTemplate, relaxNGWithXMLModelEdit, diagnostic);
+	}
+
+	private CodeAction createRelaxNGCompactCodeAction(String rncURI, String rncFileName, String rncTemplate,
+			ICodeActionRequest request, CancelChecker cancelChecker) throws BadLocationException {
+		Diagnostic diagnostic = request.getDiagnostic();
+		DOMDocument document = request.getDocument();
+		String title = "Generate '" + rncFileName + "' and bind with RelaxNG Compact";
+		if (request.canSupportResolve()) {
+			return createGenerateFileUnresolvedCodeAction(rncURI, title, diagnostic, document,
+					GenerateRelaxNGCompactSchemaCodeActionResolver.PARTICIPANT_ID);
+		}
+		SharedSettings sharedSettings = request.getSharedSettings();
+		TextDocumentEdit relaxNGCompactWithXMLModelEdit = createXmlModelEdit(rncFileName, null, document,
+				sharedSettings);
+		return createGrammarFileAndBindIt(title, rncURI, rncTemplate, relaxNGCompactWithXMLModelEdit, diagnostic);
 	}
 
 	private static CodeAction createGenerateFileUnresolvedCodeAction(String generateFileURI, String title,

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/generators/FileContentGeneratorManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/generators/FileContentGeneratorManager.java
@@ -20,6 +20,8 @@ import org.eclipse.lemminx.extensions.generators.xml2xsd.XML2XMLSchemaGenerator;
 import org.eclipse.lemminx.extensions.generators.xml2xsd.XMLSchemaGeneratorSettings;
 import org.eclipse.lemminx.extensions.generators.xml2relaxng.XML2RelaxNGGenerator;
 import org.eclipse.lemminx.extensions.generators.xml2relaxng.RelaxNGGeneratorSettings;
+import org.eclipse.lemminx.extensions.generators.xml2rnc.XML2RelaxNGCompactGenerator;
+import org.eclipse.lemminx.extensions.generators.xml2rnc.RelaxNGCompactGeneratorSettings;
 import org.eclipse.lemminx.services.IXMLFullFormatter;
 import org.eclipse.lemminx.settings.SharedSettings;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
@@ -55,6 +57,7 @@ public class FileContentGeneratorManager {
 		registerGenerator(new XML2DTDGenerator(), DTDGeneratorSettings.class);
 		registerGenerator(new XML2XMLSchemaGenerator(), XMLSchemaGeneratorSettings.class);
 		registerGenerator(new XML2RelaxNGGenerator(), RelaxNGGeneratorSettings.class);
+		registerGenerator(new XML2RelaxNGCompactGenerator(), RelaxNGCompactGeneratorSettings.class);
 	}
 
 	/**

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/generators/xml2rnc/RelaxNGCompactGeneratorSettings.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/generators/xml2rnc/RelaxNGCompactGeneratorSettings.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.generators.xml2rnc;
+
+import org.eclipse.lemminx.extensions.generators.FileContentGeneratorSettings;
+
+/**
+ * RelaxNG Compact Syntax generator settings.
+ *
+ */
+public class RelaxNGCompactGeneratorSettings extends FileContentGeneratorSettings {
+
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/generators/xml2rnc/XML2RelaxNGCompactGenerator.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/generators/xml2rnc/XML2RelaxNGCompactGenerator.java
@@ -1,0 +1,246 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.generators.xml2rnc;
+
+import java.util.Collection;
+import java.util.Set;
+
+import org.eclipse.lemminx.extensions.generators.AbstractXML2GrammarGenerator;
+import org.eclipse.lemminx.extensions.generators.AttributeDeclaration;
+import org.eclipse.lemminx.extensions.generators.AttributeDeclaration.DataType;
+import org.eclipse.lemminx.extensions.generators.Cardinality;
+import org.eclipse.lemminx.extensions.generators.ElementDeclaration;
+import org.eclipse.lemminx.extensions.generators.Grammar;
+import org.eclipse.lemminx.services.IXMLFullFormatter;
+import org.eclipse.lemminx.settings.SharedSettings;
+import org.eclipse.lemminx.utils.StringUtils;
+import org.eclipse.lemminx.utils.XMLBuilder;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+import org.w3c.dom.Document;
+
+/**
+ * File Generator implementation to generate RelaxNG Compact Syntax (.rnc) from
+ * a given XML source.
+ *
+ */
+public class XML2RelaxNGCompactGenerator extends AbstractXML2GrammarGenerator<RelaxNGCompactGeneratorSettings> {
+
+	private static final String XML_SCHEMA_DATATYPES = "http://www.w3.org/2001/XMLSchema-datatypes";
+
+	private static final String NL = System.lineSeparator();
+
+	@Override
+	public String generate(Document prototypeDocument, SharedSettings sharedSettings,
+			RelaxNGCompactGeneratorSettings generatorSettings, IXMLFullFormatter formatter,
+			CancelChecker cancelChecker) {
+		// RNC is not XML, skip the XML formatter
+		return super.generate(prototypeDocument, sharedSettings, generatorSettings, null, cancelChecker);
+	}
+
+	@Override
+	protected void generate(Grammar grammar, RelaxNGCompactGeneratorSettings settings, XMLBuilder rnc,
+			CancelChecker cancelChecker) {
+		String targetNamespace = grammar.getDefaultNamespace();
+		if (!StringUtils.isEmpty(targetNamespace)) {
+			rnc.append("default namespace = \"");
+			rnc.append(targetNamespace);
+			rnc.append("\"");
+			rnc.append(NL);
+		}
+		rnc.append("datatypes xsd = \"");
+		rnc.append(XML_SCHEMA_DATATYPES);
+		rnc.append("\"");
+		rnc.append(NL);
+
+		ElementDeclaration rootElement = grammar.getElements().stream().findFirst().orElse(null);
+		String rootElementName = rootElement == null ? "" : rootElement.getName();
+		rnc.append(NL);
+		rnc.append("start = ");
+		rnc.append(rootElementName);
+		rnc.append("Content");
+		rnc.append(NL);
+
+		for (ElementDeclaration element : grammar.getElements()) {
+			cancelChecker.checkCanceled();
+			rnc.append(NL);
+			generateRncElement(rnc, element, settings, rootElementName + "Content", cancelChecker);
+		}
+	}
+
+	private void generateRncElement(XMLBuilder rnc, ElementDeclaration elementDecl,
+			RelaxNGCompactGeneratorSettings settings, String patternName, CancelChecker cancelChecker) {
+		Collection<ElementDeclaration> children = elementDecl.getElements();
+		Collection<AttributeDeclaration> attributes = elementDecl.getAttributes();
+		boolean hasChildren = !children.isEmpty();
+		boolean hasAttributes = !attributes.isEmpty();
+		boolean hasCharacterContent = elementDecl.hasCharacterContent();
+		boolean mixedContent = hasChildren && hasCharacterContent;
+
+		String name = elementDecl.getName();
+
+		rnc.append(patternName);
+		rnc.append(" = element ");
+		rnc.append(name);
+		rnc.append(" {");
+
+		if (!hasChildren && !hasAttributes) {
+			if (hasCharacterContent) {
+				rnc.append(" text");
+			} else {
+				rnc.append(" empty");
+			}
+			rnc.append(" }");
+			rnc.append(NL);
+		} else {
+			rnc.append(NL);
+			boolean hasContent = false;
+
+			if (mixedContent) {
+				rnc.append("  mixed {");
+				rnc.append(NL);
+				generateChildRefs(rnc, elementDecl, children, true, cancelChecker);
+				rnc.append(NL);
+				rnc.append("  }");
+				hasContent = true;
+			} else if (hasCharacterContent && !hasChildren) {
+				rnc.append("  text");
+				hasContent = true;
+			}
+
+			if (hasChildren && !mixedContent) {
+				generateChildRefs(rnc, elementDecl, children, false, cancelChecker);
+				hasContent = true;
+			}
+
+			if (hasAttributes) {
+				generateAttributes(rnc, attributes, settings, hasContent, cancelChecker);
+			}
+
+			rnc.append(NL);
+			rnc.append("}");
+			rnc.append(NL);
+
+			for (ElementDeclaration child : children) {
+				generateRncElement(rnc, child, settings, child.getName() + "Content", cancelChecker);
+			}
+		}
+	}
+
+	private void generateChildRefs(XMLBuilder rnc, ElementDeclaration elementDecl,
+			Collection<ElementDeclaration> children, boolean mixedContent, CancelChecker cancelChecker) {
+		boolean sequenced = elementDecl.getChildrenProperties().isSequenced();
+		String indent = mixedContent ? "    " : "  ";
+		String separator = sequenced ? "," : " &";
+
+		boolean first = true;
+		for (ElementDeclaration child : children) {
+			cancelChecker.checkCanceled();
+			String childName = child.getName();
+			Cardinality childCardinality = elementDecl.getChildrenProperties().getCardinalities().get(childName);
+
+			if (!first) {
+				rnc.append(separator);
+				rnc.append(NL);
+			}
+			first = false;
+
+			rnc.append(indent);
+			rnc.append(childName);
+			rnc.append("Content");
+
+			if (childCardinality != null) {
+				if (childCardinality.getMin() == 0) {
+					rnc.append("?");
+				} else if (childCardinality.getMax() > 1) {
+					rnc.append("+");
+				}
+			}
+		}
+	}
+
+	private void generateAttributes(XMLBuilder rnc, Collection<AttributeDeclaration> attributes,
+			RelaxNGCompactGeneratorSettings settings, boolean needsCommaBefore, CancelChecker cancelChecker) {
+		boolean needsSeparator = needsCommaBefore;
+		for (AttributeDeclaration attribute : attributes) {
+			cancelChecker.checkCanceled();
+
+			boolean required = attribute.isRequired();
+			boolean fixed = attribute.isFixedValue(settings);
+			boolean enums = attribute.isEnums(settings);
+			String rncType = getRncType(attribute.getDataType());
+
+			if (needsSeparator) {
+				rnc.append(",");
+				rnc.append(NL);
+			}
+			needsSeparator = true;
+
+			rnc.append("  attribute ");
+			rnc.append(attribute.getName());
+			rnc.append(" {");
+
+			if (enums && !fixed) {
+				Set<String> values = attribute.getValues();
+				rnc.append(" ");
+				boolean firstValue = true;
+				for (String value : values) {
+					cancelChecker.checkCanceled();
+					if (!firstValue) {
+						rnc.append(" | ");
+					}
+					firstValue = false;
+					rnc.append("\"");
+					rnc.append(value);
+					rnc.append("\"");
+				}
+				rnc.append(" }");
+			} else if (fixed) {
+				String value = attribute.getValues().stream().findFirst().orElse(null);
+				rnc.append(" \"");
+				rnc.append(value);
+				rnc.append("\" }");
+			} else if (rncType != null) {
+				rnc.append(" ");
+				rnc.append(rncType);
+				rnc.append(" }");
+			} else {
+				rnc.append(" text }");
+			}
+
+			if (!required) {
+				rnc.append("?");
+			}
+		}
+	}
+
+	private static String getRncType(DataType dataType) {
+		switch (dataType) {
+			case DATE:
+				return "xsd:date";
+			case DATE_TIME:
+				return "xsd:dateTime";
+			case INTEGER:
+				return "xsd:integer";
+			case DECIMAL:
+				return "xsd:decimal";
+			case BOOLEAN:
+				return "xsd:boolean";
+			default:
+				return null;
+		}
+	}
+
+	@Override
+	protected String getFileExtension() {
+		return "rnc";
+	}
+}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLProblemsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLProblemsTest.java
@@ -29,6 +29,7 @@ import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.extensions.contentmodel.participants.XMLSyntaxErrorCode;
 import org.eclipse.lemminx.extensions.contentmodel.participants.codeactions.nogrammarconstraints.GenerateDocTypeCodeActionResolver;
+import org.eclipse.lemminx.extensions.contentmodel.participants.codeactions.nogrammarconstraints.GenerateRelaxNGCompactSchemaCodeActionResolver;
 import org.eclipse.lemminx.extensions.contentmodel.participants.codeactions.nogrammarconstraints.GenerateRelaxNGSchemaCodeActionResolver;
 import org.eclipse.lemminx.extensions.contentmodel.participants.codeactions.nogrammarconstraints.GenerateXMLModelWithDTDCodeActionResolver;
 import org.eclipse.lemminx.extensions.contentmodel.participants.codeactions.nogrammarconstraints.GenerateXMLModelWithXSDCodeActionResolver;
@@ -105,6 +106,11 @@ public class XMLProblemsTest extends AbstractCacheBasedTest {
 				"    </element>" + lineSeparator() + //
 				"  </define>" + lineSeparator() + //
 				"</grammar>";
+		String rncTemplate = "datatypes xsd = \"http://www.w3.org/2001/XMLSchema-datatypes\"" + lineSeparator() + //
+				lineSeparator() + //
+				"start = rootContent" + lineSeparator() + //
+				lineSeparator() + //
+				"rootContent = element root { empty }" + lineSeparator();
 		testCodeActionsFor(xml, d, null, settings,
 				// XSD with xsi:noNamespaceSchemaLocation
 				ca(d, //
@@ -142,6 +148,13 @@ public class XMLProblemsTest extends AbstractCacheBasedTest {
 								rngTemplate), //
 						teOp("test.xml", 0, 0, 0, 0, //
 								"<?xml-model href=\"test.rng\"?>" + lineSeparator())),
+				// RelaxNG Compact with xml-model
+				ca(d, //
+						createFile("test.rnc", false), //
+						teOp("test.rnc", 0, 0, 0, 0, //
+								rncTemplate), //
+						teOp("test.xml", 0, 0, 0, 0, //
+								"<?xml-model href=\"test.rnc\"?>" + lineSeparator())),
 				// Open binding wizard command
 				ca(d, new Command("Bind to existing grammar/schema", OPEN_BINDING_WIZARD,
 						Arrays.asList(new Object[] { "test.xml" }))));
@@ -173,6 +186,11 @@ public class XMLProblemsTest extends AbstractCacheBasedTest {
 				"    </element>" + lineSeparator() + //
 				"  </define>" + lineSeparator() + //
 				"</grammar>";
+		String rncTemplate = "datatypes xsd = \"http://www.w3.org/2001/XMLSchema-datatypes\"" + lineSeparator() + //
+				lineSeparator() + //
+				"start = rootContent" + lineSeparator() + //
+				lineSeparator() + //
+				"rootContent = element root { empty }" + lineSeparator();
 		testCodeActionsFor(xml, d, null, settings,
 				// XSD with xsi:noNamespaceSchemaLocation
 				ca(d, //
@@ -210,6 +228,13 @@ public class XMLProblemsTest extends AbstractCacheBasedTest {
 								rngTemplate), //
 						teOp("test.xml", 0, 0, 0, 0, //
 								"<?xml-model href=\"test.rng\"?>" + lineSeparator())),
+				// RelaxNG Compact with xml-model
+				ca(d, //
+						createFile("test.rnc", false), //
+						teOp("test.rnc", 0, 0, 0, 0, //
+								rncTemplate), //
+						teOp("test.xml", 0, 0, 0, 0, //
+								"<?xml-model href=\"test.rnc\"?>" + lineSeparator())),
 				// Open binding wizard command
 				ca(d, new Command("Bind to existing grammar/schema", OPEN_BINDING_WIZARD,
 						Arrays.asList(new Object[] { "test.xml" }))));
@@ -238,6 +263,8 @@ public class XMLProblemsTest extends AbstractCacheBasedTest {
 				ca(d, createData("test.xml", GenerateXMLModelWithDTDCodeActionResolver.PARTICIPANT_ID, "test.dtd")),
 				// RelaxNG with xml-model
 				ca(d, createData("test.xml", GenerateRelaxNGSchemaCodeActionResolver.PARTICIPANT_ID, "test.rng")),
+				// RelaxNG Compact with xml-model
+				ca(d, createData("test.xml", GenerateRelaxNGCompactSchemaCodeActionResolver.PARTICIPANT_ID, "test.rnc")),
 				// Open binding wizard command
 				ca(d, new Command("Bind to existing grammar/schema", OPEN_BINDING_WIZARD,
 						Arrays.asList(new Object[] { "test.xml" }))), //

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/generators/xml2rnc/XML2RelaxNGCompactGeneratorTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/generators/xml2rnc/XML2RelaxNGCompactGeneratorTest.java
@@ -1,0 +1,585 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.generators.xml2rnc;
+
+import static java.lang.System.lineSeparator;
+import static org.eclipse.lemminx.XMLAssert.assertGrammarGenerator;
+
+import java.io.IOException;
+
+import org.eclipse.lemminx.AbstractCacheBasedTest;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for generating RelaxNG Compact Syntax (.rnc) schema from XML source.
+ *
+ */
+public class XML2RelaxNGCompactGeneratorTest extends AbstractCacheBasedTest {
+
+	@Test
+	public void basic() throws IOException {
+		String xml = "<note>\r\n" + //
+				"	<to>Tove</to>\r\n" + //
+				"	<from>Jani</from>\r\n" + //
+				"	<heading>Reminder</heading>\r\n" + //
+				"	<body>Don't forget me this weekend!</body>\r\n" + //
+				"</note>";
+		String rnc = "datatypes xsd = \"http://www.w3.org/2001/XMLSchema-datatypes\"" + lineSeparator() + //
+				lineSeparator() + //
+				"start = noteContent" + lineSeparator() + //
+				lineSeparator() + //
+				"noteContent = element note {" + lineSeparator() + //
+				"  toContent," + lineSeparator() + //
+				"  fromContent," + lineSeparator() + //
+				"  headingContent," + lineSeparator() + //
+				"  bodyContent" + lineSeparator() + //
+				"}" + lineSeparator() + //
+				"toContent = element to { text }" + lineSeparator() + //
+				"fromContent = element from { text }" + lineSeparator() + //
+				"headingContent = element heading { text }" + lineSeparator() + //
+				"bodyContent = element body { text }" + lineSeparator();
+		assertGrammarGenerator(xml, new RelaxNGCompactGeneratorSettings(), rnc);
+	}
+
+	@Test
+	public void basicWithNS() throws IOException {
+		String xml = "<note xmlns=\"https://www.w3schools.com\">\r\n" + //
+				"	<to>Tove</to>\r\n" + //
+				"	<from>Jani</from>\r\n" + //
+				"	<heading>Reminder</heading>\r\n" + //
+				"	<body>Don't forget me this weekend!</body>\r\n" + //
+				"</note>";
+		String rnc = "default namespace = \"https://www.w3schools.com\"" + lineSeparator() + //
+				"datatypes xsd = \"http://www.w3.org/2001/XMLSchema-datatypes\"" + lineSeparator() + //
+				lineSeparator() + //
+				"start = noteContent" + lineSeparator() + //
+				lineSeparator() + //
+				"noteContent = element note {" + lineSeparator() + //
+				"  toContent," + lineSeparator() + //
+				"  fromContent," + lineSeparator() + //
+				"  headingContent," + lineSeparator() + //
+				"  bodyContent" + lineSeparator() + //
+				"}" + lineSeparator() + //
+				"toContent = element to { text }" + lineSeparator() + //
+				"fromContent = element from { text }" + lineSeparator() + //
+				"headingContent = element heading { text }" + lineSeparator() + //
+				"bodyContent = element body { text }" + lineSeparator();
+		assertGrammarGenerator(xml, new RelaxNGCompactGeneratorSettings(), rnc);
+	}
+
+	@Test
+	public void emptyElement() throws IOException {
+		String xml = "<root />";
+		String rnc = "datatypes xsd = \"http://www.w3.org/2001/XMLSchema-datatypes\"" + lineSeparator() + //
+				lineSeparator() + //
+				"start = rootContent" + lineSeparator() + //
+				lineSeparator() + //
+				"rootContent = element root { empty }" + lineSeparator();
+		assertGrammarGenerator(xml, new RelaxNGCompactGeneratorSettings(), rnc);
+	}
+
+	@Test
+	public void textOnlyElement() throws IOException {
+		String xml = "<root>Hello</root>";
+		String rnc = "datatypes xsd = \"http://www.w3.org/2001/XMLSchema-datatypes\"" + lineSeparator() + //
+				lineSeparator() + //
+				"start = rootContent" + lineSeparator() + //
+				lineSeparator() + //
+				"rootContent = element root { text }" + lineSeparator();
+		assertGrammarGenerator(xml, new RelaxNGCompactGeneratorSettings(), rnc);
+	}
+
+	@Test
+	public void decimalAttr() throws IOException {
+		String xml = "<note version=\"1.2\" />";
+		String rnc = "datatypes xsd = \"http://www.w3.org/2001/XMLSchema-datatypes\"" + lineSeparator() + //
+				lineSeparator() + //
+				"start = noteContent" + lineSeparator() + //
+				lineSeparator() + //
+				"noteContent = element note {" + lineSeparator() + //
+				"  attribute version { xsd:decimal }" + lineSeparator() + //
+				"}" + lineSeparator();
+		assertGrammarGenerator(xml, new RelaxNGCompactGeneratorSettings(), rnc);
+	}
+
+	@Test
+	public void decimalAttrAndContent() throws IOException {
+		String xml = "<note version=\"1.2\" >ABCD</note>";
+		String rnc = "datatypes xsd = \"http://www.w3.org/2001/XMLSchema-datatypes\"" + lineSeparator() + //
+				lineSeparator() + //
+				"start = noteContent" + lineSeparator() + //
+				lineSeparator() + //
+				"noteContent = element note {" + lineSeparator() + //
+				"  text," + lineSeparator() + //
+				"  attribute version { xsd:decimal }" + lineSeparator() + //
+				"}" + lineSeparator();
+		assertGrammarGenerator(xml, new RelaxNGCompactGeneratorSettings(), rnc);
+	}
+
+	@Test
+	public void decimalAttrAndMixedContent() throws IOException {
+		String xml = "<note version=\"1.2\" >AB<C/>D</note>";
+		String rnc = "datatypes xsd = \"http://www.w3.org/2001/XMLSchema-datatypes\"" + lineSeparator() + //
+				lineSeparator() + //
+				"start = noteContent" + lineSeparator() + //
+				lineSeparator() + //
+				"noteContent = element note {" + lineSeparator() + //
+				"  mixed {" + lineSeparator() + //
+				"    CContent" + lineSeparator() + //
+				"  }," + lineSeparator() + //
+				"  attribute version { xsd:decimal }" + lineSeparator() + //
+				"}" + lineSeparator() + //
+				"CContent = element C { empty }" + lineSeparator();
+		assertGrammarGenerator(xml, new RelaxNGCompactGeneratorSettings(), rnc);
+	}
+
+	@Test
+	public void multipleAttrs() throws IOException {
+		String xml = "<note version=\"1.2\" >\r\n" + //
+				"	<to attr1=\"abcd\" attr2=\"efgh\">Tove</to>\r\n" + //
+				"	<from>Jani</from>\r\n" + //
+				"	<heading>Reminder</heading>\r\n" + //
+				"	<body>Don't forget me this weekend!</body>\r\n" + //
+				"</note>";
+		String rnc = "datatypes xsd = \"http://www.w3.org/2001/XMLSchema-datatypes\"" + lineSeparator() + //
+				lineSeparator() + //
+				"start = noteContent" + lineSeparator() + //
+				lineSeparator() + //
+				"noteContent = element note {" + lineSeparator() + //
+				"  toContent," + lineSeparator() + //
+				"  fromContent," + lineSeparator() + //
+				"  headingContent," + lineSeparator() + //
+				"  bodyContent," + lineSeparator() + //
+				"  attribute version { xsd:decimal }" + lineSeparator() + //
+				"}" + lineSeparator() + //
+				"toContent = element to {" + lineSeparator() + //
+				"  text," + lineSeparator() + //
+				"  attribute attr1 { text }," + lineSeparator() + //
+				"  attribute attr2 { text }" + lineSeparator() + //
+				"}" + lineSeparator() + //
+				"fromContent = element from { text }" + lineSeparator() + //
+				"headingContent = element heading { text }" + lineSeparator() + //
+				"bodyContent = element body { text }" + lineSeparator();
+		assertGrammarGenerator(xml, new RelaxNGCompactGeneratorSettings(), rnc);
+	}
+
+	@Test
+	public void mixedContent() {
+		String xml = "<a><b/>text</a>";
+		String rnc = "datatypes xsd = \"http://www.w3.org/2001/XMLSchema-datatypes\"" + lineSeparator() + //
+				lineSeparator() + //
+				"start = aContent" + lineSeparator() + //
+				lineSeparator() + //
+				"aContent = element a {" + lineSeparator() + //
+				"  mixed {" + lineSeparator() + //
+				"    bContent" + lineSeparator() + //
+				"  }" + lineSeparator() + //
+				"}" + lineSeparator() + //
+				"bContent = element b { empty }" + lineSeparator();
+		assertGrammarGenerator(xml, new RelaxNGCompactGeneratorSettings(), rnc);
+	}
+
+	@Test
+	public void threeLevel() {
+		String xml = "<a>\r\n" + //
+				"	<b>\r\n" + //
+				"		<c/>\r\n" + //
+				"	</b>\r\n" + //
+				"</a>";
+		String rnc = "datatypes xsd = \"http://www.w3.org/2001/XMLSchema-datatypes\"" + lineSeparator() + //
+				lineSeparator() + //
+				"start = aContent" + lineSeparator() + //
+				lineSeparator() + //
+				"aContent = element a {" + lineSeparator() + //
+				"  bContent" + lineSeparator() + //
+				"}" + lineSeparator() + //
+				"bContent = element b {" + lineSeparator() + //
+				"  cContent" + lineSeparator() + //
+				"}" + lineSeparator() + //
+				"cContent = element c { empty }" + lineSeparator();
+		assertGrammarGenerator(xml, new RelaxNGCompactGeneratorSettings(), rnc);
+	}
+
+	@Test
+	public void threeLevelAndText() {
+		String xml = "<a>\r\n" + //
+				"	<b>\r\n" + //
+				"		<c />\r\n" + //
+				"		<d>X</d>\r\n" + //
+				"	</b>\r\n" + //
+				"</a>";
+		String rnc = "datatypes xsd = \"http://www.w3.org/2001/XMLSchema-datatypes\"" + lineSeparator() + //
+				lineSeparator() + //
+				"start = aContent" + lineSeparator() + //
+				lineSeparator() + //
+				"aContent = element a {" + lineSeparator() + //
+				"  bContent" + lineSeparator() + //
+				"}" + lineSeparator() + //
+				"bContent = element b {" + lineSeparator() + //
+				"  cContent," + lineSeparator() + //
+				"  dContent" + lineSeparator() + //
+				"}" + lineSeparator() + //
+				"cContent = element c { empty }" + lineSeparator() + //
+				"dContent = element d { text }" + lineSeparator();
+		assertGrammarGenerator(xml, new RelaxNGCompactGeneratorSettings(), rnc);
+	}
+
+	@Test
+	public void occurrences() {
+		String xml = "<invoice xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"  xsi:noNamespaceSchemaLocation=\"grocery-invoice.xsd\">\r\n" + //
+				"  <item name=\"Rice\" price=\"4.99\" />\r\n" + //
+				"  <item name=\"Baked Beans\" price=\"1.99\" />\r\n" + //
+				"  <item name=\"Salad\" price=\"5.99\" />\r\n" + //
+				"</invoice>";
+		String rnc = "datatypes xsd = \"http://www.w3.org/2001/XMLSchema-datatypes\"" + lineSeparator() + //
+				lineSeparator() + //
+				"start = invoiceContent" + lineSeparator() + //
+				lineSeparator() + //
+				"invoiceContent = element invoice {" + lineSeparator() + //
+				"  itemContent+" + lineSeparator() + //
+				"}" + lineSeparator() + //
+				"itemContent = element item {" + lineSeparator() + //
+				"  attribute name { text }," + lineSeparator() + //
+				"  attribute price { xsd:decimal }" + lineSeparator() + //
+				"}" + lineSeparator();
+		assertGrammarGenerator(xml, new RelaxNGCompactGeneratorSettings(), rnc);
+	}
+
+	@Test
+	public void oneZeroOccurrences() {
+		String xml = "<root>\r\n" + //
+				"    <a>\r\n" + //
+				"        <b />\r\n" + //
+				"    </a>\r\n" + //
+				"    <a></a>\r\n" + //
+				"</root>";
+		String rnc = "datatypes xsd = \"http://www.w3.org/2001/XMLSchema-datatypes\"" + lineSeparator() + //
+				lineSeparator() + //
+				"start = rootContent" + lineSeparator() + //
+				lineSeparator() + //
+				"rootContent = element root {" + lineSeparator() + //
+				"  aContent+" + lineSeparator() + //
+				"}" + lineSeparator() + //
+				"aContent = element a {" + lineSeparator() + //
+				"  bContent?" + lineSeparator() + //
+				"}" + lineSeparator() + //
+				"bContent = element b { empty }" + lineSeparator();
+		assertGrammarGenerator(xml, new RelaxNGCompactGeneratorSettings(), rnc);
+	}
+
+	@Test
+	public void oneZeroOccurrences2() {
+		String xml = "<root>\r\n" + //
+				"    <a>\r\n" + //
+				"        <b />\r\n" + //
+				"    </a>\r\n" + //
+				"    <a>\r\n" + //
+				"        <c />\r\n" + //
+				"    </a>\r\n" + //
+				"    <a>\r\n" + //
+				"        <b />\r\n" + //
+				"        <c />\r\n" + //
+				"    </a>\r\n" + //
+				"    <a></a>\r\n" + //
+				"</root>";
+		String rnc = "datatypes xsd = \"http://www.w3.org/2001/XMLSchema-datatypes\"" + lineSeparator() + //
+				lineSeparator() + //
+				"start = rootContent" + lineSeparator() + //
+				lineSeparator() + //
+				"rootContent = element root {" + lineSeparator() + //
+				"  aContent+" + lineSeparator() + //
+				"}" + lineSeparator() + //
+				"aContent = element a {" + lineSeparator() + //
+				"  bContent?," + lineSeparator() + //
+				"  cContent?" + lineSeparator() + //
+				"}" + lineSeparator() + //
+				"bContent = element b { empty }" + lineSeparator() + //
+				"cContent = element c { empty }" + lineSeparator();
+		assertGrammarGenerator(xml, new RelaxNGCompactGeneratorSettings(), rnc);
+	}
+
+	@Test
+	public void interleave() {
+		String xml = "<root>\r\n" + //
+				"	<a>\r\n" + //
+				"		<c />\r\n" + //
+				"		<b />\r\n" + //
+				"	</a>\r\n" + //
+				"	<a>\r\n" + //
+				"		<b />\r\n" + //
+				"		<c />\r\n" + //
+				"	</a>\r\n" + //
+				"</root>";
+		String rnc = "datatypes xsd = \"http://www.w3.org/2001/XMLSchema-datatypes\"" + lineSeparator() + //
+				lineSeparator() + //
+				"start = rootContent" + lineSeparator() + //
+				lineSeparator() + //
+				"rootContent = element root {" + lineSeparator() + //
+				"  aContent+" + lineSeparator() + //
+				"}" + lineSeparator() + //
+				"aContent = element a {" + lineSeparator() + //
+				"  cContent &" + lineSeparator() + //
+				"  bContent" + lineSeparator() + //
+				"}" + lineSeparator() + //
+				"cContent = element c { empty }" + lineSeparator() + //
+				"bContent = element b { empty }" + lineSeparator();
+		assertGrammarGenerator(xml, new RelaxNGCompactGeneratorSettings(), rnc);
+	}
+
+	@Test
+	public void optionalAttribute() {
+		String xml = "<root>\r\n" + //
+				"	<item attr1=\"\" attr2=\"\"/>\r\n" + //
+				"	<item attr1=\"\" />\r\n" + //
+				"</root>";
+		String rnc = "datatypes xsd = \"http://www.w3.org/2001/XMLSchema-datatypes\"" + lineSeparator() + //
+				lineSeparator() + //
+				"start = rootContent" + lineSeparator() + //
+				lineSeparator() + //
+				"rootContent = element root {" + lineSeparator() + //
+				"  itemContent+" + lineSeparator() + //
+				"}" + lineSeparator() + //
+				"itemContent = element item {" + lineSeparator() + //
+				"  attribute attr1 { text }," + lineSeparator() + //
+				"  attribute attr2 { text }?" + lineSeparator() + //
+				"}" + lineSeparator();
+		assertGrammarGenerator(xml, new RelaxNGCompactGeneratorSettings(), rnc);
+	}
+
+	@Test
+	public void attrIDsAndFixed() {
+		String xml = "<root>\r\n" + //
+				"	<item attr1=\"id1\" attr2=\"A\" />\r\n" + //
+				"	<item attr1=\"id2\" attr2=\"A\" />\r\n" + //
+				"	<item attr1=\"id3\" attr2=\"A\" />\r\n" + //
+				"	<item attr1=\"id4\" attr2=\"A\" />\r\n" + //
+				"	<item attr1=\"id5\" attr2=\"A\" />\r\n" + //
+				"	<item attr1=\"id6\" attr2=\"A\" />\r\n" + //
+				"	<item attr1=\"id7\" attr2=\"A\" />\r\n" + //
+				"	<item attr1=\"id8\" attr2=\"A\" />\r\n" + //
+				"	<item attr1=\"id9\" attr2=\"A\" />\r\n" + //
+				"	<item attr1=\"id10\" attr2=\"A\" />\r\n" + //
+				"</root>";
+		String rnc = "datatypes xsd = \"http://www.w3.org/2001/XMLSchema-datatypes\"" + lineSeparator() + //
+				lineSeparator() + //
+				"start = rootContent" + lineSeparator() + //
+				lineSeparator() + //
+				"rootContent = element root {" + lineSeparator() + //
+				"  itemContent+" + lineSeparator() + //
+				"}" + lineSeparator() + //
+				"itemContent = element item {" + lineSeparator() + //
+				"  attribute attr1 { text }," + lineSeparator() + //
+				"  attribute attr2 { \"A\" }" + lineSeparator() + //
+				"}" + lineSeparator();
+		assertGrammarGenerator(xml, new RelaxNGCompactGeneratorSettings(), rnc);
+	}
+
+	@Test
+	public void attrIDsAndEnums() {
+		String xml = "<root>\r\n" + //
+				"	<item attr1=\"id1\" attr2=\"A\" />\r\n" + //
+				"	<item attr1=\"id2\" attr2=\"A\" />\r\n" + //
+				"	<item attr1=\"id3\" attr2=\"A\" />\r\n" + //
+				"	<item attr1=\"id4\" attr2=\"A\" />\r\n" + //
+				"	<item attr1=\"id5\" attr2=\"A\" />\r\n" + //
+				"	<item attr1=\"id6\" attr2=\"B\" />\r\n" + //
+				"	<item attr1=\"id7\" attr2=\"B\" />\r\n" + //
+				"	<item attr1=\"id8\" attr2=\"B\" />\r\n" + //
+				"	<item attr1=\"id9\" attr2=\"B\" />\r\n" + //
+				"	<item attr1=\"id10\" attr2=\"B\" />\r\n" + //
+				"</root>";
+		String rnc = "datatypes xsd = \"http://www.w3.org/2001/XMLSchema-datatypes\"" + lineSeparator() + //
+				lineSeparator() + //
+				"start = rootContent" + lineSeparator() + //
+				lineSeparator() + //
+				"rootContent = element root {" + lineSeparator() + //
+				"  itemContent+" + lineSeparator() + //
+				"}" + lineSeparator() + //
+				"itemContent = element item {" + lineSeparator() + //
+				"  attribute attr1 { text }," + lineSeparator() + //
+				"  attribute attr2 { \"A\" | \"B\" }" + lineSeparator() + //
+				"}" + lineSeparator();
+		assertGrammarGenerator(xml, new RelaxNGCompactGeneratorSettings(), rnc);
+	}
+
+	@Test
+	public void attrTypes() {
+		String xml = "<root>\r\n" + //
+				"	<item dateTime=\"2001-10-26T21:32:52+02:00\"\r\n" + //
+				"		  date=\"2001-10-26\"\r\n" + //
+				"         boolean=\"true\"\r\n" + //
+				"         integer=\"1\"\r\n" + //
+				"         decimal=\"1.2\"  />\r\n" + //
+				"</root>";
+		String rnc = "datatypes xsd = \"http://www.w3.org/2001/XMLSchema-datatypes\"" + lineSeparator() + //
+				lineSeparator() + //
+				"start = rootContent" + lineSeparator() + //
+				lineSeparator() + //
+				"rootContent = element root {" + lineSeparator() + //
+				"  itemContent" + lineSeparator() + //
+				"}" + lineSeparator() + //
+				"itemContent = element item {" + lineSeparator() + //
+				"  attribute dateTime { xsd:dateTime }," + lineSeparator() + //
+				"  attribute date { xsd:date }," + lineSeparator() + //
+				"  attribute boolean { xsd:boolean }," + lineSeparator() + //
+				"  attribute integer { xsd:integer }," + lineSeparator() + //
+				"  attribute decimal { xsd:decimal }" + lineSeparator() + //
+				"}" + lineSeparator();
+		assertGrammarGenerator(xml, new RelaxNGCompactGeneratorSettings(), rnc);
+	}
+
+	@Test
+	public void attrTypesWith2Occurs() {
+		String xml = "<root>\r\n" + //
+				"	<item dateTime=\"2001-10-26T21:32:52+02:00\"\r\n" + //
+				"		  date=\"2001-10-26\"\r\n" + //
+				"         boolean=\"true\"\r\n" + //
+				"         integer=\"1\"\r\n" + //
+				"         decimal=\"1.2\"  />\r\n" + //
+				"	<item dateTime=\"2001-10-26T21:32:52+02:00\"\r\n" + //
+				"		  date=\"2001-10-26\"\r\n" + //
+				"         boolean=\"true\"\r\n" + //
+				"         integer=\"1\"\r\n" + //
+				"         decimal=\"XXXXXXXXXXXXXXXXXXXXXX\"  />\r\n" + //
+				"</root>";
+		String rnc = "datatypes xsd = \"http://www.w3.org/2001/XMLSchema-datatypes\"" + lineSeparator() + //
+				lineSeparator() + //
+				"start = rootContent" + lineSeparator() + //
+				lineSeparator() + //
+				"rootContent = element root {" + lineSeparator() + //
+				"  itemContent+" + lineSeparator() + //
+				"}" + lineSeparator() + //
+				"itemContent = element item {" + lineSeparator() + //
+				"  attribute dateTime { xsd:dateTime }," + lineSeparator() + //
+				"  attribute date { xsd:date }," + lineSeparator() + //
+				"  attribute boolean { xsd:boolean }," + lineSeparator() + //
+				"  attribute integer { xsd:integer }," + lineSeparator() + //
+				"  attribute decimal { text }" + lineSeparator() + //
+				"}" + lineSeparator();
+		assertGrammarGenerator(xml, new RelaxNGCompactGeneratorSettings(), rnc);
+	}
+
+	@Test
+	public void singleEmptyChild() {
+		String xml = "<root><child/></root>";
+		String rnc = "datatypes xsd = \"http://www.w3.org/2001/XMLSchema-datatypes\"" + lineSeparator() + //
+				lineSeparator() + //
+				"start = rootContent" + lineSeparator() + //
+				lineSeparator() + //
+				"rootContent = element root {" + lineSeparator() + //
+				"  childContent" + lineSeparator() + //
+				"}" + lineSeparator() + //
+				"childContent = element child { empty }" + lineSeparator();
+		assertGrammarGenerator(xml, new RelaxNGCompactGeneratorSettings(), rnc);
+	}
+
+	@Test
+	public void attrOnlyElement() {
+		String xml = "<config debug=\"true\" version=\"2\" />";
+		String rnc = "datatypes xsd = \"http://www.w3.org/2001/XMLSchema-datatypes\"" + lineSeparator() + //
+				lineSeparator() + //
+				"start = configContent" + lineSeparator() + //
+				lineSeparator() + //
+				"configContent = element config {" + lineSeparator() + //
+				"  attribute debug { xsd:boolean }," + lineSeparator() + //
+				"  attribute version { xsd:integer }" + lineSeparator() + //
+				"}" + lineSeparator();
+		assertGrammarGenerator(xml, new RelaxNGCompactGeneratorSettings(), rnc);
+	}
+
+	@Test
+	public void deepNesting() {
+		String xml = "<a>\r\n" + //
+				"	<b>\r\n" + //
+				"		<c>\r\n" + //
+				"			<d>leaf</d>\r\n" + //
+				"		</c>\r\n" + //
+				"	</b>\r\n" + //
+				"</a>";
+		String rnc = "datatypes xsd = \"http://www.w3.org/2001/XMLSchema-datatypes\"" + lineSeparator() + //
+				lineSeparator() + //
+				"start = aContent" + lineSeparator() + //
+				lineSeparator() + //
+				"aContent = element a {" + lineSeparator() + //
+				"  bContent" + lineSeparator() + //
+				"}" + lineSeparator() + //
+				"bContent = element b {" + lineSeparator() + //
+				"  cContent" + lineSeparator() + //
+				"}" + lineSeparator() + //
+				"cContent = element c {" + lineSeparator() + //
+				"  dContent" + lineSeparator() + //
+				"}" + lineSeparator() + //
+				"dContent = element d { text }" + lineSeparator();
+		assertGrammarGenerator(xml, new RelaxNGCompactGeneratorSettings(), rnc);
+	}
+
+	@Test
+	public void multipleChildrenWithAttrs() {
+		String xml = "<catalog>\r\n" + //
+				"	<book id=\"1\" title=\"XML Guide\" />\r\n" + //
+				"	<book id=\"2\" title=\"Java Guide\" />\r\n" + //
+				"</catalog>";
+		String rnc = "datatypes xsd = \"http://www.w3.org/2001/XMLSchema-datatypes\"" + lineSeparator() + //
+				lineSeparator() + //
+				"start = catalogContent" + lineSeparator() + //
+				lineSeparator() + //
+				"catalogContent = element catalog {" + lineSeparator() + //
+				"  bookContent+" + lineSeparator() + //
+				"}" + lineSeparator() + //
+				"bookContent = element book {" + lineSeparator() + //
+				"  attribute id { xsd:integer }," + lineSeparator() + //
+				"  attribute title { text }" + lineSeparator() + //
+				"}" + lineSeparator();
+		assertGrammarGenerator(xml, new RelaxNGCompactGeneratorSettings(), rnc);
+	}
+
+	@Test
+	public void mixedContentMultipleChildren() {
+		String xml = "<p>Hello <b>bold</b> and <i>italic</i> text</p>";
+		String rnc = "datatypes xsd = \"http://www.w3.org/2001/XMLSchema-datatypes\"" + lineSeparator() + //
+				lineSeparator() + //
+				"start = pContent" + lineSeparator() + //
+				lineSeparator() + //
+				"pContent = element p {" + lineSeparator() + //
+				"  mixed {" + lineSeparator() + //
+				"    bContent," + lineSeparator() + //
+				"    iContent" + lineSeparator() + //
+				"  }" + lineSeparator() + //
+				"}" + lineSeparator() + //
+				"bContent = element b { text }" + lineSeparator() + //
+				"iContent = element i { text }" + lineSeparator();
+		assertGrammarGenerator(xml, new RelaxNGCompactGeneratorSettings(), rnc);
+	}
+
+	@Test
+	public void siblingDifferentTypes() {
+		String xml = "<root>\r\n" + //
+				"	<name>John</name>\r\n" + //
+				"	<age />\r\n" + //
+				"	<address>123 Main St</address>\r\n" + //
+				"</root>";
+		String rnc = "datatypes xsd = \"http://www.w3.org/2001/XMLSchema-datatypes\"" + lineSeparator() + //
+				lineSeparator() + //
+				"start = rootContent" + lineSeparator() + //
+				lineSeparator() + //
+				"rootContent = element root {" + lineSeparator() + //
+				"  nameContent," + lineSeparator() + //
+				"  ageContent," + lineSeparator() + //
+				"  addressContent" + lineSeparator() + //
+				"}" + lineSeparator() + //
+				"nameContent = element name { text }" + lineSeparator() + //
+				"ageContent = element age { empty }" + lineSeparator() + //
+				"addressContent = element address { text }" + lineSeparator();
+		assertGrammarGenerator(xml, new RelaxNGCompactGeneratorSettings(), rnc);
+	}
+}


### PR DESCRIPTION
Add RelaxNG Compact Syntax (.rnc) generator from XML

Fixes #842 #1406

Here a demo:

<img width="939" height="525" alt="RNGCompactGenerator" src="https://github.com/user-attachments/assets/826c6534-59b5-4f6f-9444-828bc28e3593" />
