### PR TITLE
Fix XML encoding detection for schema documentation hover

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/DOMUtils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/DOMUtils.java
@@ -12,6 +12,7 @@
 package org.eclipse.lemminx.utils;
 
 import org.eclipse.lemminx.commons.CharSequenceReader;
+import java.io.InputStream;
 import java.net.URL;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -241,9 +242,10 @@ public class DOMUtils {
 	 * @return the DOM document from the given XML Schema uri.
 	 */
 	public static DOMDocument loadDocument(String documentURI, URIResolverExtensionManager resolverExtensionManager) {
-		try {
-			return DOMParser.getInstance().parse(IOUtils.convertStreamToString(new URL(documentURI).openStream()),
-					documentURI, resolverExtensionManager);
+		try (InputStream is = new URL(documentURI).openStream()) {
+			byte[] bytes = is.readAllBytes();
+			String text = new String(bytes, IOUtils.detectXmlEncoding(bytes));
+			return DOMParser.getInstance().parse(text, documentURI, resolverExtensionManager);
 		} catch (Exception e) {
 			return null;
 		}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/IOUtils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/IOUtils.java
@@ -12,11 +12,13 @@
 package org.eclipse.lemminx.utils;
 
 import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
 
 /**
  * IO utilities class
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -25,7 +27,7 @@ public class IOUtils {
 	/**
 	 * Convert the given {@link InputStream} into a String. The source InputStream
 	 * will then be closed.
-	 * 
+	 *
 	 * @param is the input stream
 	 * @return the given input stream in a String.
 	 */
@@ -34,5 +36,120 @@ public class IOUtils {
 			s.useDelimiter("\\A");
 			return s.hasNext() ? s.next() : "";
 		}
+	}
+
+	/**
+	 * Detect the encoding declared in the XML prolog of the given bytes.
+	 *
+	 * <p>
+	 * Scans only the first 200 bytes char-by-char for the
+	 * {@code encoding="..."} attribute in {@code <?xml ...?>}.
+	 * Returns UTF-8 if no prolog, no encoding attribute, or
+	 * an unsupported encoding name is found.
+	 * </p>
+	 *
+	 * @param bytes the raw bytes of an XML document.
+	 * @return the detected {@link Charset}, never null.
+	 */
+	public static Charset detectXmlEncoding(byte[] bytes) {
+		int len = Math.min(bytes.length, 200);
+		int i = 0;
+
+		// Skip UTF-8 BOM (EF BB BF)
+		if (len >= 3
+				&& (bytes[0] & 0xFF) == 0xEF
+				&& (bytes[1] & 0xFF) == 0xBB
+				&& (bytes[2] & 0xFF) == 0xBF) {
+			i = 3;
+		}
+
+		// Skip leading whitespace
+		while (i < len && isXmlWhitespace(bytes[i])) {
+			i++;
+		}
+
+		// Check for <?xml followed by whitespace
+		if (i + 6 > len
+				|| bytes[i] != '<'
+				|| bytes[i + 1] != '?'
+				|| bytes[i + 2] != 'x'
+				|| bytes[i + 3] != 'm'
+				|| bytes[i + 4] != 'l'
+				|| !isXmlWhitespace(bytes[i + 5])) {
+			return StandardCharsets.UTF_8;
+		}
+		i += 6;
+
+		// Scan for encoding="..." within the XML declaration
+		while (i < len - 1) {
+			if (bytes[i] == '?' && bytes[i + 1] == '>') {
+				break;
+			}
+
+			// Skip quoted attribute values (e.g. version="1.0")
+			if (bytes[i] == '"' || bytes[i] == '\'') {
+				byte quote = bytes[i];
+				i++;
+				while (i < len && bytes[i] != quote) {
+					i++;
+				}
+				if (i < len) {
+					i++;
+				}
+				continue;
+			}
+
+			// Match 'encoding' keyword
+			if (i + 8 <= len
+					&& bytes[i] == 'e'
+					&& bytes[i + 1] == 'n'
+					&& bytes[i + 2] == 'c'
+					&& bytes[i + 3] == 'o'
+					&& bytes[i + 4] == 'd'
+					&& bytes[i + 5] == 'i'
+					&& bytes[i + 6] == 'n'
+					&& bytes[i + 7] == 'g') {
+				i += 8;
+				// Skip whitespace before '='
+				while (i < len && isXmlWhitespace(bytes[i])) {
+					i++;
+				}
+				if (i >= len || bytes[i] != '=') {
+					break;
+				}
+				i++;
+				// Skip whitespace after '='
+				while (i < len && isXmlWhitespace(bytes[i])) {
+					i++;
+				}
+				if (i >= len) {
+					break;
+				}
+				byte quote = bytes[i];
+				if (quote != '"' && quote != '\'') {
+					break;
+				}
+				i++;
+				int start = i;
+				while (i < len && bytes[i] != quote) {
+					i++;
+				}
+				if (i >= len) {
+					break;
+				}
+				String encodingName = new String(bytes, start, i - start, StandardCharsets.US_ASCII);
+				try {
+					return Charset.forName(encodingName);
+				} catch (Exception e) {
+					return StandardCharsets.UTF_8;
+				}
+			}
+			i++;
+		}
+		return StandardCharsets.UTF_8;
+	}
+
+	private static boolean isXmlWhitespace(byte b) {
+		return b == ' ' || b == '\t' || b == '\r' || b == '\n';
 	}
 }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/relaxng/xml/hover/RelaxNGHoverTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/relaxng/xml/hover/RelaxNGHoverTest.java
@@ -99,6 +99,54 @@ public class RelaxNGHoverTest extends AbstractCacheBasedTest {
 				System.lineSeparator() + "Source: [docCollision.rng](" + schemaURI + ")", r(5, 3, 5, 6));
 	}
 
