### PR TITLE
Fix: add file path completion to href in <?xml-model?> PI

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/XMLModel.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/XMLModel.java
@@ -130,8 +130,28 @@ public class XMLModel {
 	}
 
 	/**
+	 * Returns the {@link XMLModel} that wraps the given PI node, or null if the
+	 * node is not an xml-model PI declared in the document.
+	 *
+	 * @param node     the DOM node.
+	 * @param document the DOM document.
+	 * @return the matching XMLModel or null.
+	 */
+	public static XMLModel findXMLModel(DOMNode node, DOMDocument document) {
+		if (!isXMLModel(node)) {
+			return null;
+		}
+		for (XMLModel xmlModel : document.getXMLModels()) {
+			if (xmlModel.processingInstruction == node) {
+				return xmlModel;
+			}
+		}
+		return null;
+	}
+
+	/**
 	 * Returns the href range and null otherwise.
-	 * 
+	 *
 	 * @return the href range and null otherwise.
 	 */
 	public DOMRange getHrefNode() {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/filepath/participants/FilePathCompletionParticipant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/filepath/participants/FilePathCompletionParticipant.java
@@ -33,6 +33,7 @@ import org.eclipse.lemminx.dom.DOMText;
 import org.eclipse.lemminx.dom.DTDDeclParameter;
 import org.eclipse.lemminx.dom.NoNamespaceSchemaLocation;
 import org.eclipse.lemminx.dom.SchemaLocation;
+import org.eclipse.lemminx.dom.XMLModel;
 import org.eclipse.lemminx.extensions.filepath.FilePathPlugin;
 import org.eclipse.lemminx.extensions.filepath.IFilePathExpression;
 import org.eclipse.lemminx.extensions.filepath.SimpleFilePathExpression;
@@ -106,6 +107,15 @@ public class FilePathCompletionParticipant extends CompletionParticipantAdapter 
 
 		public Character getSeparator() {
 			return ' ';
+		};
+	};
+
+	private static final IFilePathExpression XML_MODEL_HREF_FILE_PATH_EXPRESSION = new SimpleFilePathExpression() {
+
+		@Override
+		protected boolean acceptFile(Path path) {
+			String fileName = getFileName(path);
+			return DOMUtils.isXSD(fileName) || DOMUtils.isDTD(fileName) || DOMUtils.isRelaxNGUri(fileName);
 		};
 	};
 
@@ -206,6 +216,24 @@ public class FilePathCompletionParticipant extends CompletionParticipantAdapter 
 		DTDDeclParameter systemId = xmlDocument.getDoctype().getSystemIdNode();
 		addFileCompletionItems(xmlDocument, systemId.getStart() + 1 /* increment to be after the quote */,
 				systemId.getEnd() - 1, request.getOffset(), DOCTYPE_FILE_PATH_EXPRESSION, response, cancelChecker);
