### PR TITLE
Support <!-- @formatter:off/on --> comments to disable formatting

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/snippets/SnippetRegistry.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/snippets/SnippetRegistry.java
@@ -253,8 +253,7 @@ public class SnippetRegistry {
 			item.setKind(CompletionItemKind.Snippet);
 			item.setDocumentation(
 					Either.forRight(createDocumentation(snippet, model, canSupportMarkdown, lineDelimiter)));
-			String prefix = snippet.getPrefixes().get(0);
-			item.setFilterText(prefix);
+			item.setFilterText(String.join(" ", snippet.getPrefixes()));
 			item.setDetail(snippet.getDescription());
 			Range range = replaceRange;
 			if (!StringUtils.isEmpty(snippet.getSuffix()) && suffixProvider != null) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMCharacterData.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMCharacterData.java
@@ -97,6 +97,36 @@ public abstract class DOMCharacterData extends DOMTreeNode implements CharacterD
 		return false;
 	}
 
+	/**
+	 * Returns true if the trimmed content of this character data equals the
+	 * given text, using zero-allocation char-by-char comparison against the
+	 * document's {@link CharSequence}.
+	 *
+	 * @param text the text to match against the trimmed content.
+	 * @return true if the trimmed content equals the given text.
+	 */
+	public boolean containsText(String text) {
+		CharSequence docText = getOwnerDocument().getTextSequence();
+		int s = getStartContent();
+		int e = getEndContent();
+		while (s < e && Character.isWhitespace(docText.charAt(s))) {
+			s++;
+		}
+		while (e > s && Character.isWhitespace(docText.charAt(e - 1))) {
+			e--;
+		}
+		int len = e - s;
+		if (len != text.length()) {
+			return false;
+		}
+		for (int i = 0; i < len; i++) {
+			if (docText.charAt(s + i) != text.charAt(i)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
 	public boolean hasData() {
 		return getStartContent() < getEndContent();
 	}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/DOMElementFormatter.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/DOMElementFormatter.java
@@ -299,6 +299,10 @@ public class DOMElementFormatter {
 
 	private int formatEndTagElement(DOMElement element, XMLFormattingConstraints parentConstraints,
 			XMLFormattingConstraints constraints, List<TextEdit> edits) {
+		// When formatting is off, skip end tag formatting to preserve whitespace
+		if (formatterDocument.isFormatterOff()) {
+			return element.getTagName() != null ? element.getTagName().length() + 2 : 0;
+		}
 		// 1) remove / add some spaces on the left of the end tag element
 		// before formatting : [space][space]</a>
 		// after formatting : </a>

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/XMLFormatterDocument.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/XMLFormatterDocument.java
@@ -91,6 +91,21 @@ public class XMLFormatterDocument {
 
 	private CancelChecker cancelChecker;
 
+	private static final String FORMATTER_OFF = "@formatter:off";
+	private static final String FORMATTER_ON = "@formatter:on";
+
+	private boolean formatterOff;
+
+	/**
+	 * Returns true if formatting is currently turned off by a
+	 * {@code <!-- @formatter:off -->} comment.
+	 *
+	 * @return true if formatting is off.
+	 */
+	public boolean isFormatterOff() {
+		return formatterOff;
+	}
+
 	/**
 	 * XML formatter document.
 	 */
@@ -325,6 +340,32 @@ public class XMLFormatterDocument {
 
 	public void format(DOMNode child, XMLFormattingConstraints parentConstraints, int start, int end,
 			List<TextEdit> edits) {
+		// Support @formatter:off/on to toggle formatting (see issue #1648)
+
+		if (child.getNodeType() == Node.COMMENT_NODE) {
+			DOMComment comment = (DOMComment) child;
+			if (!formatterOff && comment.containsText(FORMATTER_OFF)) {
+				commentFormatter.formatComment(comment, parentConstraints, start, end, edits);
+				formatterOff = true;
+				return;
+			}
+			if (formatterOff && comment.containsText(FORMATTER_ON)) {
+				formatterOff = false;
+				if (isMaxLineWidthSupported()) {
+					parentConstraints.setAvailableLineWidth(
+							updateLineWidthWithLastLine(child, parentConstraints.getAvailableLineWidth()));
+				}
+				return;
+			}
+		}
+
+		if (formatterOff) {
+			if (isMaxLineWidthSupported()) {
+				parentConstraints.setAvailableLineWidth(
+						updateLineWidthWithLastLine(child, parentConstraints.getAvailableLineWidth()));
+			}
+			return;
+		}
 
 		switch (child.getNodeType()) {
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/capabilities/ServerCapabilitiesConstants.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/capabilities/ServerCapabilitiesConstants.java
@@ -86,7 +86,7 @@ public class ServerCapabilitiesConstants {
 	public static final String INLINE_COMPLETION_ID = UUID.randomUUID().toString();
 
 	public static final CompletionOptions DEFAULT_COMPLETION_OPTIONS = new CompletionOptions(true,
-			Arrays.asList(".", ":", "<", "\"", "=", "/", "\\", "?", "\'", "&", "#"));
+			Arrays.asList(".", ":", "<", "\"", "=", "/", "\\", "?", "\'", "&", "#", "@"));
 	public static final TextDocumentSyncKind DEFAULT_SYNC_OPTION = TextDocumentSyncKind.Full;
 	public static final DocumentLinkOptions DEFAULT_LINK_OPTIONS = new DocumentLinkOptions(true);
 	public static final RenameOptions DEFAULT_RENAME_OPTIONS = new RenameOptions(true);

--- a/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/services/snippets/comment-snippets.json
+++ b/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/services/snippets/comment-snippets.json
@@ -9,5 +9,29 @@
     ],
     "description": "Insert Comment",
     "sortText": "ZZa"
+  },
+  "Formatter Off": {
+    "prefix": [
+      "<!--",
+      "@formatter:off"
+    ],
+    "label": "@formatter:off",
+    "body": [
+      "<!-- @formatter:off -->"
+    ],
+    "description": "Disable formatting",
+    "sortText": "ZZa1"
+  },
+  "Formatter On": {
+    "prefix": [
+      "<!--",
+      "@formatter:on"
+    ],
+    "label": "@formatter:on",
+    "body": [
+      "<!-- @formatter:on -->"
+    ],
+    "description": "Enable formatting",
+    "sortText": "ZZa2"
   }
  }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/XMLAssert.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/XMLAssert.java
@@ -128,7 +128,7 @@ public class XMLAssert {
 
 	// ------------------- Completion assert
 
-	public static final int COMMENT_SNIPPETS = 1;
+	public static final int COMMENT_SNIPPETS = 3;
 
 	public static final int CDATA_SNIPPETS = 1;
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/catalog/XMLCatalogExtensionTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/catalog/XMLCatalogExtensionTest.java
@@ -34,7 +34,7 @@ public class XMLCatalogExtensionTest extends AbstractCacheBasedTest {
 				"<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\">\r\n" + //
 				"    |";
 
-		XMLAssert.testCompletionFor(xml, 15 + 2 /* CDATA and Comments */, c("public", "<public publicId=\"\" uri=\"\" />"));
+		XMLAssert.testCompletionFor(xml, 15 + 4 /* CDATA and Comments */, c("public", "<public publicId=\"\" uri=\"\" />"));
 	}
 
 	@Test

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/ContentModelManagerCacheTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/ContentModelManagerCacheTest.java
@@ -58,7 +58,7 @@ public class ContentModelManagerCacheTest extends BaseFileTempTest {
 				"    xsi:noNamespaceSchemaLocation=\"tag.xsd\">\r\n" + //
 				"  | " + // <-- completion must provide tag
 				"</root>";
-		XMLAssert.testCompletionFor(xml, null, xmlPath, 5 /* region, endregion, cdata, comment, tag */,
+		XMLAssert.testCompletionFor(xml, null, xmlPath, 7 /* region, endregion, cdata, 3 comments, tag */,
 				c("tag", "<tag></tag>"));
 		// Open again the completion to use the cache
 		XMLAssert.testCompletionFor(xml, null, xmlPath, null, c("tag", "<tag></tag>"));
@@ -78,21 +78,21 @@ public class ContentModelManagerCacheTest extends BaseFileTempTest {
 				"</xs:schema>";
 		updateFile(xsdPath, xsd);
 
-		XMLAssert.testCompletionFor(xml, null, xmlPath, 5 /* region, endregion, cdata, comment, label */,
+		XMLAssert.testCompletionFor(xml, null, xmlPath, 7 /* region, endregion, cdata, 3 comments, label */,
 				c("label", "<label></label>"));
 		// Open again the completion to use the cache
-		XMLAssert.testCompletionFor(xml, null, xmlPath, 5, c("label", "<label></label>"));
+		XMLAssert.testCompletionFor(xml, null, xmlPath, 7, c("label", "<label></label>"));
 
 		// delete the XSD file
 		MoreFiles.deleteRecursively(new File(xsdPath).toPath(), RecursiveDeleteOption.ALLOW_INSECURE);
 		// Completion must be empty
-		XMLAssert.testCompletionFor(xml, null, xmlPath, 4 /* region, endregion, cdata, comment */);
+		XMLAssert.testCompletionFor(xml, null, xmlPath, 6 /* region, endregion, cdata, 3 comments */);
 
 		// recreate the XSD file
 		createFile(xsdPath, xsd);
-		XMLAssert.testCompletionFor(xml, null, xmlPath, 5 /* region, endregion, cdata, comment, label */,
+		XMLAssert.testCompletionFor(xml, null, xmlPath, 7 /* region, endregion, cdata, 3 comments, label */,
 				c("label", "<label></label>"));
-		XMLAssert.testCompletionFor(xml, null, xmlPath, 5 /* region, endregion, cdata, comment, label */,
+		XMLAssert.testCompletionFor(xml, null, xmlPath, 7 /* region, endregion, cdata, 3 comments, label */,
 				c("label", "<label></label>"));
 
 	}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/DTDCompletionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/DTDCompletionExtensionsTest.java
@@ -228,7 +228,7 @@ public class DTDCompletionExtensionsTest extends AbstractCacheBasedTest {
 				+ "<svg xmlns=\"http://www.w3.org/2000/svg\">\n" + "    <animate attributeName=\"foo\">\n"
 				+ "        <|\n" + // <-- completion
 				"    </animate>\n" + "</svg>";
-		testCompletionFor(xml, false, 3 + 2 /* CDATA and Comments */,
+		testCompletionFor(xml, false, 3 + 4 /* CDATA and Comments */,
 				c("desc", te(4, 8, 4, 9, "<desc></desc>"), "<desc"),
 				c("metadata", te(4, 8, 4, 9, "<metadata></metadata>"), "<metadata"),
 				c("title", te(4, 8, 4, 9, "<title></title>"), "<title"));

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaCompletionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaCompletionExtensionsTest.java
@@ -240,7 +240,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"  <ViewDefinitions>\r\n" + //
 				"    <View><|";
 		// Completion only with Name
-		testCompletionFor(xml, null, "src/test/resources/Format.xml", 4 + 2 /* CDATA and Comments */,
+		testCompletionFor(xml, null, "src/test/resources/Format.xml", 4 + 4 /* CDATA and Comments */,
 				c("Name", "<Name></Name>"), c("End with '</Configuration>'", "/Configuration>"),
 				c("End with '</ViewDefinitions>'", "/ViewDefinitions>"), c("End with '</View>'", "/View>"));
 
@@ -250,7 +250,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"  <ViewDefinitions>\r\n" + //
 				"    <View><Name /><|";
 		// Completion only with Name
-		testCompletionFor(xml, null, "src/test/resources/Format.xml", 5 + 2 /* CDATA and Comments */,
+		testCompletionFor(xml, null, "src/test/resources/Format.xml", 5 + 4 /* CDATA and Comments */,
 				c("OutOfBand", "<OutOfBand>false</OutOfBand>"),
 				c("ViewSelectedBy", "<ViewSelectedBy></ViewSelectedBy>"),
 				c("End with '</Configuration>'", "/Configuration>"),
@@ -264,7 +264,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				+ " xsi:schemaLocation=\"http://invoice xsd/invoice-ns.xsd \">\r\n" + //
 				"  <|";
 		// Completion only for date
-		testCompletionFor(xml, null, "src/test/resources/invoice.xml", 2 + 2 /* CDATA and Comments */,
+		testCompletionFor(xml, null, "src/test/resources/invoice.xml", 2 + 4 /* CDATA and Comments */,
 				c("date", "<date></date>"), c("End with '</invoice>'", "</invoice>"));
 
 		// Completion only for number
@@ -272,7 +272,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"<invoice xmlns=\"http://invoice\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n"
 				+ " xsi:schemaLocation=\"http://invoice xsd/invoice-ns.xsd \">\r\n" + //
 				"  <date></date>|";
-		testCompletionFor(xml, null, "src/test/resources/invoice.xml", 2 + 2 /* CDATA and Comments */,
+		testCompletionFor(xml, null, "src/test/resources/invoice.xml", 2 + 4 /* CDATA and Comments */,
 				c("number", "<number></number>"), c("End with '</invoice>'", "</invoice>"));
 	}
 
@@ -411,7 +411,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"	xsi:noNamespaceSchemaLocation=\"xsd/dressSize.xsd\" >\r\n" + //
 				"	| " + //
 				"</dresssize>";
-		testCompletionFor(xml, null, "src/test/resources/dressSize.xml", 4 /*
+		testCompletionFor(xml, null, "src/test/resources/dressSize.xml", 6 /*
 																			 * start/end region + CDATA and Comments
 																			 */ + 4, //
 				c("small", te(2, 52, 3, 2, "small"), //
@@ -686,7 +686,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				4 /*
 					 * edmx:DataServices, <edmx:DataServices, #region, #endregion AND NOT
 					 * edm:Annotation
-					 */ + 2 /* CDATA and Comments */, c("edmx:DataServices", "<edmx:DataServices></edmx:DataServices>"), //
+					 */ + 4 /* CDATA and Comments */, c("edmx:DataServices", "<edmx:DataServices></edmx:DataServices>"), //
 				c("edmx:Reference", "<edmx:Reference Uri=\"\"></edmx:Reference>"));
 
 		// with xmlns="http://docs.oasis-open.org/odata/ns/edm"
@@ -698,7 +698,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				4 /*
 					 * edmx:DataServices, <edmx:DataServices, #region, #endregion AND NOT
 					 * edm:Annotation
-					 */ + 2 /* CDATA and Comments */, c("edmx:DataServices", "<edmx:DataServices></edmx:DataServices>"), //
+					 */ + 4 /* CDATA and Comments */, c("edmx:DataServices", "<edmx:DataServices></edmx:DataServices>"), //
 				c("edmx:Reference", "<edmx:Reference Uri=\"\"></edmx:Reference>"));
 	}
 
@@ -832,7 +832,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				" <employee /> <| " + //
 				"</person>";
 		// Completion only member or employee
-		testCompletionFor(xml, null, "src/test/resources/choice.xml", 2 + 2 /* CDATA and Comments */,
+		testCompletionFor(xml, null, "src/test/resources/choice.xml", 2 + 4 /* CDATA and Comments */,
 				c("employee", "<employee></employee>"));
 
 		xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n" + //
@@ -843,7 +843,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				" <employee /> <| " + //
 				"</person>";
 		// maxOccurs = 3, completion should be empty
-		testCompletionFor(xml, null, "src/test/resources/choice.xml", 2 /* CDATA and Comments */);
+		testCompletionFor(xml, null, "src/test/resources/choice.xml", 4 /* CDATA and Comments */);
 	}
 
 	@Test
@@ -895,7 +895,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"	xsi:noNamespaceSchemaLocation=\"xsd/sequence.xsd\">\r\n" + //
 				"	<e1></e1><e2></e2><e3 /><optional3></optional3><optional3></optional3>|";
 		// optional3 is not return by completion since optional3 has a max=2 occurences
-		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 1 + 2 /* CDATA and Comments */,
+		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 1 + 4 /* CDATA and Comments */,
 				c("End with '</data>'", "</data>"));
 	}
 
@@ -907,7 +907,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				" xsi:noNamespaceSchemaLocation=\"xsd/all.xsd\">\r\n" + //
 				"    <|\r\n" + //
 				"</Demo>";
-		testCompletionFor(xml, null, "src/test/resources/all.xml", 2 + 2 /* CDATA and Comments */,
+		testCompletionFor(xml, null, "src/test/resources/all.xml", 2 + 4 /* CDATA and Comments */,
 				c("Hello", "<Hello></Hello>"), c("World", "<World></World>"));
 
 		// Completion after Hello only: World is offered (Hello already at maxOccurs)
@@ -917,7 +917,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"    <Hello></Hello>\r\n" + //
 				"    <|\r\n" + //
 				"</Demo>";
-		testCompletionFor(xml, null, "src/test/resources/all.xml", 1 + 2 /* CDATA and Comments */,
+		testCompletionFor(xml, null, "src/test/resources/all.xml", 1 + 4 /* CDATA and Comments */,
 				c("World", "<World></World>"));
 
 		// Completion after both Hello and World: no element completions
@@ -928,7 +928,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"    <World></World>\r\n" + //
 				"    <|\r\n" + //
 				"</Demo>";
-		testCompletionFor(xml, null, "src/test/resources/all.xml", 2 /* CDATA and Comments */);
+		testCompletionFor(xml, null, "src/test/resources/all.xml", 4 /* CDATA and Comments */);
 
 		// Completion after World only: Hello is offered
 		xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + //
@@ -937,7 +937,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"    <World></World>\r\n" + //
 				"    <|\r\n" + //
 				"</Demo>";
-		testCompletionFor(xml, null, "src/test/resources/all.xml", 1 + 2 /* CDATA and Comments */,
+		testCompletionFor(xml, null, "src/test/resources/all.xml", 1 + 4 /* CDATA and Comments */,
 				c("Hello", "<Hello></Hello>"));
 	}
 
@@ -971,7 +971,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"	<a/>" + //
 				"</ui:page>";
 		testCompletionFor(xmlLanguageService, xml, null, null,
-				getTempDirPath().resolve("target/any.xml").toUri().toString(), 4 + 1, true,
+				getTempDirPath().resolve("target/any.xml").toUri().toString(), 6 + 1, true,
 				c("title", "<title></title>"));
 
 		// xs:any completion with strict -> only XML Schema global element declaration
@@ -983,7 +983,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"	<a/>" + //
 				"</ui:page>";
 		testCompletionFor(xmlLanguageService, xml, null, null,
-				getTempDirPath().resolve("target/any.xml").toUri().toString(), 4 + 2, true,
+				getTempDirPath().resolve("target/any.xml").toUri().toString(), 6 + 2, true,
 				c("ui:page", "<ui:page></ui:page>"), c("ui:textbox", "<ui:textbox></ui:textbox>"));
 
 		// no completion
@@ -995,7 +995,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"	<a/>" + //
 				"</ui:page>";
 		testCompletionFor(xmlLanguageService, xml, null, null,
-				getTempDirPath().resolve("target/any.xml").toUri().toString(), 4, true);
+				getTempDirPath().resolve("target/any.xml").toUri().toString(), 6, true);
 	}
 
 	@Test
@@ -1029,7 +1029,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"	<a/>" + //
 				"</ui:page>";
 		testCompletionFor(xmlLanguageService, xml, null, null,
-				getTempDirPath().resolve("target/any.xml").toUri().toString(), 4 + 1, true,
+				getTempDirPath().resolve("target/any.xml").toUri().toString(), 6 + 1, true,
 				c("title", "<title></title>"));
 
 		// xs:any completion with strict -> all XML Schema element declaration
@@ -1041,7 +1041,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"	<a/>" + //
 				"</ui:page>";
 		testCompletionFor(xmlLanguageService, xml, null, null,
-				getTempDirPath().resolve("target/any.xml").toUri().toString(), 4 + 4, true,
+				getTempDirPath().resolve("target/any.xml").toUri().toString(), 6 + 4, true,
 				c("title", "<title></title>"), c("a", "<a/>"), c("ui:page", "<ui:page></ui:page>"),
 				c("ui:textbox", "<ui:textbox></ui:textbox>"));
 
@@ -1054,7 +1054,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"	<a/>" + //
 				"</ui:page>";
 		testCompletionFor(xmlLanguageService, xml, null, null,
-				getTempDirPath().resolve("target/any.xml").toUri().toString(), 4, true);
+				getTempDirPath().resolve("target/any.xml").toUri().toString(), 6, true);
 	}
 
 	@Test
@@ -1089,7 +1089,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"		</plugins>\r\n" + //
 				"	</build>\r\n" + //
 				"</project>";
-		testCompletionFor(xml, "src/test/resources/catalogs/catalog.xml", null, 3 /* project, comment and cdata */,
+		testCompletionFor(xml, "src/test/resources/catalogs/catalog.xml", null, 5 /* project, 3 comments and cdata */,
 				c("project", te(20, 7, 20, 9, "<project></project>"), "<project"));
 	}
 
@@ -1176,7 +1176,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"<root xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
 				"	xsi:noNamespaceSchemaLocation=\"xsd/tag.xsd\">\r\n" + //
 				"	|";
-		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 4 + 2 /* CDATA and Comments */,
+		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 4 + 4 /* CDATA and Comments */,
 				c("tag", "<tag></tag>"), c("End with '</root>'", "</root>"), c("#region", "<!-- #region -->"),
 				c("#endregion", "<!-- #endregion-->"), c("<![CDATA[", "<![CDATA[ ]]>"), //
 				c("<!--", "<!-- -->"));
@@ -1186,7 +1186,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"	xsi:noNamespaceSchemaLocation=\"xsd/tag.xsd\">\r\n" + //
 				"	|\r\n" + //
 				"</root>";
-		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 3 + 2 /* CDATA and Comments */,
+		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 3 + 4 /* CDATA and Comments */,
 				c("tag", "<tag></tag>"), c("#region", "<!-- #region -->"), c("#endregion", "<!-- #endregion-->"),
 				c("<![CDATA[", "<![CDATA[ ]]>"), c("<!--", "<!-- -->"));
 
@@ -1194,7 +1194,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"<root xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
 				"	xsi:noNamespaceSchemaLocation=\"xsd/tag.xsd\">\r\n" + //
 				"	<|";
-		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 2 + 2 /* CDATA and Comments */,
+		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 2 + 4 /* CDATA and Comments */,
 				c("tag", "<tag></tag>"), c("End with '</root>'", "</root>"));
 
 		xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" + //
@@ -1202,35 +1202,35 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"	xsi:noNamespaceSchemaLocation=\"xsd/tag.xsd\">\r\n" + //
 				"	<|\r\n" + //
 				"</root>";
-		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 1 + 2 /* CDATA and Comments */,
+		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 1 + 4 /* CDATA and Comments */,
 				c("tag", "<tag></tag>"));
 
 		xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" + //
 				"<root xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
 				"	xsi:noNamespaceSchemaLocation=\"xsd/tag.xsd\">\r\n" + //
 				"	<tag />|";
-		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 2 + 2 /* CDATA and Comments */,
+		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 2 + 4 /* CDATA and Comments */,
 				c("optional", "<optional></optional>"), c("End with '</root>'", "</root>"));
 
 		xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" + //
 				"<root xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
 				"	xsi:noNamespaceSchemaLocation=\"xsd/tag.xsd\">\r\n" + //
 				"	<tag />|\r\n" + "</root>";
-		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 1 + 2 /* CDATA and Comments */,
+		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 1 + 4 /* CDATA and Comments */,
 				c("optional", "<optional></optional>"));
 
 		xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" + //
 				"<root xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
 				"	xsi:noNamespaceSchemaLocation=\"xsd/tag.xsd\">\r\n" + //
 				"	<tag /><|";
-		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 2 + 2 /* CDATA and Comments */,
+		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 2 + 4 /* CDATA and Comments */,
 				c("optional", "<optional></optional>"), c("End with '</root>'", "/root>"));
 
 		xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" + //
 				"<root xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
 				"	xsi:noNamespaceSchemaLocation=\"xsd/tag.xsd\">\r\n" + //
 				"	<tag /><|\r\n" + "</root>";
-		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 1 + 2 /* CDATA and Comments */,
+		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 1 + 4 /* CDATA and Comments */,
 				c("optional", "<optional></optional>"));
 
 		xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" + //
@@ -1238,7 +1238,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"	xsi:noNamespaceSchemaLocation=\"xsd/tag.xsd\">\r\n" + //
 				"	<tag />\r\n" + //
 				"|";
-		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 4 + 2 /* CDATA and Comments */,
+		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 4 + 4 /* CDATA and Comments */,
 				c("optional", "<optional></optional>"), c("End with '</root>'", "</root>"),
 				c("#region", "<!-- #region -->"), c("#endregion", "<!-- #endregion-->"));
 
@@ -1247,7 +1247,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"	xsi:noNamespaceSchemaLocation=\"xsd/tag.xsd\">\r\n" + //
 				"	<tag />\r\n" + //
 				"|r\n" + "</root>";
-		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 3 + 2 /* CDATA and Comments */,
+		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 3 + 4 /* CDATA and Comments */,
 				c("optional", "<optional></optional>"), c("#region", "<!-- #region -->"),
 				c("#endregion", "<!-- #endregion-->"));
 
@@ -1256,7 +1256,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"	xsi:noNamespaceSchemaLocation=\"xsd/tag.xsd\">\r\n" + //
 				"	<tag />\r\n" + //
 				"<|";
-		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 2 + 2 /* CDATA and Comments */,
+		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 2 + 4 /* CDATA and Comments */,
 				c("optional", "<optional></optional>"), c("End with '</root>'", "/root>"));
 
 		xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" + //
@@ -1264,7 +1264,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"	xsi:noNamespaceSchemaLocation=\"xsd/tag.xsd\">\r\n" + //
 				"	<tag />\r\n" + //
 				"<|\r\n" + "</root>";
-		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 1 + 2 /* CDATA and Comments */,
+		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 1 + 4 /* CDATA and Comments */,
 				c("optional", "<optional></optional>"));
 
 		xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" + //
@@ -1273,7 +1273,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"	<tag />\r\n" + //
 				"	<optional />\r\n" + //
 				"|";
-		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 4 + 2 /* CDATA and Comments */,
+		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 4 + 4 /* CDATA and Comments */,
 				c("optional", "<optional></optional>"), c("End with '</root>'", "</root>"),
 				c("#region", "<!-- #region -->"), c("#endregion", "<!-- #endregion-->"));
 
