### PR TITLE
Fix attribute completion for cross-namespace XSD extensions

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/SchemaLocation.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/SchemaLocation.java
@@ -15,6 +15,7 @@ package org.eclipse.lemminx.dom;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -77,6 +78,16 @@ public class SchemaLocation {
 	 */
 	public Collection<SchemaLocationHint> getSchemaLocationHints() {
 		return schemaLocationValuePairs.values();
+	}
+
+	/**
+	 * Returns all namespace/location-hint pairs from this xsi:schemaLocation
+	 * attribute.
+	 *
+	 * @return the set of namespace-to-SchemaLocationHint entries
+	 */
+	public Set<Map.Entry<String, SchemaLocationHint>> getSchemaLocationEntries() {
+		return schemaLocationValuePairs.entrySet();
 	}
 
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/model/ContentModelManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/model/ContentModelManager.java
@@ -26,6 +26,8 @@ import java.util.Set;
 
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.dom.DOMElement;
+import org.eclipse.lemminx.dom.SchemaLocation;
+import org.eclipse.lemminx.dom.SchemaLocationHint;
 import org.eclipse.lemminx.extensions.contentmodel.model.ContentModelProvider.Identifier;
 import org.eclipse.lemminx.extensions.contentmodel.participants.diagnostics.LSPXMLGrammarPool;
 import org.eclipse.lemminx.extensions.contentmodel.settings.XMLFileAssociation;
@@ -167,6 +169,37 @@ public class ContentModelManager {
 			CMDocument cmDocument = findCMDocument(xmlDocument.getDocumentURI(), namespaceURI, null, null);
 			if (cmDocument != null) {
 				documents.add(cmDocument);
+			}
+		}
+		if (documents.isEmpty() && namespaceURI != null) {
+			// No CMDocument found for the requested namespace through direct
+			// association. The namespace may be transitively imported by a
+			// schema declared for another namespace (xs:import).
+			// Load each declared schema (using its declared namespace) and
+			// check if its XS model covers the requested namespace.
+			for (ContentModelProvider modelProvider : modelProviders) {
+				if (modelProvider.adaptFor(xmlDocument, false)) {
+					SchemaLocation schemaLocation = xmlDocument.getSchemaLocation();
+					if (schemaLocation != null) {
+						for (Map.Entry<String, SchemaLocationHint> entry : schemaLocation
+								.getSchemaLocationEntries()) {
+							String declaredNamespace = entry.getKey();
+							SchemaLocationHint locationHint = entry.getValue();
+							String location = locationHint.getHint();
+							if (!StringUtils.isEmpty(location)) {
+								CMDocument cmDocument = findCMDocument(xmlDocument.getDocumentURI(),
+										declaredNamespace, location, modelProvider);
+								if (cmDocument != null && cmDocument.hasNamespace(namespaceURI)) {
+									documents.add(cmDocument);
+									break;
+								}
+							}
+						}
+					}
+					if (!documents.isEmpty()) {
+						break;
+					}
+				}
 			}
 		}
 		return documents;

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/contentmodel/CMXSDDocument.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/contentmodel/CMXSDDocument.java
@@ -529,8 +529,16 @@ public class CMXSDDocument implements CMDocument, XSElementDeclHelper {
 			return null;
 		}
 
-		String documentURI = xercesElement != null ? xercesElement.getOwnerDocument().getDocumentURI()
-				: getSchemaURI(schemaGrammar);
+		String documentURI;
+		if (schemaGrammar != null
+				&& elementDeclaration.getElementDeclaration().getScope() == XSElementDecl.SCOPE_GLOBAL) {
+			// For global elements, xercesElement may point to an xs:element ref
+			// in a different schema than the actual definition.
+			documentURI = getSchemaURI(schemaGrammar);
+		} else {
+			documentURI = xercesElement != null ? xercesElement.getOwnerDocument().getDocumentURI()
+					: getSchemaURI(schemaGrammar);
+		}
 		if (URIUtils.isFileResource(documentURI)) {
 			// Only XML Schema file is supported. In the case of XML file is bound with an
 			// HTTP url and cache is enable, documentURI is a file uri from the cache

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaCompletionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaCompletionExtensionsTest.java
@@ -1684,6 +1684,82 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				c("derivedProp", "<derivedProp></derivedProp>"));
 	}
 