+	}
+
+	@Override
+	public void onXMLModelHref(String value, ICompletionRequest request, ICompletionResponse response,
+			CancelChecker cancelChecker) throws Exception {
+		// File path completion on <?xml-model href="..." ?>
+		DOMDocument xmlDocument = request.getXMLDocument();
+		XMLModel xmlModel = XMLModel.findXMLModel(request.getNode(), xmlDocument);
+		if (xmlModel == null) {
+			return;
+		}
+		DOMRange hrefNode = xmlModel.getHrefNode();
+		if (hrefNode == null) {
+			return;
+		}
+		addFileCompletionItems(xmlDocument, hrefNode.getStart() + 1 /* increment to be after the quote */,
+				hrefNode.getEnd() - 1, request.getOffset(), XML_MODEL_HREF_FILE_PATH_EXPRESSION, response,
+				cancelChecker);
 	}
 
 	private static void addFileCompletionItems(DOMDocument xmlDocument, int startOffset, int endOffset,

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLCompletions.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLCompletions.java
@@ -32,8 +32,10 @@ import org.eclipse.lemminx.dom.DOMAttr;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.dom.DOMElement;
 import org.eclipse.lemminx.dom.DOMNode;
+import org.eclipse.lemminx.dom.DOMRange;
 import org.eclipse.lemminx.dom.DOMText;
 import org.eclipse.lemminx.dom.DTDDeclParameter;
+import org.eclipse.lemminx.dom.XMLModel;
 import org.eclipse.lemminx.dom.parser.Scanner;
 import org.eclipse.lemminx.dom.parser.ScannerState;
 import org.eclipse.lemminx.dom.parser.TokenType;
@@ -267,6 +269,25 @@ public class XMLCompletions {
 						}
 						if (offset <= scanner.getTokenEnd()) {
 							collectInsideContent(completionRequest, completionResponse, cancelChecker);
+							return completionResponse;
+						}
+						break;
+					case PIContent:
+						if (scanner.getTokenOffset() <= offset && offset <= scanner.getTokenEnd()) {
+							XMLModel xmlModel = XMLModel.findXMLModel(completionRequest.getNode(),
+									xmlDocument);
+							if (xmlModel != null) {
+								DOMRange hrefNode = xmlModel.getHrefNode();
+								if (hrefNode != null) {
+									int hrefStart = hrefNode.getStart();
+									int hrefEnd = hrefNode.getEnd();
+									if (hrefStart < offset && offset <= hrefEnd - 1) {
+										collectXMLModelHrefSuggestions(hrefStart, hrefEnd,
+												completionRequest, completionResponse, cancelChecker);
+										return completionResponse;
+									}
+								}
+							}
 							return completionResponse;
 						}
 						break;
@@ -1026,6 +1047,57 @@ public class XMLCompletions {
 			} catch (Exception e) {
 				LOGGER.log(Level.SEVERE, "While performing ICompletionParticipant#onDTDSystemId", e);
 			}
+		}
+	}
+
+	/**
+	 * Collects completion suggestions for the href pseudo-attribute value of an
+	 * {@code <?xml-model?>} processing instruction.
+	 *
+	 * @param valueStart         the start offset of the href value (including the
+	 *                           opening quote)
+	 * @param valueEnd           the end offset of the href value (including the
+	 *                           closing quote)
+	 * @param completionRequest  the completion request
+	 * @param completionResponse the completion response
+	 * @param cancelChecker      the cancel checker
+	 */
+	private void collectXMLModelHrefSuggestions(int valueStart, int valueEnd, CompletionRequest completionRequest,
+			CompletionResponse completionResponse, CancelChecker cancelChecker) {
+		Collection<ICompletionParticipant> completionParticipants = getCompletionParticipants();
+		if (completionParticipants.isEmpty()) {
+			return;
+		}
+		int offset = completionRequest.getOffset();
+		CharSequence text = completionRequest.getXMLDocument().getTextSequence();
+		// Adjust range to exclude quotes
+		int valueContentStart = valueStart + 1;
+		int valueContentEnd = valueEnd - 1;
+		String valuePrefix = offset >= valueContentStart && offset <= valueContentEnd
+				? StringUtils.getString(text, valueContentStart, offset)
+				: "";
+		try {
+			Range replaceRange = getReplaceRange(valueContentStart, valueContentEnd, completionRequest);
+			completionRequest.setReplaceRange(replaceRange);
+			for (ICompletionParticipant participant : completionParticipants) {
+				try {
+					participant.onXMLModelHref(valuePrefix, completionRequest, completionResponse, cancelChecker);
+				} catch (CancellationException e) {
+					throw e;
+				} catch (Exception e) {
+					LOGGER.log(Level.SEVERE,
+							"While performing ICompletionParticipant#onXMLModelHref for participant '"
+									+ participant.getClass().getName() + "'.",
+							e);
+				}
+			}
+		} catch (BadLocationException e) {
+			LOGGER.log(Level.SEVERE,
+					"While performing Completions, getReplaceRange() was given a bad Offset location", e);
+		} catch (CancellationException e) {
+			throw e;
+		} catch (Exception e) {
+			LOGGER.log(Level.SEVERE, "While performing ICompletionParticipant#onXMLModelHref", e);
 		}
 	}
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/extensions/completion/ICompletionParticipant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/extensions/completion/ICompletionParticipant.java
@@ -60,6 +60,22 @@ public interface ICompletionParticipant {
 			throws Exception;
 
 	/**
+	 * Collects and stores completion items for the href pseudo-attribute of an
+	 * {@code <?xml-model?>} processing instruction.
+	 *
+	 * @param valuePrefix the href value before the offset in which completion was
+	 *                    invoked
+	 * @param request     the completion request
+	 * @param response    the completion response
+	 * @throws Exception
+	 */
+	default void onXMLModelHref(String valuePrefix, ICompletionRequest request, ICompletionResponse response,
+			CancelChecker cancelChecker)
+			throws Exception {
+		// Do nothing
+	}
+
+	/**
 	 * Returns the completion item resolver that corresponds to the given
 	 * participant id or null otherwise.
 	 *

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/snippets/XMLDeclarationSnippetContext.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/snippets/XMLDeclarationSnippetContext.java
@@ -32,7 +32,7 @@ public class XMLDeclarationSnippetContext implements IXMLSnippetContext {
 		DOMDocument document = request.getXMLDocument();
 		DOMNode node = request.getNode();
 		int offset = request.getOffset();
-		if ((node.isComment() || node.isDoctype()) && offset < node.getEnd()) {
+		if ((node.isComment() || node.isDoctype() || node.isProcessingInstruction()) && offset < node.getEnd()) {
 			// completion was triggered inside comment, xml processing instruction
 			// --> <?xml version="1.0" encoding="UTF-8" | ?>
 			return false;

--- a/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/services/snippets/processing-instruction-snippets.json
+++ b/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/services/snippets/processing-instruction-snippets.json
@@ -1,7 +1,21 @@
 {
+	"Insert XML Model": {
+	  "prefix": [
+		"<?xml-model",
+		"xml-model"
+	  ],
+	  "suffix": "?>",
+	  "body": [
+		"<?xml-model href=\"${1:file}\"?>${0}"
+	  ],
+	  "label": "Insert xml-model",
+	  "description": "Insert XML Model Processing Instruction",
+	  "sortText": "model"
+	},
 	"Insert XML Model: XSD": {
 	  "prefix": [
-		"<?xml-model"
+		"<?xml-model",
+		"xml-model"
 	  ],
 	  "suffix": "?>",
 	  "body": [
@@ -13,7 +27,8 @@
 	},
 	"Insert XML Model: DTD": {
 		"prefix": [
-		  "<?xml-model"
+		  "<?xml-model",
+		  "xml-model"
 		],
 		"suffix": "?>",
 		"body": [
@@ -25,7 +40,8 @@
 	  },
 	"Insert Stylesheet: XSL": {
 		"prefix": [
-		  "<?xml-stylesheet"
+		  "<?xml-stylesheet",
+		  "xml-stylesheet"
 		],
 		"suffix": "?>",
 		"body": [
@@ -37,7 +53,8 @@
 	},
 	"Insert Stylesheet: CSS": {
 		"prefix": [
-		  "<?xml-stylesheet"
+		  "<?xml-stylesheet",
+		  "xml-stylesheet"
 		],
 		"suffix": "?>",
 		"body": [

--- a/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/services/snippets/xml-declaration-snippets.json
+++ b/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/services/snippets/xml-declaration-snippets.json
@@ -1,7 +1,8 @@
 {
   "Insert XML Declaration": {
     "prefix": [
-      "<?xml"
+      "<?xml",
+      "xml"
     ],
     "suffix": "?>",
     "body": [
@@ -13,7 +14,8 @@
   },
   "Insert XML Declaration with standalone": {
     "prefix": [
-      "<?xml"
+      "<?xml",
+      "xml"
     ],
     "suffix": "?>",
     "body": [

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/XMLAssert.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/XMLAssert.java
@@ -142,7 +142,7 @@ public class XMLAssert {
 
 	public static final int XML_DECLARATION_SNIPPETS = 2;
 
-	public static final int PROCESSING_INSTRUCTION_SNIPPETS = 4;
+	public static final int PROCESSING_INSTRUCTION_SNIPPETS = 5;
 
 	public static final int REGION_SNIPPETS = 2;
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaCrossNamespaceTypeDefTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaCrossNamespaceTypeDefTest.java
@@ -12,8 +12,11 @@
 package org.eclipse.lemminx.extensions.contentmodel;
 
 import static org.eclipse.lemminx.XMLAssert.assertHover;
+import static org.eclipse.lemminx.XMLAssert.c;
 import static org.eclipse.lemminx.XMLAssert.ll;
 import static org.eclipse.lemminx.XMLAssert.r;
+import static org.eclipse.lemminx.XMLAssert.te;
+import static org.eclipse.lemminx.XMLAssert.testCompletionFor;
 import static org.eclipse.lemminx.XMLAssert.testTypeDefinitionFor;
 
 import org.apache.xerces.impl.XMLEntityManager;
@@ -95,6 +98,32 @@ public class XMLSchemaCrossNamespaceTypeDefTest extends AbstractCacheBasedTest {
                         System.lineSeparator() + //
                         System.lineSeparator() + "Source: [product-export-benefits.xsd](" + schemaURI + ")",
                 r(4, 26, 4, 30));
+    }
+
+    @Test
+    public void issue1079ElementCompletionWithSchemaLocation() throws BadLocationException {
+        String xml = "<ExportDef xmlns=\"urn:Platform:Export\"\r\n" +
+                "           xmlns:benefits=\"urn:Product:Export:Benefits\"\r\n" +
+                "           xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+                "           xsi:schemaLocation=\"urn:Platform:Export xsd/issue-1079/export-model.xsd\">\r\n" +
+                "  <|\r\n" +
+                "</ExportDef>";
+        testCompletionFor(xml, null, "src/test/resources/test.xml", null,
+                c("benefits:QuestionValue", "<benefits:QuestionValue name=\"\" />"));
+    }
+
+    @Test
+    public void issue1079ElementCompletionWithoutImportSchemaLocation() throws BadLocationException {
+        // xs:import without schemaLocation — resolved only via xsi:schemaLocation
+        String xml = "<ExportDef xmlns=\"urn:Platform:Export\"\r\n" +
+                "           xmlns:benefits=\"urn:Product:Export:Benefits\"\r\n" +
+                "           xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+                "           xsi:schemaLocation=\"urn:Platform:Export xsd/issue-1079/export-model-nolocation.xsd\r\n" +
+                "                               urn:Product:Export:Benefits xsd/issue-1079/product-export-benefits.xsd\">\r\n" +
+                "  <|\r\n" +
+                "</ExportDef>";
+        testCompletionFor(xml, null, "src/test/resources/test.xml", null,
+                c("benefits:QuestionValue", "<benefits:QuestionValue name=\"\" />"));
     }
 
     @Test

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/filepath/participants/FilePathCompletionWithSettingsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/filepath/participants/FilePathCompletionWithSettingsTest.java
@@ -185,8 +185,9 @@ public class FilePathCompletionWithSettingsTest extends AbstractFilePathCompleti
 	@Test
 	public void testFilePathCompletionStartWithDotDot() throws BadLocationException {
 		String xml = "<a path=\"../filePathCompletion/folderA/|\">";
-		CompletionItem[] items = getCompletionItemList(0, 39, 39, "xsdA1.xsd", "xsdA2.xsd", "dtdA1.dtd", "dtdA2.dtd");
-		testCompletionFor(xml, 4, items);
+		CompletionItem[] items = getCompletionItemList(0, 39, 39, "xsdA1.xsd", "xsdA2.xsd", "dtdA1.dtd", "dtdA2.dtd",
+				"rncA1.rnc", "rngA1.rng");
+		testCompletionFor(xml, 6, items);
 	}
 
 	@Test
@@ -195,15 +196,17 @@ public class FilePathCompletionWithSettingsTest extends AbstractFilePathCompleti
 			return;
 		}
 		String xml = "<a path=\"..\\filePathCompletion\\folderA\\|\">";
-		CompletionItem[] items = getCompletionItemList(0, 39, 39, "xsdA1.xsd", "xsdA2.xsd", "dtdA1.dtd", "dtdA2.dtd");
-		testCompletionFor(xml, 4, items);
+		CompletionItem[] items = getCompletionItemList(0, 39, 39, "xsdA1.xsd", "xsdA2.xsd", "dtdA1.dtd", "dtdA2.dtd",
+				"rncA1.rnc", "rngA1.rng");
+		testCompletionFor(xml, 6, items);
 	}
 
 	@Test
 	public void testFilePathCompletionStartWithDot() throws BadLocationException {
 		String xml = "<a path=\"./folderA/|\">";
-		CompletionItem[] items = getCompletionItemList(0, 19, 19, "xsdA1.xsd", "xsdA2.xsd", "dtdA1.dtd", "dtdA2.dtd");
-		testCompletionFor(xml, 4, items);
+		CompletionItem[] items = getCompletionItemList(0, 19, 19, "xsdA1.xsd", "xsdA2.xsd", "dtdA1.dtd", "dtdA2.dtd",
+				"rncA1.rnc", "rngA1.rng");
+		testCompletionFor(xml, 6, items);
 	}
 
 	@Test
@@ -212,8 +215,9 @@ public class FilePathCompletionWithSettingsTest extends AbstractFilePathCompleti
 			return;
 		}
 		String xml = "<a path=\".\\folderA\\|\">";
-		CompletionItem[] items = getCompletionItemList(0, 19, 19, "xsdA1.xsd", "xsdA2.xsd", "dtdA1.dtd", "dtdA2.dtd");
-		testCompletionFor(xml, 4, items);
+		CompletionItem[] items = getCompletionItemList(0, 19, 19, "xsdA1.xsd", "xsdA2.xsd", "dtdA1.dtd", "dtdA2.dtd",
+				"rncA1.rnc", "rngA1.rng");
+		testCompletionFor(xml, 6, items);
 	}
 
 	@Test

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/filepath/participants/FilePathCompletionWithXMLModelTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/filepath/participants/FilePathCompletionWithXMLModelTest.java
@@ -1,0 +1,120 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.filepath.participants;
+
+import static org.eclipse.lemminx.utils.platform.Platform.isWindows;
+
+import org.eclipse.lemminx.commons.BadLocationException;
+import org.eclipse.lsp4j.CompletionItem;
+import org.junit.jupiter.api.Test;
+
+/**
+ * File path support completion test with {@code <?xml-model href="..." ?>}.
+ *
+ * Test folders are in
+ * org.eclipse.lemminx/src/test/resources/filePathCompletion/
+ *
+ * @see <a href="https://github.com/eclipse-lemminx/lemminx/issues/1307">issue
+ *      1307</a>
+ */
+public class FilePathCompletionWithXMLModelTest extends AbstractFilePathCompletionTest {
+
+	@Test
+	public void empty() throws BadLocationException {
+		String xml = "<?xml-model href=\"|\"?>";
+		CompletionItem[] items = getCompletionItemList(0, 18, 18, "folderA", "folderB", "folderC", "NestedA",
+				"main.dtd", "main.xsd");
+		testCompletionFor(xml, 6, items);
+	}
+
+	@Test
+	public void dotSlash() throws BadLocationException {
+		String xml = "<?xml-model href=\"./|\"?>";
+		CompletionItem[] items = getCompletionItemList(0, 20, 20, "folderA", "folderB", "folderC", "NestedA",
+				"main.dtd", "main.xsd");
+		testCompletionFor(xml, 6, items);
+	}
+
+	@Test
+	public void dotSlashFollowingBySlash() throws BadLocationException {
+		String xml = "<?xml-model href=\"./|/\"?>";
+		CompletionItem[] items = getCompletionItemList(0, 20, 21, "folderA", "folderB", "folderC", "NestedA",
+				"main.dtd", "main.xsd");
+		testCompletionFor(xml, 6, items);
+	}
+
+	@Test
+	public void backSlash() throws BadLocationException {
+		if (!isWindows) {
+			return;
+		}
+		String xml = "<?xml-model href=\".\\|\"?>";
+		CompletionItem[] items = getCompletionItemList(0, 20, 20, "folderA", "folderB", "folderC", "NestedA",
+				"main.dtd", "main.xsd");
+		testCompletionFor(xml, 6, items);
+	}
+
+	@Test
+	public void afterFolderA() throws BadLocationException {
+		// folderA contains dtdA1.dtd, dtdA2.dtd, rncA1.rnc, rngA1.rng, xsdA1.xsd, xsdA2.xsd
+		// all are schema files and must be proposed
+		String xml = "<?xml-model href=\"./folderA/|\"?>";
+		CompletionItem[] items = getCompletionItemList(0, 28, 28, "dtdA1.dtd", "dtdA2.dtd", "rncA1.rnc",
+				"rngA1.rng", "xsdA1.xsd", "xsdA2.xsd");
+		testCompletionFor(xml, 6, items);
+	}
+
+	@Test
+	public void afterFolderABackSlash() throws BadLocationException {
+		if (!isWindows) {
+			return;
+		}
+		String xml = "<?xml-model href=\".\\folderA\\|\"?>";
+		CompletionItem[] items = getCompletionItemList(0, 28, 28, "dtdA1.dtd", "dtdA2.dtd", "rncA1.rnc",
+				"rngA1.rng", "xsdA1.xsd", "xsdA2.xsd");
+		testCompletionFor(xml, 6, items);
+	}
+
+	@Test
+	public void afterFolderB() throws BadLocationException {
+		// folderB contains dtdB1.dtd, xmlB1.xml, xsdB1.xsd
+		// xmlB1.xml must be filtered out (only schema files are proposed)
+		String xml = "<?xml-model href=\"./folderB/|\"?>";
+		CompletionItem[] items = getCompletionItemList(0, 28, 28, "dtdB1.dtd", "xsdB1.xsd");
+		testCompletionFor(xml, 2, items);
+	}
+
+	@Test
+	public void afterFolderBBackSlash() throws BadLocationException {
+		if (!isWindows) {
+			return;
+		}
+		String xml = "<?xml-model href=\".\\folderB\\|\"?>";
+		CompletionItem[] items = getCompletionItemList(0, 28, 28, "dtdB1.dtd", "xsdB1.xsd");
+		testCompletionFor(xml, 2, items);
+	}
+
+	@Test
+	public void withOtherAttributes() throws BadLocationException {
+		String xml = "<?xml-model href=\"./|\" type=\"application/xml\" schematypens=\"http://www.w3.org/2001/XMLSchema\"?>";
+		CompletionItem[] items = getCompletionItemList(0, 20, 20, "folderA", "folderB", "folderC", "NestedA",
+				"main.dtd", "main.xsd");
+		testCompletionFor(xml, 6, items);
+	}
+
+	@Test
+	public void noCompletionOutsideHref() throws BadLocationException {
+		String xml = "<?xml-model href=\"./foo.xsd\" type=\"|\"?>";
+		testCompletionFor(xml, 0);
+	}
+
+}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/prolog/PrologCompletionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/prolog/PrologCompletionExtensionsTest.java
@@ -198,17 +198,17 @@ public class PrologCompletionExtensionsTest extends AbstractCacheBasedTest {
 				c("Insert XML Declaration", //
 						"<?xml version=\"${1|1.0,1.1|}\" encoding=\"${2|UTF-8,ISO-8859-1,Windows-1251,Windows-1252,Shift JIS,GB2312,EUC-KR|}\"?>${0}", //
 						r(0, 0, 0, 5), //
-						"<?xml"));
+						"<?xml xml"));
 		testCompletionFor("<?xml|>", true, //
 				c("Insert XML Declaration", //
 						"<?xml version=\"${1|1.0,1.1|}\" encoding=\"${2|UTF-8,ISO-8859-1,Windows-1251,Windows-1252,Shift JIS,GB2312,EUC-KR|}\"?>${0}", //
 						r(0, 0, 0, 6), //
-						"<?xml"));
+						"<?xml xml"));
 		testCompletionFor("<?xml|?>", true, //
 				c("Insert XML Declaration", //
 						"<?xml version=\"${1|1.0,1.1|}\" encoding=\"${2|UTF-8,ISO-8859-1,Windows-1251,Windows-1252,Shift JIS,GB2312,EUC-KR|}\"?>${0}", //
 						r(0, 0, 0, 7), //
-						"<?xml"));
+						"<?xml xml"));
 	}
 
 	@Test