@@ -1283,7 +1283,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"	<tag />\r\n" + //
 				"	<optional />\r\n" + //
 				"<|";
-		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 2 + 2 /* CDATA and Comments */,
+		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 2 + 4 /* CDATA and Comments */,
 				c("optional", "<optional></optional>"), c("End with '</root>'", "/root>"));
 
 		xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" + //
@@ -1293,7 +1293,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"	<optional />\r\n" + //
 				"	<optional />\r\n" + //
 				"|";
-		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 3 + 2 /* CDATA and Comments */,
+		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 3 + 4 /* CDATA and Comments */,
 				c("End with '</root>'", "</root>"), c("#region", "<!-- #region -->"),
 				c("#endregion", "<!-- #endregion-->"));
 
@@ -1304,7 +1304,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"	<optional />\r\n" + //
 				"	<optional />\r\n" + //
 				"<|";
-		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 1 + 2 /* CDATA and Comments */,
+		testCompletionFor(xml, null, "src/test/resources/sequence.xml", 1 + 4 /* CDATA and Comments */,
 				c("End with '</root>'", "/root>"));
 
 	}
@@ -1591,7 +1591,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"    <View><|";
 		// Completion only with Name
 		testCompletionFor(new XMLLanguageService(), xml, (String) null, config, "src/test/resources/Format.xml",
-				4 + 2 /* CDATA and Comments */, true, c("Name", "<Name></Name>"),
+				4 + 4 /* CDATA and Comments */, true, c("Name", "<Name></Name>"),
 				c("End with '</Configuration>'", "/Configuration>"),
 				c("End with '</ViewDefinitions>'", "/ViewDefinitions>"), c("End with '</View>'", "/View>"));
 	}