+	// Tests for https://github.com/redhat-developer/vscode-xml/issues/1079
+
+	@Test
+	public void completionAttributeNameWithImportedExtendedType() throws BadLocationException {
+		// Attribute completion for element typed with an extended complexType from an imported schema
+		String xml = "<root xmlns=\"http://example.com/main\"\r\n" + //
+				"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"      xmlns:types=\"http://example.com/types\"\r\n" + //
+				"      xsi:schemaLocation=\"http://example.com/main xsd/import-extended-attrs/main.xsd\">\r\n" + //
+				"  <item | />\r\n" + //
+				"</root>";
+		testCompletionFor(xml, null, "src/test/resources/test.xml", null, //
+				c("id", te(4, 8, 4, 8, "id=\"\""), "id"), //
+				c("version", te(4, 8, 4, 8, "version=\"\""), "version"), //
+				c("category", te(4, 8, 4, 8, "category=\"\""), "category"));
+	}
+
+	@Test
+	public void completionAttributeNameWithImportedBaseType() throws BadLocationException {
+		// Attribute completion for element typed with a base complexType from an imported schema
+		String xml = "<root xmlns=\"http://example.com/main\"\r\n" + //
+				"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"      xmlns:types=\"http://example.com/types\"\r\n" + //
+				"      xsi:schemaLocation=\"http://example.com/main xsd/import-extended-attrs/main.xsd\">\r\n" + //
+				"  <base-item | />\r\n" + //
+				"</root>";
+		testCompletionFor(xml, null, "src/test/resources/test.xml", null, //
+				c("id", te(4, 13, 4, 13, "id=\"\""), "id"));
+	}
+
+	@Test
+	public void completionChildElementWithImportedExtendedType() throws BadLocationException {
+		// Child element completion for element typed with an extended complexType from an imported schema
+		String xml = "<root xmlns=\"http://example.com/main\"\r\n" + //
+				"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"      xmlns:types=\"http://example.com/types\"\r\n" + //
+				"      xsi:schemaLocation=\"http://example.com/main xsd/import-extended-attrs/main.xsd\">\r\n" + //
+				"  <item>\r\n" + //
+				"    <|\r\n" + //
+				"  </item>\r\n" + //
+				"</root>";
+		testCompletionFor(xml, null, "src/test/resources/test.xml", null, //
+				c("types:name", "<types:name></types:name>"));
+	}
+
+	@Test
+	public void completionAttributeWithCrossNamespaceExtension() throws BadLocationException {
+		// Issue #1079: attribute completion for element in imported schema that extends
+		// a type from another imported schema (cross-namespace extension)
+		String xml = "<root xmlns=\"http://example.com/main\"\r\n" + //
+				"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"      xmlns:product=\"http://example.com/product\"\r\n" + //
+				"      xsi:schemaLocation=\"http://example.com/main xsd/import-extended-attrs/main.xsd\">\r\n" + //
+				"  <product:QuestionValue | />\r\n" + //
+				"</root>";
+		testCompletionFor(xml, null, "src/test/resources/test.xml", null, //
+				c("name", te(4, 25, 4, 25, "name=\"\""), "name"), //
+				c("default", te(4, 25, 4, 25, "default=\"\""), "default"), //
+				c("type", te(4, 25, 4, 25, "type=\"\""), "type"), //
+				c("value", te(4, 25, 4, 25, "value=\"\""), "value"), //
+				c("required", te(4, 25, 4, 25, "required=\"false\""), "required"));
+	}
+
+	@Test
+	public void completionAttributeWithCrossNamespaceExtensionBaseAttrsOnly() throws BadLocationException {
+		// Verify base type attributes from cross-namespace extension are available
+		String xml = "<root xmlns=\"http://example.com/main\"\r\n" + //
+				"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"      xmlns:product=\"http://example.com/product\"\r\n" + //
+				"      xsi:schemaLocation=\"http://example.com/main xsd/import-extended-attrs/main.xsd\">\r\n" + //
+				"  <product:QuestionValue | />\r\n" + //
+				"</root>";
+		testCompletionFor(xml, null, "src/test/resources/test.xml", null, //
+				c("value", te(4, 25, 4, 25, "value=\"\""), "value"));
+	}
+
 	@Test
 	public void elementCompletionWithAbstractTypeGeneratesXsiType() throws BadLocationException {
 		// When completing an element whose type is abstract, the generated snippet

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaCrossNamespaceTypeDefTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaCrossNamespaceTypeDefTest.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.contentmodel;
+
+import static org.eclipse.lemminx.XMLAssert.assertHover;
+import static org.eclipse.lemminx.XMLAssert.ll;
+import static org.eclipse.lemminx.XMLAssert.r;
+import static org.eclipse.lemminx.XMLAssert.testTypeDefinitionFor;
+
+import org.apache.xerces.impl.XMLEntityManager;
+import org.apache.xerces.util.URI.MalformedURIException;
+import org.eclipse.lemminx.AbstractCacheBasedTest;
+import org.eclipse.lemminx.commons.BadLocationException;
+import org.eclipse.lemminx.services.XMLLanguageService;
+import org.junit.jupiter.api.Test;
+
+public class XMLSchemaCrossNamespaceTypeDefTest extends AbstractCacheBasedTest {
+
+    @Test
+    public void crossNamespaceGlobalElementTypeDef() throws BadLocationException, MalformedURIException {
+        String xmlFile = "src/test/resources/test.xml";
+        String targetSchemaURI = XMLEntityManager.expandSystemId(
+                "xsd/import-extended-attrs/product.xsd", xmlFile, true);
+
+        String xml = "<root xmlns=\"http://example.com/main\"\r\n" +
+                "      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+                "      xmlns:product=\"http://example.com/product\"\r\n" +
+                "      xsi:schemaLocation=\"http://example.com/main xsd/import-extended-attrs/main.xsd\">\r\n" +
+                "  <product:Question|Value name=\"test\" />\r\n" +
+                "</root>";
+
+        XMLLanguageService xmlLanguageService = new XMLLanguageService();
+        testTypeDefinitionFor(xmlLanguageService, xml, xmlFile,
+                ll(targetSchemaURI, r(4, 3, 4, 24), r(9, 21, 9, 36)));
+    }
+
+    @Test
+    public void issue1079ElementTypeDef() throws BadLocationException, MalformedURIException {
+        String xmlFile = "src/test/resources/test.xml";
+        String targetSchemaURI = XMLEntityManager.expandSystemId(
+                "xsd/issue-1079/product-export-benefits.xsd", xmlFile, true);
+
+        String xml = "<ExportDef xmlns=\"urn:Platform:Export\"\r\n" +
+                "           xmlns:benefits=\"urn:Product:Export:Benefits\"\r\n" +
+                "           xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+                "           xsi:schemaLocation=\"urn:Platform:Export xsd/issue-1079/export-model.xsd\">\r\n" +
+                "  <benefits:Question|Value name=\"Address.Line1\" />\r\n" +
+                "</ExportDef>";
+
+        XMLLanguageService xmlLanguageService = new XMLLanguageService();
+        testTypeDefinitionFor(xmlLanguageService, xml, xmlFile,
+                ll(targetSchemaURI, r(4, 3, 4, 25), r(20, 20, 20, 35)));
+    }
+
+    @Test
+    public void issue1079ElementHover() throws BadLocationException, MalformedURIException {
+        String xmlFile = "src/test/resources/test.xml";
+        String schemaURI = XMLEntityManager.expandSystemId(
+                "xsd/issue-1079/product-export-benefits.xsd", xmlFile, true).replace("///", "/");
+        String xml = "<ExportDef xmlns=\"urn:Platform:Export\"\r\n" +
+                "           xmlns:benefits=\"urn:Product:Export:Benefits\"\r\n" +
+                "           xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+                "           xsi:schemaLocation=\"urn:Platform:Export xsd/issue-1079/export-model.xsd\">\r\n" +
+                "  <benefits:Question|Value name=\"Address.Line1\" />\r\n" +
+                "</ExportDef>";
+        assertHover(xml, xmlFile,
+                "Defines a question value mapping for the export process." + //
+                        System.lineSeparator() + //
+                        System.lineSeparator() + "Source: [product-export-benefits.xsd](" + schemaURI + ")",
+                r(4, 3, 4, 25));
+    }
+
+    @Test
+    public void issue1079AttributeHover() throws BadLocationException, MalformedURIException {
+        String xmlFile = "src/test/resources/test.xml";
+        String schemaURI = XMLEntityManager.expandSystemId(
+                "xsd/issue-1079/product-export-benefits.xsd", xmlFile, true).replace("///", "/");
+        String xml = "<ExportDef xmlns=\"urn:Platform:Export\"\r\n" +
+                "           xmlns:benefits=\"urn:Product:Export:Benefits\"\r\n" +
+                "           xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+                "           xsi:schemaLocation=\"urn:Platform:Export xsd/issue-1079/export-model.xsd\">\r\n" +
+                "  <benefits:QuestionValue na|me=\"Address.Line1\" />\r\n" +
+                "</ExportDef>";
+        assertHover(xml, xmlFile,
+                "The fully qualified question name (e.g. Address.Line1, Contact.Email)." + //
+                        System.lineSeparator() + //
+                        System.lineSeparator() + "Source: [product-export-benefits.xsd](" + schemaURI + ")",
+                r(4, 26, 4, 30));
+    }
+
+    @Test
+    public void crossNamespaceAttributeTypeDef() throws BadLocationException, MalformedURIException {
+        String xmlFile = "src/test/resources/test.xml";
+        String targetSchemaURI = XMLEntityManager.expandSystemId(
+                "xsd/import-extended-attrs/product.xsd", xmlFile, true);
+
+        String xml = "<root xmlns=\"http://example.com/main\"\r\n" +
+                "      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+                "      xmlns:product=\"http://example.com/product\"\r\n" +
+                "      xsi:schemaLocation=\"http://example.com/main xsd/import-extended-attrs/main.xsd\">\r\n" +
+                "  <product:QuestionValue na|me=\"test\" />\r\n" +
+                "</root>";
+
+        XMLLanguageService xmlLanguageService = new XMLLanguageService();
+        testTypeDefinitionFor(xmlLanguageService, xml, xmlFile,
+                ll(targetSchemaURI, r(4, 25, 4, 29), r(13, 39, 13, 45)));
+    }
+}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsi/XSICompletionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsi/XSICompletionExtensionsTest.java
@@ -193,6 +193,22 @@ public class XSICompletionExtensionsTest extends AbstractCacheBasedTest {
 				c("Student", te(3, 23, 3, 23, "Student"), "Student"));
 	}
 