@@ -218,22 +218,22 @@ public class PrologCompletionExtensionsTest extends AbstractCacheBasedTest {
 				c("Insert XML Declaration", //
 						"<?xml version=\"${1|1.0,1.1|}\" encoding=\"${2|UTF-8,ISO-8859-1,Windows-1251,Windows-1252,Shift JIS,GB2312,EUC-KR|}\"?>${0}", //
 						r(0, 0, 0, 2), //
-						"<?xml"));
+						"<?xml xml"));
 		testCompletionFor("<?|", false, //
 				c("Insert XML Declaration", //
 						"<?xml version=\"1.0\" encoding=\"UTF-8\"?>", //
 						r(0, 0, 0, 2), //
-						"<?xml"));
+						"<?xml xml"));
 		testCompletionFor("<?|>", true, //
 				c("Insert XML Declaration", //
 						"<?xml version=\"${1|1.0,1.1|}\" encoding=\"${2|UTF-8,ISO-8859-1,Windows-1251,Windows-1252,Shift JIS,GB2312,EUC-KR|}\"?>${0}", //
 						r(0, 0, 0, 3), //
-						"<?xml"));
+						"<?xml xml"));
 		testCompletionFor("<?|?>", true, //
 				c("Insert XML Declaration", //
 						"<?xml version=\"${1|1.0,1.1|}\" encoding=\"${2|UTF-8,ISO-8859-1,Windows-1251,Windows-1252,Shift JIS,GB2312,EUC-KR|}\"?>${0}", //
 						r(0, 0, 0, 4), //
-						"<?xml"));
+						"<?xml xml"));
 	}
 
 	@Test