@@ -1629,7 +1629,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"</web-app>";
 		testCompletionFor(xml, "src/test/resources/catalogs/catalog-web-app.xml", //
 				"web.xml", //
-				31, //
+				33, //
 				c("servlet", te(4, 4, 4, 4, "<servlet></servlet>"), "servlet", null, null));
 	}
 
@@ -1664,7 +1664,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"  </item>\r\n" + //
 				"</root>";
 		testCompletionFor(xml, null, "src/test/resources/xsitype-ns.xml",
-				2 + 2 /* CDATA and Comments */, //
+				2 + 4 /* CDATA and Comments */, //
 				c("tns:baseProp", "<tns:baseProp></tns:baseProp>"), //
 				c("tns:derivedProp", "<tns:derivedProp></tns:derivedProp>"));
 	}
@@ -1679,7 +1679,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"  </item>\r\n" + //
 				"</root>";
 		testCompletionFor(xml, null, "src/test/resources/xsitype-ns.xml",
-				2 + 2 /* CDATA and Comments */, //
+				2 + 4 /* CDATA and Comments */, //
 				c("baseProp", "<baseProp></baseProp>"), //
 				c("derivedProp", "<derivedProp></derivedProp>"));
 	}
@@ -1694,7 +1694,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"  <|" + //
 				"</root>";
 		testCompletionSnippetSupportFor(xml, "src/test/resources/xsitype-abstract.xml",
-				1 + 2 /* CDATA and Comments */, //
+				1 + 4 /* CDATA and Comments */, //
 				c("Character",
 						"<Character xsi:type=\"${1|Student,Teacher|}\" Name=\"$2\">$3</Character>$0",
 						r(3, 2, 3, 3), "<Character"));

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/entities/EntitiesCompletionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/entities/EntitiesCompletionExtensionsTest.java
@@ -39,7 +39,7 @@ public class EntitiesCompletionExtensionsTest extends AbstractCacheBasedTest {
 				"	]>\r\n" + //
 				"	<copyright>&|</copyright>";
 		testCompletionFor(xml, 1 + //
-				2 /* CDATA and Comments */ + //
+				4 /* CDATA and Comments */ + //
 				PredefinedEntity.values().length /* predefined entities */, //
 				c("&c;", "&c;", r(5, 12, 5, 13), "&c;"));
 	}