+	@Test
+	public void xsiTypeValueCompletionWithCrossNamespaceImport() throws BadLocationException {
+		// xsi:type value completion for element with a named type from an imported
+		// schema that has derived types (cross-namespace via xs:import)
+		String xml = "<root xmlns=\"http://example.com/main\"\r\n" + //
+				"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"      xmlns:types=\"http://example.com/types\"\r\n" + //
+				"      xsi:schemaLocation=\"http://example.com/main xsd/import-extended-attrs/main.xsd\">\r\n" + //
+				"  <base-item xsi:type=\"|\">\r\n" + //
+				"    <types:name>test</types:name>\r\n" + //
+				"  </base-item>\r\n" + //
+				"</root>";
+		testCompletionFor(xml, "src/test/resources/test.xml",
+				c("types:ExtendedType", te(4, 23, 4, 23, "types:ExtendedType"), "types:ExtendedType"));
+	}
+
 	private SharedSettings singleQuotesSharedSettings() {
 		SharedSettings settings = new SharedSettings();
 		settings.getPreferences().setQuoteStyle(QuoteStyle.singleQuotes);

--- a/org.eclipse.lemminx/src/test/resources/xsd/import-extended-attrs/main.xsd
+++ b/org.eclipse.lemminx/src/test/resources/xsd/import-extended-attrs/main.xsd
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://example.com/main"
+           xmlns:tns="http://example.com/main"
+           xmlns:types="http://example.com/types"
+           xmlns:product="http://example.com/product"
+           elementFormDefault="qualified">
+
+    <xs:import namespace="http://example.com/types" schemaLocation="types.xsd"/>
+    <xs:import namespace="http://example.com/product" schemaLocation="product.xsd"/>
+
+    <xs:element name="root">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="item" type="types:ExtendedType"/>
+                <xs:element name="base-item" type="types:BaseType" minOccurs="0"/>
+                <xs:element ref="product:QuestionValue" minOccurs="0"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string"/>
+        </xs:complexType>
+    </xs:element>
+
+</xs:schema>

--- a/org.eclipse.lemminx/src/test/resources/xsd/import-extended-attrs/platform.xsd
+++ b/org.eclipse.lemminx/src/test/resources/xsd/import-extended-attrs/platform.xsd
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://example.com/platform"
+           xmlns:tns="http://example.com/platform"
+           elementFormDefault="qualified">
+
+    <xs:complexType name="TagValueType">
+        <xs:attribute name="value" type="xs:string"/>
+        <xs:attribute name="required" type="xs:boolean"/>
+    </xs:complexType>
+
+</xs:schema>

--- a/org.eclipse.lemminx/src/test/resources/xsd/import-extended-attrs/product.xsd
+++ b/org.eclipse.lemminx/src/test/resources/xsd/import-extended-attrs/product.xsd
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://example.com/product"
+           xmlns:tns="http://example.com/product"
+           xmlns:platform="http://example.com/platform"
+           elementFormDefault="qualified">
+
+    <xs:import namespace="http://example.com/platform" schemaLocation="platform.xsd"/>
+
+    <xs:element name="QuestionValue">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="platform:TagValueType">
+                    <xs:attribute name="name" type="xs:string" use="required"/>
+                    <xs:attribute name="default" type="xs:string"/>
+                    <xs:attribute name="type" type="xs:string"/>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+</xs:schema>

--- a/org.eclipse.lemminx/src/test/resources/xsd/import-extended-attrs/types.xsd
+++ b/org.eclipse.lemminx/src/test/resources/xsd/import-extended-attrs/types.xsd
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://example.com/types"
+           xmlns:tns="http://example.com/types"
+           elementFormDefault="qualified">
+
+    <xs:complexType name="BaseType">
+        <xs:sequence>
+            <xs:element name="name" type="xs:string"/>
+        </xs:sequence>
+        <xs:attribute name="id" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="ExtendedType">
+        <xs:complexContent>
+            <xs:extension base="tns:BaseType">
+                <xs:sequence>
+                    <xs:element name="description" type="xs:string" minOccurs="0"/>
+                </xs:sequence>
+                <xs:attribute name="version" type="xs:string"/>
+                <xs:attribute name="category" type="xs:string"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+</xs:schema>

--- a/org.eclipse.lemminx/src/test/resources/xsd/issue-1079/export-model.xsd
+++ b/org.eclipse.lemminx/src/test/resources/xsd/issue-1079/export-model.xsd
@@ -1,0 +1,20 @@
+<xsd:schema targetNamespace="urn:Platform:Export"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:benefits="urn:Product:Export:Benefits"
+            xmlns:export="urn:Platform:Export"
+            elementFormDefault="qualified">
+
+  <xsd:import namespace="urn:Product:Export:Benefits" schemaLocation="product-export-benefits.xsd"/>
+
+  <xsd:element name="ExportDef">
+    <xsd:annotation>
+      <xsd:documentation>Root element that defines an export configuration with question value mappings.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="benefits:QuestionValue" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+</xsd:schema>

--- a/org.eclipse.lemminx/src/test/resources/xsd/issue-1079/product-export-benefits.xsd
+++ b/org.eclipse.lemminx/src/test/resources/xsd/issue-1079/product-export-benefits.xsd
@@ -1,0 +1,49 @@
+<xsd:schema targetNamespace="urn:Product:Export:Benefits"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:benefits="urn:Product:Export:Benefits"
+            elementFormDefault="qualified">
+
+  <xsd:simpleType name="QuestionNameType">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="[A-Za-z]+(\.[A-Za-z0-9]+)*"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="QuestionDataType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="String"/>
+      <xsd:enumeration value="Integer"/>
+      <xsd:enumeration value="Boolean"/>
+      <xsd:enumeration value="Date"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:element name="QuestionValue">
+    <xsd:annotation>
+      <xsd:documentation>Defines a question value mapping for the export process.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:attribute name="default" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>The default value to use when the question has no answer.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="name" type="benefits:QuestionNameType" use="required">
+        <xsd:annotation>
+          <xsd:documentation>The fully qualified question name (e.g. Address.Line1, Contact.Email).</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="ignore-invalid" type="xsd:boolean" default="false">
+        <xsd:annotation>
+          <xsd:documentation>When true, invalid answers are silently ignored instead of raising an error.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="type" type="benefits:QuestionDataType">
+        <xsd:annotation>
+          <xsd:documentation>The expected data type of the answer (String, Integer, Boolean, Date).</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+</xsd:schema>


### PR DESCRIPTION
## Summary

Fixes https://github.com/redhat-developer/vscode-xml/issues/1079

When an element is defined in a transitively imported XSD schema (via `xs:import`) and extends a type from another namespace (`xs:extension`), attribute completion was not working. Only `xsi:nil` and `xsi:type` were proposed instead of the element's actual attributes.

### Given `platform.xsd`

```xml
<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
           targetNamespace="http://example.com/platform">

    <xs:complexType name="TagValueType">
        <xs:attribute name="value" type="xs:string"/>
        <xs:attribute name="required" type="xs:boolean"/>
    </xs:complexType>

</xs:schema>
```

### Given `product.xsd` (imports `platform.xsd`)

```xml
<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
           targetNamespace="http://example.com/product"
           xmlns:platform="http://example.com/platform">

    <xs:import namespace="http://example.com/platform" schemaLocation="platform.xsd"/>

    <xs:element name="QuestionValue">
        <xs:complexType>
            <xs:complexContent>
                <xs:extension base="platform:TagValueType">
                    <xs:attribute name="name" type="xs:string" use="required"/>
                    <xs:attribute name="default" type="xs:string"/>
                    <xs:attribute name="type" type="xs:string"/>
                </xs:extension>
            </xs:complexContent>
        </xs:complexType>
    </xs:element>

</xs:schema>
```

### Given `main.xsd` (imports `product.xsd`)

```xml
<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
           targetNamespace="http://example.com/main"
           xmlns:product="http://example.com/product">

    <xs:import namespace="http://example.com/product" schemaLocation="product.xsd"/>

    <xs:element name="root">
        <xs:complexType>
            <xs:sequence>
                <xs:element ref="product:QuestionValue" minOccurs="0"/>
            </xs:sequence>
        </xs:complexType>
    </xs:element>

</xs:schema>
```

### Given XML

```xml
<root xmlns="http://example.com/main"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xmlns:product="http://example.com/product"
      xsi:schemaLocation="http://example.com/main main.xsd">
  <product:QuestionValue | />
</root>
```

### Before (bug)

Completion only shows: `xsi:nil`, `xsi:type`

### After (fix)

Completion shows: `name`, `default`, `type`, `value`, `required`

Here a demo:

<img width="939" height="489" alt="XSDAttrDemo" src="https://github.com/user-attachments/assets/7fd0ea42-72ef-4331-b2e0-9b84dce59fe0" />


## Fix

`ContentModelManager.findCMDocument()` had no fallback for namespaces only available transitively via `xs:import`. Added a fallback that iterates declared `xsi:schemaLocation` entries and checks if the loaded schema's `XSModel` covers the requested namespace.