@@ -242,27 +242,27 @@ public class PrologCompletionExtensionsTest extends AbstractCacheBasedTest {
 				c("Insert XML Declaration", //
 						"<?xml version=\"${1|1.0,1.1|}\" encoding=\"${2|UTF-8,ISO-8859-1,Windows-1251,Windows-1252,Shift JIS,GB2312,EUC-KR|}\"?>${0}", //
 						r(0, 0, 0, 3), //
-						"<?xml"));
+						"<?xml xml"));
 		testCompletionFor("<?xm|", true, //
 				c("Insert XML Declaration", //
 						"<?xml version=\"${1|1.0,1.1|}\" encoding=\"${2|UTF-8,ISO-8859-1,Windows-1251,Windows-1252,Shift JIS,GB2312,EUC-KR|}\"?>${0}", //
 						r(0, 0, 0, 4), //
-						"<?xml"));
+						"<?xml xml"));
 		testCompletionFor("<?xml|", true, //
 				c("Insert XML Declaration", //
 						"<?xml version=\"${1|1.0,1.1|}\" encoding=\"${2|UTF-8,ISO-8859-1,Windows-1251,Windows-1252,Shift JIS,GB2312,EUC-KR|}\"?>${0}", //
 						r(0, 0, 0, 5), //
-						"<?xml"));
+						"<?xml xml"));
 		testCompletionFor("<?xml|?", true, //
 				c("Insert XML Declaration", //
 						"<?xml version=\"${1|1.0,1.1|}\" encoding=\"${2|UTF-8,ISO-8859-1,Windows-1251,Windows-1252,Shift JIS,GB2312,EUC-KR|}\"?>${0}", //
 						r(0, 0, 0, 6), //
-						"<?xml"));
+						"<?xml xml"));
 		testCompletionFor("<?xml|?>", true, //
 				c("Insert XML Declaration", //
 						"<?xml version=\"${1|1.0,1.1|}\" encoding=\"${2|UTF-8,ISO-8859-1,Windows-1251,Windows-1252,Shift JIS,GB2312,EUC-KR|}\"?>${0}", //
 						r(0, 0, 0, 7), //
-						"<?xml"));
+						"<?xml xml"));
 	}
 
 	@Test