+	@Test
+	public void hoverWithUmlautNoEncodingDeclared() throws BadLocationException, MalformedURIException {
+		String schemaURI = getRelaxNGFileURI("umlautDoc.rng");
+		String xml = "<?xml-model href=\"umlautDoc.rng\" ?>\r\n" + //
+				"<layout>\r\n" + //
+				"  <te|xt>hello</text>\r\n" + //
+				"</layout>";
+		assertHover(xml, "Textinhalt mit Umlauten: ä, ö, ü, ß" + //
+				System.lineSeparator() + //
+				System.lineSeparator() + "Source: [umlautDoc.rng](" + schemaURI + ")", r(2, 3, 2, 7));
+	}
+
+	@Test
+	public void hoverWithUmlautNoEncodingDeclaredOnElement() throws BadLocationException, MalformedURIException {
+		String schemaURI = getRelaxNGFileURI("umlautDoc.rng");
+		String xml = "<?xml-model href=\"umlautDoc.rng\" ?>\r\n" + //
+				"<lay|out>\r\n" + //
+				"  <text>hello</text>\r\n" + //
+				"</layout>";
+		assertHover(xml, "Seitenlayout für die Ausgabe" + //
+				System.lineSeparator() + //
+				System.lineSeparator() + "Source: [umlautDoc.rng](" + schemaURI + ")", r(1, 1, 1, 7));
+	}
+
+	@Test
+	public void hoverWithUmlautUTF8Declared() throws BadLocationException, MalformedURIException {
+		String schemaURI = getRelaxNGFileURI("umlautDocUTF8.rng");
+		String xml = "<?xml-model href=\"umlautDocUTF8.rng\" ?>\r\n" + //
+				"<layout>\r\n" + //
+				"  <te|xt>hello</text>\r\n" + //
+				"</layout>";
+		assertHover(xml, "Textinhalt mit Umlauten: ä, ö, ü, ß" + //
+				System.lineSeparator() + //
+				System.lineSeparator() + "Source: [umlautDocUTF8.rng](" + schemaURI + ")", r(2, 3, 2, 7));
+	}
+
+	@Test
+	public void hoverWithUmlautISO88591Declared() throws BadLocationException, MalformedURIException {
+		String schemaURI = getRelaxNGFileURI("umlautDocISO88591.rng");
+		String xml = "<?xml-model href=\"umlautDocISO88591.rng\" ?>\r\n" + //
+				"<layout>\r\n" + //
+				"  <te|xt>hello</text>\r\n" + //
+				"</layout>";
+		assertHover(xml, "Textinhalt mit Umlauten: ä, ö, ü, ß" + //
+				System.lineSeparator() + //
+				System.lineSeparator() + "Source: [umlautDocISO88591.rng](" + schemaURI + ")", r(2, 3, 2, 7));
+	}
+
 	private static void assertHover(String value, String expectedHoverLabel, Range expectedHoverRange)
 			throws BadLocationException {
 		XMLAssert.assertHover(new XMLLanguageService(), value, null, "src/test/resources/relaxng/test.xml",

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/utils/IOUtilsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/utils/IOUtilsTest.java
@@ -1,0 +1,125 @@
+/**
+ *  Copyright (c) 2024 Red Hat Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v2.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *  Red Hat Inc. - initial API and implementation
+ */
+package org.eclipse.lemminx.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+public class IOUtilsTest {
+
+	@Test
+	public void noProlog() {
+		assertEncoding("<root/>", StandardCharsets.UTF_8);
+	}
+
+	@Test
+	public void emptyBytes() {
+		assertEncoding("", StandardCharsets.UTF_8);
+	}
+
+	@Test
+	public void prologWithoutEncoding() {
+		assertEncoding("<?xml version=\"1.0\"?>", StandardCharsets.UTF_8);
+	}
+
+	@Test
+	public void prologWithUtf8() {
+		assertEncoding("<?xml version=\"1.0\" encoding=\"UTF-8\"?>", StandardCharsets.UTF_8);
+	}
+
+	@Test
+	public void prologWithIso88591() {
+		assertEncoding("<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>",
+				Charset.forName("ISO-8859-1"));
+	}
+
+	@Test
+	public void prologWithSingleQuotes() {
+		assertEncoding("<?xml version='1.0' encoding='ISO-8859-1'?>",
+				Charset.forName("ISO-8859-1"));
+	}
+
+	@Test
+	public void prologWithSpacesAroundEquals() {
+		assertEncoding("<?xml version = \"1.0\" encoding = \"ISO-8859-1\" ?>",
+				Charset.forName("ISO-8859-1"));
+	}
+
+	@Test
+	public void prologWithUtf8Bom() {
+		byte[] bom = new byte[] { (byte) 0xEF, (byte) 0xBB, (byte) 0xBF };
+		byte[] xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>".getBytes(StandardCharsets.US_ASCII);
+		byte[] bytes = new byte[bom.length + xml.length];
+		System.arraycopy(bom, 0, bytes, 0, bom.length);
+		System.arraycopy(xml, 0, bytes, bom.length, xml.length);
+		assertEquals(StandardCharsets.UTF_8, IOUtils.detectXmlEncoding(bytes));
+	}
+
+	@Test
+	public void prologWithUtf8BomAndIso88591() {
+		byte[] bom = new byte[] { (byte) 0xEF, (byte) 0xBB, (byte) 0xBF };
+		byte[] xml = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>".getBytes(StandardCharsets.US_ASCII);
+		byte[] bytes = new byte[bom.length + xml.length];
+		System.arraycopy(bom, 0, bytes, 0, bom.length);
+		System.arraycopy(xml, 0, bytes, bom.length, xml.length);
+		assertEquals(Charset.forName("ISO-8859-1"), IOUtils.detectXmlEncoding(bytes));
+	}
+
+	@Test
+	public void invalidEncodingFallsBackToUtf8() {
+		assertEncoding("<?xml version=\"1.0\" encoding=\"INVALID-ENCODING-XYZ\"?>",
+				StandardCharsets.UTF_8);
+	}
+
+	@Test
+	public void processingInstructionNotProlog() {
+		assertEncoding("<?xml-stylesheet type=\"text/xsl\" href=\"style.xsl\"?>",
+				StandardCharsets.UTF_8);
+	}
+
+	@Test
+	public void prologWithLeadingWhitespace() {
+		assertEncoding("  \t\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>",
+				Charset.forName("ISO-8859-1"));
+	}
+
+	@Test
+	public void prologEncodingOnly() {
+		assertEncoding("<?xml encoding=\"ISO-8859-1\"?>",
+				Charset.forName("ISO-8859-1"));
+	}
+
+	@Test
+	public void prologWithWindows1252() {
+		assertEncoding("<?xml version=\"1.0\" encoding=\"windows-1252\"?>",
+				Charset.forName("windows-1252"));
+	}
+
+	@Test
+	public void truncatedPrologNoClosingQuote() {
+		assertEncoding("<?xml version=\"1.0\" encoding=\"UTF-8", StandardCharsets.UTF_8);
+	}
+
+	@Test
+	public void truncatedPrologNoEquals() {
+		assertEncoding("<?xml version=\"1.0\" encoding", StandardCharsets.UTF_8);
+	}
+
+	private static void assertEncoding(String xml, Charset expected) {
+		assertEquals(expected, IOUtils.detectXmlEncoding(xml.getBytes(StandardCharsets.US_ASCII)));
+	}
+}

--- a/org.eclipse.lemminx/src/test/resources/relaxng/umlautDoc.rng
+++ b/org.eclipse.lemminx/src/test/resources/relaxng/umlautDoc.rng
@@ -1,0 +1,12 @@
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">
+  <start>
+    <element name="layout">
+      <a:documentation>Seitenlayout für die Ausgabe</a:documentation>
+      <element name="text">
+        <a:documentation>Textinhalt mit Umlauten: ä, ö, ü, ß</a:documentation>
+        <text/>
+      </element>
+    </element>
+  </start>
+</grammar>

--- a/org.eclipse.lemminx/src/test/resources/relaxng/umlautDocISO88591.rng
+++ b/org.eclipse.lemminx/src/test/resources/relaxng/umlautDocISO88591.rng
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">
+  <start>
+    <element name="layout">
+      <a:documentation>Seitenlayout für die Ausgabe</a:documentation>
+      <element name="text">
+        <a:documentation>Textinhalt mit Umlauten: ä, ö, ü, ß</a:documentation>
+        <text/>
+      </element>
+    </element>
+  </start>
+</grammar>

--- a/org.eclipse.lemminx/src/test/resources/relaxng/umlautDocUTF8.rng
+++ b/org.eclipse.lemminx/src/test/resources/relaxng/umlautDocUTF8.rng
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">
+  <start>
+    <element name="layout">
+      <a:documentation>Seitenlayout für die Ausgabe</a:documentation>
+      <element name="text">
+        <a:documentation>Textinhalt mit Umlauten: ä, ö, ü, ß</a:documentation>
+        <text/>
+      </element>
+    </element>
+  </start>
+</grammar>


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-xml/issues/1097

IOUtils.convertStreamToString() used Scanner(InputStream) which defaults to the platform charset. On Windows this is typically Windows-1252, not UTF-8, causing corruption of non-ASCII characters (e.g. German umlauts) in RNG/XSD schema documentation shown in hover tooltips.

Add IOUtils.detectXmlEncoding() which scans the first 200 bytes of the XML prolog char-by-char to extract the declared encoding attribute, falling back to UTF-8 when no prolog, no encoding attribute, or an unsupported encoding name is found.

DOMUtils.loadDocument() now reads raw bytes and uses detectXmlEncoding() to respect the declared encoding when loading schema documents.