@@ -55,7 +55,7 @@ public class EntitiesCompletionExtensionsTest extends AbstractCacheBasedTest {
 				"  &|\r\n" + // <- here completion shows mdash entity
 				"</root>";
 		testCompletionFor(xml, 1 + //
-				2 /* CDATA and Comments */ + //
+				4 /* CDATA and Comments */ + //
 				PredefinedEntity.values().length /* predefined entities */,
 				c("&mdash;", "&mdash;", r(5, 2, 5, 3), "&mdash;"));
 
@@ -72,7 +72,7 @@ public class EntitiesCompletionExtensionsTest extends AbstractCacheBasedTest {
 				"  &m|\r\n" + // <- here completion shows mdash entity
 				"</root>";
 		testCompletionFor(xml, 1 + //
-				2 /* CDATA and Comments */ + //
+				4 /* CDATA and Comments */ + //
 				PredefinedEntity.values().length /* predefined entities */,
 				c("&mdash;", "&mdash;", r(5, 2, 5, 4), "&mdash;"));
 
@@ -89,7 +89,7 @@ public class EntitiesCompletionExtensionsTest extends AbstractCacheBasedTest {
 				"  &m|dblablabla\r\n" + // <- here completion shows mdash entity
 				"</root>";
 		testCompletionFor(xml, 1 + //
-				2 /* CDATA and Comments */ + //
+				4 /* CDATA and Comments */ + //
 				PredefinedEntity.values().length /* predefined entities */,
 				c("&mdash;", "&mdash;", r(5, 2, 5, 4), "&mdash;"));
 	}
@@ -106,7 +106,7 @@ public class EntitiesCompletionExtensionsTest extends AbstractCacheBasedTest {
 				"  &foo_b|\r\n" + // <- here completion shows mdash entity
 				"</root>";
 		testCompletionFor(xml, 2 + //
-				2 /* CDATA and Comments */ + //
+				4 /* CDATA and Comments */ + //
 				PredefinedEntity.values().length /* predefined entities */,
 				c("&foo_bar;", "&foo_bar;", r(6, 2, 6, 8), "&foo_bar;"), //
 				c("&foo_baz;", "&foo_baz;", r(6, 2, 6, 8), "&foo_baz;"));
@@ -124,7 +124,7 @@ public class EntitiesCompletionExtensionsTest extends AbstractCacheBasedTest {
 				"  &foo_b|\r\n" + // <- here completion shows mdash entity
 				"</root>";
 		testCompletionFor(xml, 2 + //
-				2 /* CDATA and Comments */ + //
+				4 /* CDATA and Comments */ + //
 				PredefinedEntity.values().length /* predefined entities */, true,
 				c("&foo_bar;", "&foo_bar;", r(6, 2, 6, 8), "&foo_bar;"), //
 				c("&foo_baz;", "&foo_baz;", r(6, 2, 6, 8), "&foo_baz;"));
@@ -141,7 +141,7 @@ public class EntitiesCompletionExtensionsTest extends AbstractCacheBasedTest {
 				"  &m|d;blablabla\r\n" + // <- here completion shows mdash entity
 				"</root>";
 		testCompletionFor(xml, 1 + //
-				2 /* CDATA and Comments */ + //
+				4 /* CDATA and Comments */ + //
 				PredefinedEntity.values().length /* predefined entities */,
 				c("&mdash;", "&mdash;", r(5, 2, 5, 6), "&mdash;"));
 	}
@@ -155,7 +155,7 @@ public class EntitiesCompletionExtensionsTest extends AbstractCacheBasedTest {
 				"<root>\r\n" + //
 				"  |\r\n" + // <- no entity completion
 				"</root>";
-		testCompletionFor(xml, 2 + 2 /* CDATA and Comments */);
+		testCompletionFor(xml, 2 + 4 /* CDATA and Comments */);
 	}
 
 	// Test for external entities
@@ -170,7 +170,7 @@ public class EntitiesCompletionExtensionsTest extends AbstractCacheBasedTest {
 				"\r\n &|" + //
 				"</root-element>";
 		testCompletionFor(xml, null, "test.xml", 2 + //
-				2 /* CDATA and Comments */ + //
+				4 /* CDATA and Comments */ + //
 				PredefinedEntity.values().length /* predefined entities */,
 				c("&mdash;", "&mdash;", r(6, 1, 6, 2), "&mdash;"), //
 				c("&foo;", "&foo;", r(6, 1, 6, 2), "&foo;"));
@@ -182,7 +182,7 @@ public class EntitiesCompletionExtensionsTest extends AbstractCacheBasedTest {
 				"<!DOCTYPE author SYSTEM \"src/test/resources/dtd/entities/base-system.dtd\">\r\n" + //
 				"<author>&|</author>";
 		testCompletionFor(xml, null, "test.xml", 2 + //
-				2 /* CDATA and Comments */ + //
+				4 /* CDATA and Comments */ + //
 				PredefinedEntity.values().length /* predefined entities */,
 				c("&writer;", "&writer;", r(2, 8, 2, 9), "&writer;"), //
 				c("&copyright;", "&copyright;", r(2, 8, 2, 9), "&copyright;"));
@@ -201,7 +201,7 @@ public class EntitiesCompletionExtensionsTest extends AbstractCacheBasedTest {
 				"&|\r\n" + //
 				"</root>";
 		testCompletionFor(xml, null, "test.xml", 29 + //
-				2 /* CDATA and Comments */ + //
+				4 /* CDATA and Comments */ + //
 				PredefinedEntity.values().length /* predefined entities */, //
 				c("&fdcuf_hide_actions_column;", "&fdcuf_hide_actions_column;", r(5, 0, 5, 1),
 						"&fdcuf_hide_actions_column;"));

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLCompletionTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLCompletionTest.java
@@ -53,27 +53,27 @@ public class XMLCompletionTest {
 
 	@Test
 	public void successfulEndTagCompletion() throws BadLocationException {
-		testCompletionFor("<a>|", 1 + 2 /* CDATA and Comments */, c("End with '</a>'", "</a>", r(0, 3, 0, 3), "</a>"));
-		testCompletionFor("<a>a|", 1 + 2 /* CDATA and Comments */, c("End with '</a>'", "</a>", r(0, 3, 0, 4), "</a>"));
-		testCompletionFor("<a><|", 1 + 2 /* CDATA and Comments */, c("End with '</a>'", "/a>", r(0, 4, 0, 4), "/a>"));
+		testCompletionFor("<a>|", 1 + CDATA_SNIPPETS + COMMENT_SNIPPETS, c("End with '</a>'", "</a>", r(0, 3, 0, 3), "</a>"));
+		testCompletionFor("<a>a|", 1 + CDATA_SNIPPETS + COMMENT_SNIPPETS, c("End with '</a>'", "</a>", r(0, 3, 0, 4), "</a>"));
+		testCompletionFor("<a><|", 1 + CDATA_SNIPPETS + COMMENT_SNIPPETS, c("End with '</a>'", "/a>", r(0, 4, 0, 4), "/a>"));
 		testCompletionFor("<a></|", 1, c("End with '</a>'", "/a>", r(0, 4, 0, 5), "/a>"));
 
-		testCompletionFor("<a><b>|</a>", 1 + 2 /* CDATA and Comments */,
+		testCompletionFor("<a><b>|</a>", 1 + CDATA_SNIPPETS + COMMENT_SNIPPETS,
 				c("End with '</b>'", "</b>", r(0, 6, 0, 6), "</b>"));
-		testCompletionFor("<a><b><|</a>", 1 + 2 /* CDATA and Comments */,
+		testCompletionFor("<a><b><|</a>", 1 + CDATA_SNIPPETS + COMMENT_SNIPPETS,
 				c("End with '</b>'", "/b>", r(0, 7, 0, 7), "/b>"));
 		testCompletionFor("<a><b></|</a>", 1, c("End with '</b>'", "/b>", r(0, 7, 0, 8), "/b>"));
 
-		testCompletionFor("<a>   <b>|</a>", 1 + 2 /* CDATA and Comments */,
+		testCompletionFor("<a>   <b>|</a>", 1 + CDATA_SNIPPETS + COMMENT_SNIPPETS,
 				c("End with '</b>'", "</b>", r(0, 9, 0, 9), "</b>"));
-		testCompletionFor("<a>   <b><|</a>", 1 + 2 /* CDATA and Comments */,
+		testCompletionFor("<a>   <b><|</a>", 1 + CDATA_SNIPPETS + COMMENT_SNIPPETS,
 				c("End with '</b>'", "/b>", r(0, 10, 0, 10), "/b>"));
 		testCompletionFor("<a>   <b></|</a>", 1, c("End with '</b>'", "/b>", r(0, 10, 0, 11), "/b>"));
 
-		testCompletionFor("<a><b>|", 2 + 2 /* CDATA and Comments */,
+		testCompletionFor("<a><b>|", 2 + CDATA_SNIPPETS + COMMENT_SNIPPETS,
 				c("End with '</b>'", "</b>", r(0, 6, 0, 6), "</b>"),
 				c("End with '</a>'", "</a>", r(0, 6, 0, 6), "</a>"));
-		testCompletionFor("<a><b><|", 2 + 2 /* CDATA and Comments */, c("End with '</b>'", "/b>", r(0, 7, 0, 7), "/b>"),
+		testCompletionFor("<a><b><|", 2 + CDATA_SNIPPETS + COMMENT_SNIPPETS, c("End with '</b>'", "/b>", r(0, 7, 0, 7), "/b>"),
 				c("End with '</a>'", "/a>", r(0, 7, 0, 7), "/a>"));
 		testCompletionFor("<a><b></|", 2, c("End with '</b>'", "/b>", r(0, 7, 0, 8), "/b>"),
 				c("End with '</a>'", "/a>", r(0, 7, 0, 8), "/a>"));
@@ -86,7 +86,7 @@ public class XMLCompletionTest {
 
 		testCompletionFor("  <a>\r\n" + //
 				"     <b>\r\n" + //
-				"<|", 2 + 2 /* CDATA and Comments */, //
+				"<|", 2 + CDATA_SNIPPETS + COMMENT_SNIPPETS, //
 				c("End with '</b>'", "     </b>", r(2, 0, 2, 1), "</b>"), //
 				c("End with '</a>'", "  </a>", r(2, 0, 2, 1), "</a>"));
 	}
@@ -94,19 +94,19 @@ public class XMLCompletionTest {
 	@Test
 	public void noEndTagCompletionAfterSlashContent() throws BadLocationException {
 		// See https://github.com/redhat-developer/vscode-xml/issues/1088
-		testCompletionFor("<a>/|", 0 + 2 /* CDATA and Comments */);
-		testCompletionFor("<a>\r\n/|", 0 + 2 /* CDATA and Comments */);
-		testCompletionFor("<a>some/|", 0 + 2 /* CDATA and Comments */);
+		testCompletionFor("<a>/|", 0 + CDATA_SNIPPETS + COMMENT_SNIPPETS);
+		testCompletionFor("<a>\r\n/|", 0 + CDATA_SNIPPETS + COMMENT_SNIPPETS);
+		testCompletionFor("<a>some/|", 0 + CDATA_SNIPPETS + COMMENT_SNIPPETS);
 	}
 
 	@Test
 	public void unneededEndTagCompletion() throws BadLocationException {
-		testCompletionFor("<a>|</a>", 0 + 2 /* CDATA and Comments */);
-		testCompletionFor("<a><|</a>", 0 + 2 /* CDATA and Comments */);
+		testCompletionFor("<a>|</a>", 0 + CDATA_SNIPPETS + COMMENT_SNIPPETS);
+		testCompletionFor("<a><|</a>", 0 + CDATA_SNIPPETS + COMMENT_SNIPPETS);
 		testCompletionFor("<a></|</a>", 0);
 
-		testCompletionFor("<a><b>|</b></a>", 0 + 2 /* CDATA and Comments */);
-		testCompletionFor("<a><b><|</b></a>", 0 + 2 /* CDATA and Comments */);
+		testCompletionFor("<a><b>|</b></a>", 0 + CDATA_SNIPPETS + COMMENT_SNIPPETS);
+		testCompletionFor("<a><b><|</b></a>", 0 + CDATA_SNIPPETS + COMMENT_SNIPPETS);
 		testCompletionFor("<a><b></|</b></a>", 0);
 	}
 
@@ -135,9 +135,9 @@ public class XMLCompletionTest {
 
 	@Test
 	public void completionBasedOnParent() throws BadLocationException {
-		testCompletionFor("<a><b />|</a>", 1 + 2 /* CDATA and Comments */, c("b", "<b />", r(0, 8, 0, 8), "b"));
-		testCompletionFor("<a><b /><|</a>", 1 + 2 /* CDATA and Comments */, c("b", "<b />", r(0, 8, 0, 9), "<b"));
-		testCompletionFor("<a>|</b></a>", 1 + 2 /* CDATA and Comments */, c("b", "<b>", r(0, 3, 0, 3), "b"));
+		testCompletionFor("<a><b />|</a>", 1 + CDATA_SNIPPETS + COMMENT_SNIPPETS, c("b", "<b />", r(0, 8, 0, 8), "b"));
+		testCompletionFor("<a><b /><|</a>", 1 + CDATA_SNIPPETS + COMMENT_SNIPPETS, c("b", "<b />", r(0, 8, 0, 9), "<b"));
+		testCompletionFor("<a>|</b></a>", 1 + CDATA_SNIPPETS + COMMENT_SNIPPETS, c("b", "<b>", r(0, 3, 0, 3), "b"));
 		testCompletionFor("<a><|b</b></a>", c("b", "<b>", r(0, 3, 0, 5), "<b"));
 	}
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/extensions/ErrorParticipantLanguageServiceTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/extensions/ErrorParticipantLanguageServiceTest.java
@@ -415,7 +415,7 @@ public class ErrorParticipantLanguageServiceTest extends AbstractCacheBasedTest 
 				c("xmlns", "xmlns", r(0, 4, 0, 6), "xmlns"), //
 				c("xmlns:xsi", "xmlns:xsi", r(0, 4, 0, 6), "xmlns:xsi"));
 		testCompletionFor(new ErrorParticipantLanguageService(), "<aa bb=\"cc\">dd|</aa>", null, (a) -> {
-		}, null, 4, new SharedSettings(), //
+		}, null, 6, new SharedSettings(), //
 				ErrorParticipantLanguageService.TEST_COMPLETION_ITEM);
 		testCompletionFor(new ErrorParticipantLanguageService(), "<!DOCTYPE foo SYSTEM \"./zrb|\">", null, (a) -> {
 		}, null, 1, new SharedSettings(), //

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/settings/XMLFormatterOffOnTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/settings/XMLFormatterOffOnTest.java
@@ -1,0 +1,201 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.services.format.settings;
+
+import static java.lang.System.lineSeparator;
+import static org.eclipse.lemminx.XMLAssert.c;
+import static org.eclipse.lemminx.XMLAssert.testCompletionFor;
+
+import org.eclipse.lemminx.AbstractCacheBasedTest;
+import org.eclipse.lemminx.XMLAssert;
+import org.eclipse.lemminx.commons.BadLocationException;
+import org.eclipse.lemminx.settings.SharedSettings;
+import org.eclipse.lsp4j.TextEdit;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for &lt;!-- @formatter:off --&gt; / &lt;!-- @formatter:on --&gt;
+ * support.
+ *
+ * @see <a href="https://github.com/eclipse-lemminx/lemminx/issues/1648">lemminx#1648</a>
+ */
+public class XMLFormatterOffOnTest extends AbstractCacheBasedTest {
+
+	// https://github.com/eclipse-lemminx/lemminx/issues/1648
+	@Test
+	public void formatterOffOnPreservesContent() throws BadLocationException {
+		String content = "<root>" + lineSeparator() + //
+				"  <!-- @formatter:off -->" + lineSeparator() + //
+				"      <badly-indented>" + lineSeparator() + //
+				"    <child />" + lineSeparator() + //
+				"          </badly-indented>" + lineSeparator() + //
+				"  <!-- @formatter:on -->" + lineSeparator() + //
+				"  <normal>" + lineSeparator() + //
+				"    <child />" + lineSeparator() + //
+				"  </normal>" + lineSeparator() + //
+				"</root>";
+		String expected = content;
+		assertFormat(content, expected);
+	}
+
+	@Test
+	public void formatterOffOnFormatsCommentAndResumes() throws BadLocationException {
+		String content = "<root>" + lineSeparator() + //
+				"<!-- @formatter:off -->" + lineSeparator() + //
+				"      <badly-indented />" + lineSeparator() + //
+				"<!-- @formatter:on -->" + lineSeparator() + //
+				"      <normal />" + lineSeparator() + //
+				"</root>";
+		String expected = "<root>" + lineSeparator() + //
+				"  <!-- @formatter:off -->" + lineSeparator() + //
+				"      <badly-indented />" + lineSeparator() + //
+				"<!-- @formatter:on -->" + lineSeparator() + //
+				"  <normal />" + lineSeparator() + //
+				"</root>";
+		assertFormat(content, expected, (TextEdit[]) null);
+	}
+
+	@Test
+	public void formatterOffWithoutOn() throws BadLocationException {
+		String content = "<root>" + lineSeparator() + //
+				"  <!-- @formatter:off -->" + lineSeparator() + //
+				"      <badly-indented>" + lineSeparator() + //
+				"    <child />" + lineSeparator() + //
+				"          </badly-indented>" + lineSeparator() + //
+				"</root>";
+		String expected = content;
+		assertFormat(content, expected);
+	}
+
+	@Test
+	public void formatterOffOnIdempotent() throws BadLocationException {
+		String content = "<root>" + lineSeparator() + //
+				"  <!-- @formatter:off -->" + lineSeparator() + //
+				"      <badly-indented>" + lineSeparator() + //
+				"    <child />" + lineSeparator() + //
+				"          </badly-indented>" + lineSeparator() + //
+				"  <!-- @formatter:on -->" + lineSeparator() + //
+				"  <normal>" + lineSeparator() + //
+				"    <child />" + lineSeparator() + //
+				"  </normal>" + lineSeparator() + //
+				"</root>";
+		String expected = content;
+		assertFormat(content, expected);
+		assertFormat(expected, expected);
+	}
+
+	@Test
+	public void formatterOffOnMultipleRegions() throws BadLocationException {
+		String content = "<root>" + lineSeparator() + //
+				"  <!-- @formatter:off -->" + lineSeparator() + //
+				"    <a>preserve   this</a>" + lineSeparator() + //
+				"  <!-- @formatter:on -->" + lineSeparator() + //
+				"  <b>format this</b>" + lineSeparator() + //
+				"  <!-- @formatter:off -->" + lineSeparator() + //
+				"    <c>preserve   this   too</c>" + lineSeparator() + //
+				"  <!-- @formatter:on -->" + lineSeparator() + //
+				"  <d>format this too</d>" + lineSeparator() + //
+				"</root>";
+		String expected = content;
+		assertFormat(content, expected);
+	}
+
+	@Test
+	public void formatterOffOnWithExtraSpacesInComment() throws BadLocationException {
+		String content = "<root>" + lineSeparator() + //
+				"  <!--   @formatter:off   -->" + lineSeparator() + //
+				"      <badly-indented />" + lineSeparator() + //
+				"  <!--   @formatter:on   -->" + lineSeparator() + //
+				"  <normal />" + lineSeparator() + //
+				"</root>";
+		String expected = content;
+		assertFormat(content, expected);
+	}
+
+	@Test
+	public void formatterOffOnNoEffectOnNormalComments() throws BadLocationException {
+		String content = "<root>" + lineSeparator() + //
+				"      <!-- normal comment -->" + lineSeparator() + //
+				"      <element />" + lineSeparator() + //
+				"</root>";
+		String expected = "<root>" + lineSeparator() + //
+				"  <!-- normal comment -->" + lineSeparator() + //
+				"  <element />" + lineSeparator() + //
+				"</root>";
+		assertFormat(content, expected, (TextEdit[]) null);
+	}
+
+	@Test
+	public void formatterOffOnNestedElements() throws BadLocationException {
+		String content = "<root>" + lineSeparator() + //
+				"  <!-- @formatter:off -->" + lineSeparator() + //
+				"  <parent>" + lineSeparator() + //
+				"        <child>" + lineSeparator() + //
+				"  <grandchild />" + lineSeparator() + //
+				"        </child>" + lineSeparator() + //
+				"  </parent>" + lineSeparator() + //
+				"  <!-- @formatter:on -->" + lineSeparator() + //
+				"</root>";
+		String expected = content;
+		assertFormat(content, expected);
+	}
+
+	@Test
+	public void formatterOffOnPreservesTextContent() throws BadLocationException {
+		String content = "<root>" + lineSeparator() + //
+				"  <!-- @formatter:off -->" + lineSeparator() + //
+				"  <pre>  multiple   spaces   preserved  </pre>" + lineSeparator() + //
+				"  <!-- @formatter:on -->" + lineSeparator() + //
+				"</root>";
+		String expected = content;
+		assertFormat(content, expected);
+	}
+
+	@Test
+	public void formatterOffInsideElement() throws BadLocationException {
+		String content = "<records>" + lineSeparator() + //
+				"  <record>" + lineSeparator() + //
+				"    <name></name>" + lineSeparator() + //
+				"    <!-- @formatter:off -->" + lineSeparator() + //
+				"                          <email></email>" + lineSeparator() + //
+				"                                    </record>" + lineSeparator() + //
+				"            <record>" + lineSeparator() + //
+				"              <name></name>" + lineSeparator() + //
+				"            </record>" + lineSeparator() + //
+				"  <!-- @formatter:on -->" + lineSeparator() + //
+				"  <record>" + lineSeparator() + //
+				"    <name></name>" + lineSeparator() + //
+				"  </record>" + lineSeparator() + //
+				"</records>";
+		String expected = content;
+		assertFormat(content, expected);
+	}
+	@Test
+	public void completionFormatterOffOn() throws BadLocationException {
+		String xml = "<root>\r\n" + //
+				"  |" + //
+				"</root>";
+		testCompletionFor(xml, //
+				c("@formatter:off", "<!-- @formatter:off -->", "<!-- @formatter:off"), //
+				c("@formatter:on", "<!-- @formatter:on -->", "<!-- @formatter:on"));
+	}
+
+	private static void assertFormat(String unformatted, String expected, TextEdit... expectedEdits)
+			throws BadLocationException {
+		assertFormat(unformatted, expected, new SharedSettings(), expectedEdits);
+	}
+
+	private static void assertFormat(String unformatted, String expected, SharedSettings sharedSettings,
+			TextEdit... expectedEdits) throws BadLocationException {
+		XMLAssert.assertFormat(null, unformatted, expected, sharedSettings, "test.xml", Boolean.FALSE, expectedEdits);
+	}
+}


### PR DESCRIPTION
Add support for toggling XML formatting with special comments, similar to Eclipse JDT and IntelliJ. Content between <!-- @formatter:off --> and <!-- @formatter:on --> is preserved exactly as-is during formatting.

Here a demo:

<img width="939" height="654" alt="FormatDemo3" src="https://github.com/user-attachments/assets/90dcb881-b51e-444b-9154-d6e92951d973" />

- Add containsText(String) to DOMCharacterData for zero-allocation comment content matching using char-by-char comparison
- Add @formatter:off/on snippet completion
- Add XMLFormatterOffOnTest with 9 test cases

Fixes https://github.com/eclipse-lemminx/lemminx/issues/1648