@@ -273,17 +273,17 @@ public class PrologCompletionExtensionsTest extends AbstractCacheBasedTest {
 				c("Insert XML Declaration", //
 						"<?xml version=\"${1|1.0,1.1|}\" encoding=\"${2|UTF-8,ISO-8859-1,Windows-1251,Windows-1252,Shift JIS,GB2312,EUC-KR|}\"?>${0}", //
 						r(0, 0, 0, 5), //
-						"<?xml"));
+						"<?xml xml"));
 		testCompletionFor("<?xml|>", dtdFileURI, true, //
 				c("Insert XML Declaration", //
 						"<?xml version=\"${1|1.0,1.1|}\" encoding=\"${2|UTF-8,ISO-8859-1,Windows-1251,Windows-1252,Shift JIS,GB2312,EUC-KR|}\"?>${0}", //
 						r(0, 0, 0, 6), //
-						"<?xml"));
+						"<?xml xml"));
 		testCompletionFor("<?xml|?>", dtdFileURI, true, //
 				c("Insert XML Declaration", //
 						"<?xml version=\"${1|1.0,1.1|}\" encoding=\"${2|UTF-8,ISO-8859-1,Windows-1251,Windows-1252,Shift JIS,GB2312,EUC-KR|}\"?>${0}", //
 						r(0, 0, 0, 7), //
-						"<?xml"));
+						"<?xml xml"));
 	}
 
 	@Test
@@ -294,22 +294,22 @@ public class PrologCompletionExtensionsTest extends AbstractCacheBasedTest {
 				c("Insert XML Declaration", //
 						"<?xml version=\"${1|1.0,1.1|}\" encoding=\"${2|UTF-8,ISO-8859-1,Windows-1251,Windows-1252,Shift JIS,GB2312,EUC-KR|}\"?>${0}", //
 						r(0, 0, 0, 2), //
-						"<?xml"));
+						"<?xml xml"));
 		testCompletionFor("<?|", dtdFileURI, false, //
 				c("Insert XML Declaration", //
 						"<?xml version=\"1.0\" encoding=\"UTF-8\"?>", //
 						r(0, 0, 0, 2), //
-						"<?xml"));
+						"<?xml xml"));
 		testCompletionFor("<?|>", dtdFileURI, true, //
 				c("Insert XML Declaration", //
 						"<?xml version=\"${1|1.0,1.1|}\" encoding=\"${2|UTF-8,ISO-8859-1,Windows-1251,Windows-1252,Shift JIS,GB2312,EUC-KR|}\"?>${0}", //
 						r(0, 0, 0, 3), //
-						"<?xml"));
+						"<?xml xml"));
 		testCompletionFor("<?|?>", dtdFileURI, true, //
 				c("Insert XML Declaration", //
 						"<?xml version=\"${1|1.0,1.1|}\" encoding=\"${2|UTF-8,ISO-8859-1,Windows-1251,Windows-1252,Shift JIS,GB2312,EUC-KR|}\"?>${0}", //
 						r(0, 0, 0, 4), //
-						"<?xml"));
+						"<?xml xml"));
 	}
 
 	@Test
@@ -319,27 +319,27 @@ public class PrologCompletionExtensionsTest extends AbstractCacheBasedTest {
 				c("Insert XML Declaration", //
 						"<?xml version=\"${1|1.0,1.1|}\" encoding=\"${2|UTF-8,ISO-8859-1,Windows-1251,Windows-1252,Shift JIS,GB2312,EUC-KR|}\"?>${0}", //
 						r(0, 0, 0, 3), //
-						"<?xml"));
+						"<?xml xml"));
 		testCompletionFor("<?xm|", dtdFileURI, true, //
 				c("Insert XML Declaration", //
 						"<?xml version=\"${1|1.0,1.1|}\" encoding=\"${2|UTF-8,ISO-8859-1,Windows-1251,Windows-1252,Shift JIS,GB2312,EUC-KR|}\"?>${0}", //
 						r(0, 0, 0, 4), //
-						"<?xml"));
+						"<?xml xml"));
 		testCompletionFor("<?xml|", dtdFileURI, true, //
 				c("Insert XML Declaration", //
 						"<?xml version=\"${1|1.0,1.1|}\" encoding=\"${2|UTF-8,ISO-8859-1,Windows-1251,Windows-1252,Shift JIS,GB2312,EUC-KR|}\"?>${0}", //
 						r(0, 0, 0, 5), //
-						"<?xml"));
+						"<?xml xml"));
 		testCompletionFor("<?xml|?", dtdFileURI, true, //
 				c("Insert XML Declaration", //
 						"<?xml version=\"${1|1.0,1.1|}\" encoding=\"${2|UTF-8,ISO-8859-1,Windows-1251,Windows-1252,Shift JIS,GB2312,EUC-KR|}\"?>${0}", //
 						r(0, 0, 0, 6), //
-						"<?xml"));
+						"<?xml xml"));
 		testCompletionFor("<?xml|?>", dtdFileURI, true, //
 				c("Insert XML Declaration", //
 						"<?xml version=\"${1|1.0,1.1|}\" encoding=\"${2|UTF-8,ISO-8859-1,Windows-1251,Windows-1252,Shift JIS,GB2312,EUC-KR|}\"?>${0}", //
 						r(0, 0, 0, 7), //
-						"<?xml"));
+						"<?xml xml"));
 	}
 
 	private void testCompletionFor(boolean enableItemDefaults, String xml, CompletionItem... expectedItems) throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/relaxng/xml/hover/RelaxNGHoverTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/relaxng/xml/hover/RelaxNGHoverTest.java
@@ -101,8 +101,8 @@ public class RelaxNGHoverTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void hoverWithUmlautNoEncodingDeclared() throws BadLocationException, MalformedURIException {
-		String schemaURI = getRelaxNGFileURI("umlautDoc.rng");
-		String xml = "<?xml-model href=\"umlautDoc.rng\" ?>\r\n" + //
+		String schemaURI = getRelaxNGFileURI("encoding/umlautDoc.rng");
+		String xml = "<?xml-model href=\"encoding/umlautDoc.rng\" ?>\r\n" + //
 				"<layout>\r\n" + //
 				"  <te|xt>hello</text>\r\n" + //
 				"</layout>";
@@ -113,8 +113,8 @@ public class RelaxNGHoverTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void hoverWithUmlautNoEncodingDeclaredOnElement() throws BadLocationException, MalformedURIException {
-		String schemaURI = getRelaxNGFileURI("umlautDoc.rng");
-		String xml = "<?xml-model href=\"umlautDoc.rng\" ?>\r\n" + //
+		String schemaURI = getRelaxNGFileURI("encoding/umlautDoc.rng");
+		String xml = "<?xml-model href=\"encoding/umlautDoc.rng\" ?>\r\n" + //
 				"<lay|out>\r\n" + //
 				"  <text>hello</text>\r\n" + //
 				"</layout>";
@@ -125,8 +125,8 @@ public class RelaxNGHoverTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void hoverWithUmlautUTF8Declared() throws BadLocationException, MalformedURIException {
-		String schemaURI = getRelaxNGFileURI("umlautDocUTF8.rng");
-		String xml = "<?xml-model href=\"umlautDocUTF8.rng\" ?>\r\n" + //
+		String schemaURI = getRelaxNGFileURI("encoding/umlautDocUTF8.rng");
+		String xml = "<?xml-model href=\"encoding/umlautDocUTF8.rng\" ?>\r\n" + //
 				"<layout>\r\n" + //
 				"  <te|xt>hello</text>\r\n" + //
 				"</layout>";
@@ -137,8 +137,8 @@ public class RelaxNGHoverTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void hoverWithUmlautISO88591Declared() throws BadLocationException, MalformedURIException {
-		String schemaURI = getRelaxNGFileURI("umlautDocISO88591.rng");
-		String xml = "<?xml-model href=\"umlautDocISO88591.rng\" ?>\r\n" + //
+		String schemaURI = getRelaxNGFileURI("encoding/umlautDocISO88591.rng");
+		String xml = "<?xml-model href=\"encoding/umlautDocISO88591.rng\" ?>\r\n" + //
 				"<layout>\r\n" + //
 				"  <te|xt>hello</text>\r\n" + //
 				"</layout>";

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLCompletionSnippetsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLCompletionSnippetsTest.java
@@ -51,13 +51,16 @@ public class XMLCompletionSnippetsTest {
 						r(0, 0, 0, 0), "<!DOCTYPE"),
 				c("Insert XML Declaration", //
 						"<?xml version=\"1.0\" encoding=\"UTF-8\"?>", //
-						r(0, 0, 0, 0), "<?xml"),
+						r(0, 0, 0, 0), "<?xml xml"),
+				c("Insert xml-model", //
+						"<?xml-model href=\"file\"?>", //
+						r(0, 0, 0, 0), "<?xml-model xml-model"),
 				c("Insert XML Schema association", //
 						"<?xml-model href=\"file.xsd\" type=\"application/xml\" schematypens=\"http://www.w3.org/2001/XMLSchema\"?>", //
-						r(0, 0, 0, 0), "<?xml-model"),
+						r(0, 0, 0, 0), "<?xml-model xml-model"),
 				c("Insert DTD association", //
 						"<?xml-model href=\"file.dtd\" type=\"application/xml-dtd\"?>", //
-						r(0, 0, 0, 0), "<?xml-model"),
+						r(0, 0, 0, 0), "<?xml-model xml-model"),
 				c("New XML bound with xsi:schemaLocation", //
 						"<root-element xmlns=\"https://github.com/eclipse/lemminx\"" + lineSeparator() + //
 								"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + lineSeparator() + //
@@ -124,13 +127,13 @@ public class XMLCompletionSnippetsTest {
 						r(0, 0, 0, 1), "<!DOCTYPE"),
 				c("Insert XML Declaration", //
 						"<?xml version=\"1.0\" encoding=\"UTF-8\"?>", //
-						r(0, 0, 0, 1), "<?xml"),
+						r(0, 0, 0, 1), "<?xml xml"),
 				c("Insert XML Schema association", //
 						"<?xml-model href=\"file.xsd\" type=\"application/xml\" schematypens=\"http://www.w3.org/2001/XMLSchema\"?>", //
-						r(0, 0, 0, 1), "<?xml-model"),
+						r(0, 0, 0, 1), "<?xml-model xml-model"),
 				c("Insert DTD association", //
 						"<?xml-model href=\"file.dtd\" type=\"application/xml-dtd\"?>", //
-						r(0, 0, 0, 1), "<?xml-model"),
+						r(0, 0, 0, 1), "<?xml-model xml-model"),
 				c("<!--", //
 						"<!-- -->", //
 						r(0, 0, 0, 1), "<!--"),
@@ -174,13 +177,13 @@ public class XMLCompletionSnippetsTest {
 						r(0, 0, 0, 2), "<!DOCTYPE"),
 				c("Insert XML Declaration", //
 						"<?xml version=\"1.0\" encoding=\"UTF-8\"?>", //
-						r(0, 0, 0, 2), "<?xml"),
+						r(0, 0, 0, 2), "<?xml xml"),
 				c("Insert XML Schema association", //
 						"<?xml-model href=\"file.xsd\" type=\"application/xml\" schematypens=\"http://www.w3.org/2001/XMLSchema\"?>", //
-						r(0, 0, 0, 2), "<?xml-model"),
+						r(0, 0, 0, 2), "<?xml-model xml-model"),
 				c("Insert DTD association", //
 						"<?xml-model href=\"file.dtd\" type=\"application/xml-dtd\"?>", //
-						r(0, 0, 0, 2), "<?xml-model"),
+						r(0, 0, 0, 2), "<?xml-model xml-model"),
 				c("<!--", //
 						"<!-- -->", //
 						r(0, 0, 0, 2), "<!--"),
@@ -227,7 +230,7 @@ public class XMLCompletionSnippetsTest {
 						r(0, 0, 0, 2), "<!DOCTYPE"),
 				c("Insert XML Declaration", //
 						"<?xml version=\"1.0\" encoding=\"UTF-8\"?>", //
-						r(0, 0, 0, 2), "<?xml"),
+						r(0, 0, 0, 2), "<?xml xml"),
 				c("<!--", //
 						"<!-- -->", //
 						r(0, 0, 0, 2), "<!--"));
@@ -251,13 +254,13 @@ public class XMLCompletionSnippetsTest {
 						r(0, 0, 0, 0), "<!DOCTYPE"),
 				c("Insert XML Declaration", //
 						"<?xml version=\"1.0\" encoding=\"UTF-8\"?>", //
-						r(0, 0, 0, 0), "<?xml"),
+						r(0, 0, 0, 0), "<?xml xml"),
 				c("Insert XML Schema association", //
 						"<?xml-model href=\"file.xsd\" type=\"application/xml\" schematypens=\"http://www.w3.org/2001/XMLSchema\"?>", //
-						r(0, 0, 0, 0), "<?xml-model"),
+						r(0, 0, 0, 0), "<?xml-model xml-model"),
 				c("Insert DTD association", //
 						"<?xml-model href=\"file.dtd\" type=\"application/xml-dtd\"?>", //
-						r(0, 0, 0, 0), "<?xml-model"),
+						r(0, 0, 0, 0), "<?xml-model xml-model"),
 				c("New XML bound with xsi:schemaLocation", //
 						"<root-element xmlns=\"https://github.com/eclipse/lemminx\"" + lineSeparator() + //
 								"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + lineSeparator() + //
@@ -325,13 +328,13 @@ public class XMLCompletionSnippetsTest {
 						r(0, 0, 0, 1), "<!DOCTYPE"),
 				c("Insert XML Declaration", //
 						"<?xml version=\"1.0\" encoding=\"UTF-8\"?>", //
-						r(0, 0, 0, 1), "<?xml"),
+						r(0, 0, 0, 1), "<?xml xml"),
 				c("Insert XML Schema association", //
 						"<?xml-model href=\"file.xsd\" type=\"application/xml\" schematypens=\"http://www.w3.org/2001/XMLSchema\"?>", //
-						r(0, 0, 0, 1), "<?xml-model"),
+						r(0, 0, 0, 1), "<?xml-model xml-model"),
 				c("Insert DTD association", //
 						"<?xml-model href=\"file.dtd\" type=\"application/xml-dtd\"?>", //
-						r(0, 0, 0, 1), "<?xml-model"),
+						r(0, 0, 0, 1), "<?xml-model xml-model"),
 				c("<!--", //
 						"<!-- -->", //
 						r(0, 0, 0, 1), "<!--"),
@@ -376,13 +379,13 @@ public class XMLCompletionSnippetsTest {
 						r(0, 0, 0, 2), "<!DOCTYPE"),
 				c("Insert XML Declaration", //
 						"<?xml version=\"1.0\" encoding=\"UTF-8\"?>", //
-						r(0, 0, 0, 2), "<?xml"),
+						r(0, 0, 0, 2), "<?xml xml"),
 				c("Insert XML Schema association", //
 						"<?xml-model href=\"file.xsd\" type=\"application/xml\" schematypens=\"http://www.w3.org/2001/XMLSchema\"?>", //
-						r(0, 0, 0, 2), "<?xml-model"),
+						r(0, 0, 0, 2), "<?xml-model xml-model"),
 				c("Insert DTD association", //
 						"<?xml-model href=\"file.dtd\" type=\"application/xml-dtd\"?>", //
-						r(0, 0, 0, 2), "<?xml-model"),
+						r(0, 0, 0, 2), "<?xml-model xml-model"),
 				c("<!--", //
 						"<!-- -->", //
 						r(0, 0, 0, 2), "<!--"),
@@ -430,7 +433,7 @@ public class XMLCompletionSnippetsTest {
 						r(0, 0, 0, 2), "<!DOCTYPE"),
 				c("Insert XML Declaration", //
 						"<?xml version=\"1.0\" encoding=\"UTF-8\"?>", //
-						r(0, 0, 0, 2), "<?xml"),
+						r(0, 0, 0, 2), "<?xml xml"),
 				c("<!--", //
 						"<!-- -->", //
 						r(0, 0, 0, 2), "<!--"));
@@ -452,10 +455,10 @@ public class XMLCompletionSnippetsTest {
 						r(0, 8, 0, 8), "<!DOCTYPE"),
 				c("Insert XML Schema association", //
 						"<?xml-model href=\"file.xsd\" type=\"application/xml\" schematypens=\"http://www.w3.org/2001/XMLSchema\"?>", //
-						r(0, 8, 0, 8), "<?xml-model"),
+						r(0, 8, 0, 8), "<?xml-model xml-model"),
 				c("Insert DTD association", //
 						"<?xml-model href=\"file.dtd\" type=\"application/xml-dtd\"?>", //
-						r(0, 8, 0, 8), "<?xml-model"),
+						r(0, 8, 0, 8), "<?xml-model xml-model"),
 				c("<!--", //
 						"<!-- -->", //
 						r(0, 8, 0, 8), "<!--"),
@@ -501,10 +504,10 @@ public class XMLCompletionSnippetsTest {
 						r(0, 38, 0, 38), "<!DOCTYPE"),
 				c("Insert XML Schema association", //
 						"<?xml-model href=\"file.xsd\" type=\"application/xml\" schematypens=\"http://www.w3.org/2001/XMLSchema\"?>", //
-						r(0, 38, 0, 38), "<?xml-model"),
+						r(0, 38, 0, 38), "<?xml-model xml-model"),
 				c("Insert DTD association", //
 						"<?xml-model href=\"file.dtd\" type=\"application/xml-dtd\"?>", //
-						r(0, 38, 0, 38), "<?xml-model"),
+						r(0, 38, 0, 38), "<?xml-model xml-model"),
 				c("<!--", //
 						"<!-- -->", //
 						r(0, 38, 0, 38), "<!--"),
@@ -547,10 +550,10 @@ public class XMLCompletionSnippetsTest {
 						r(0, 38, 0, 39), "<!DOCTYPE"),
 				c("Insert XML Schema association", //
 						"<?xml-model href=\"file.xsd\" type=\"application/xml\" schematypens=\"http://www.w3.org/2001/XMLSchema\"?>", //
-						r(0, 38, 0, 39), "<?xml-model"),
+						r(0, 38, 0, 39), "<?xml-model xml-model"),
 				c("Insert DTD association", //
 						"<?xml-model href=\"file.dtd\" type=\"application/xml-dtd\"?>", //
-						r(0, 38, 0, 39), "<?xml-model"),
+						r(0, 38, 0, 39), "<?xml-model xml-model"),
 				c("<!--", //
 						"<!-- -->", //
 						r(0, 38, 0, 39), "<!--"),
@@ -593,10 +596,10 @@ public class XMLCompletionSnippetsTest {
 						r(0, 38, 0, 39), "<!DOCTYPE"),
 				c("Insert XML Schema association", //
 						"<?xml-model href=\"file.xsd\" type=\"application/xml\" schematypens=\"http://www.w3.org/2001/XMLSchema\"?>", //
-						r(0, 38, 0, 39), "<?xml-model"),
+						r(0, 38, 0, 39), "<?xml-model xml-model"),
 				c("Insert DTD association", //
 						"<?xml-model href=\"file.dtd\" type=\"application/xml-dtd\"?>", //
-						r(0, 38, 0, 39), "<?xml-model"),
+						r(0, 38, 0, 39), "<?xml-model xml-model"),
 				c("<!--", //
 						"<!-- -->", //
 						r(0, 38, 0, 39), "<!--"));
@@ -613,10 +616,10 @@ public class XMLCompletionSnippetsTest {
 						r(0, 38, 0, 40), "<!DOCTYPE"),
 				c("Insert XML Schema association", //
 						"<?xml-model href=\"file.xsd\" type=\"application/xml\" schematypens=\"http://www.w3.org/2001/XMLSchema\"?>", //
-						r(0, 38, 0, 40), "<?xml-model"),
+						r(0, 38, 0, 40), "<?xml-model xml-model"),
 				c("Insert DTD association", //
 						"<?xml-model href=\"file.dtd\" type=\"application/xml-dtd\"?>", //
-						r(0, 38, 0, 40), "<?xml-model"),
+						r(0, 38, 0, 40), "<?xml-model xml-model"),
 				c("<!--", //
 						"<!-- -->", //
 						r(0, 38, 0, 40), "<!--"));
@@ -634,10 +637,10 @@ public class XMLCompletionSnippetsTest {
 						r(1, 0, 1, 0), "<!DOCTYPE"),
 				c("Insert XML Schema association", //
 						"<?xml-model href=\"file.xsd\" type=\"application/xml\" schematypens=\"http://www.w3.org/2001/XMLSchema\"?>", //
-						r(1, 0, 1, 0), "<?xml-model"),
+						r(1, 0, 1, 0), "<?xml-model xml-model"),
 				c("Insert DTD association", //
 						"<?xml-model href=\"file.dtd\" type=\"application/xml-dtd\"?>", //
-						r(1, 0, 1, 0), "<?xml-model"),
+						r(1, 0, 1, 0), "<?xml-model xml-model"),
 				c("<!--", //
 						"<!-- -->", //
 						r(1, 0, 1, 0), "<!--"), //
@@ -688,7 +691,7 @@ public class XMLCompletionSnippetsTest {
 						r(0, 0, 0, 0), "<schema"),
 				c("Insert XML Declaration", //
 						"<?xml version=\"1.0\" encoding=\"UTF-8\"?>", //
-						r(0, 0, 0, 0), "<?xml"),
+						r(0, 0, 0, 0), "<?xml xml"),
 				c("<!--", //
 						"<!-- -->", //
 						r(0, 0, 0, 0), "<!--"));
@@ -707,7 +710,7 @@ public class XMLCompletionSnippetsTest {
 						r(0, 0, 0, 1), "<schema"),
 				c("Insert XML Declaration", //
 						"<?xml version=\"1.0\" encoding=\"UTF-8\"?>", //
-						r(0, 0, 0, 1), "<?xml"),
+						r(0, 0, 0, 1), "<?xml xml"),
 				c("<!--", //
 						"<!-- -->", //
 						r(0, 0, 0, 1), "<!--"));
@@ -726,7 +729,7 @@ public class XMLCompletionSnippetsTest {
 						r(0, 0, 0, 2), "<schema"),
 				c("Insert XML Declaration", //
 						"<?xml version=\"1.0\" encoding=\"UTF-8\"?>", //
-						r(0, 0, 0, 2), "<?xml"),
+						r(0, 0, 0, 2), "<?xml xml"),
 				c("<!--", //
 						"<!-- -->", //
 						r(0, 0, 0, 2), "<!--"));
@@ -931,7 +934,7 @@ public class XMLCompletionSnippetsTest {
 						COMMENT_SNIPPETS /* Comment snippets */ , //
 				c("Insert XML Declaration", //
 						"<?xml version=\"1.0\" encoding=\"UTF-8\"?>", //
-						r(0, 0, 0, 2), "<?xml"));
+						r(0, 0, 0, 2), "<?xml xml"));
 
 	}
 
@@ -989,13 +992,13 @@ public class XMLCompletionSnippetsTest {
 						REGION_SNIPPETS /* Region Snippets */, //
 				c("Insert XML Declaration", //
 						"<?xml version=\"1.0\" encoding=\"UTF-8\"?>", //
-						r(0, 0, 0, 0), "<?xml"),
+						r(0, 0, 0, 0), "<?xml xml"),
 				c("Insert XML Schema association", //
 						"<?xml-model href=\"file.xsd\" type=\"application/xml\" schematypens=\"http://www.w3.org/2001/XMLSchema\"?>", //
-						r(0, 0, 0, 0), "<?xml-model"),
+						r(0, 0, 0, 0), "<?xml-model xml-model"),
 				c("Insert DTD association", //
 						"<?xml-model href=\"file.dtd\" type=\"application/xml-dtd\"?>", //
-						r(0, 0, 0, 0), "<?xml-model"),
+						r(0, 0, 0, 0), "<?xml-model xml-model"),
 				c("Insert SYSTEM DOCTYPE", //
 						"<!DOCTYPE root SYSTEM \"file.dtd\">", //
 						r(0, 0, 0, 0), "<!DOCTYPE"),

--- a/org.eclipse.lemminx/src/test/resources/relaxng/encoding/umlautDoc.rng
+++ b/org.eclipse.lemminx/src/test/resources/relaxng/encoding/umlautDoc.rng
@@ -1,0 +1,12 @@
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">
+  <start>
+    <element name="layout">
+      <a:documentation>Seitenlayout für die Ausgabe</a:documentation>
+      <element name="text">
+        <a:documentation>Textinhalt mit Umlauten: ä, ö, ü, ß</a:documentation>
+        <text/>
+      </element>
+    </element>
+  </start>
+</grammar>

--- a/org.eclipse.lemminx/src/test/resources/relaxng/encoding/umlautDocISO88591.rng
+++ b/org.eclipse.lemminx/src/test/resources/relaxng/encoding/umlautDocISO88591.rng
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">
+  <start>
+    <element name="layout">
+      <a:documentation>Seitenlayout für die Ausgabe</a:documentation>
+      <element name="text">
+        <a:documentation>Textinhalt mit Umlauten: ä, ö, ü, ß</a:documentation>
+        <text/>
+      </element>
+    </element>
+  </start>
+</grammar>

--- a/org.eclipse.lemminx/src/test/resources/relaxng/encoding/umlautDocUTF8.rng
+++ b/org.eclipse.lemminx/src/test/resources/relaxng/encoding/umlautDocUTF8.rng
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">
+  <start>
+    <element name="layout">
+      <a:documentation>Seitenlayout für die Ausgabe</a:documentation>
+      <element name="text">
+        <a:documentation>Textinhalt mit Umlauten: ä, ö, ü, ß</a:documentation>
+        <text/>
+      </element>
+    </element>
+  </start>
+</grammar>

--- a/org.eclipse.lemminx/src/test/resources/xsd/issue-1079/export-model-nolocation.xsd
+++ b/org.eclipse.lemminx/src/test/resources/xsd/issue-1079/export-model-nolocation.xsd
@@ -1,0 +1,21 @@
+<xsd:schema targetNamespace="urn:Platform:Export"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:benefits="urn:Product:Export:Benefits"
+            xmlns:export="urn:Platform:Export"
+            elementFormDefault="qualified">
+
+  <!-- No schemaLocation on import - relies on xsi:schemaLocation in XML -->
+  <xsd:import namespace="urn:Product:Export:Benefits"/>
+
+  <xsd:element name="ExportDef">
+    <xsd:annotation>
+      <xsd:documentation>Root element that defines an export configuration with question value mappings.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="benefits:QuestionValue" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+</xsd:schema>


### PR DESCRIPTION
Fixes #1307

Add file path completion support for the href pseudo-attribute in <?xml-model?> processing instructions, enabling autocompletion of schema file paths (XSD, DTD, RelaxNG, etc.).

Here a demo:

<img width="939" height="489" alt="XMLModelHrefCompletion" src="https://github.com/user-attachments/assets/fedc1ec1-3302-4ef5-9763-518784c06224" />
