### PR TITLE
Surround with ignore formatting

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/commands/SurroundWithCommand.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/commands/SurroundWithCommand.java
@@ -40,6 +40,7 @@ import org.eclipse.lsp4j.jsonrpc.CancelChecker;
  * <li>Surround with Tags (Wrap)</li>
  * <li>Surround with Comments</li>
  * <li>Surround with CDATA</li>
+ * <li>Ignore Formatting</li>
  * </ul>
  *
  */
@@ -73,7 +74,8 @@ public class SurroundWithCommand extends AbstractDOMDocumentCommandHandler {
 	public static enum SurroundWithKind {
 		tags, //
 		comments, //
-		cdata;
+		cdata, //
+		ignoreFormatting;
 
 		public static SurroundWithKind get(String kind) {
 			return valueOf(kind);
@@ -135,6 +137,16 @@ public class SurroundWithCommand extends AbstractDOMDocumentCommandHandler {
 					SnippetsBuilder.tabstops(1, startText);
 				}
 				endText = new StringBuilder("-->");
+				if (snippetsSupported) {
+					SnippetsBuilder.tabstops(0, endText);
+				}
+				break;
+			case ignoreFormatting:
+				startText = new StringBuilder("<!-- @formatter:off -->");
+				if (snippetsSupported && emptySelection) {
+					SnippetsBuilder.tabstops(1, startText);
+				}
+				endText = new StringBuilder("<!-- @formatter:on -->");
 				if (snippetsSupported) {
 					SnippetsBuilder.tabstops(0, endText);
 				}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/commands/SurroundWithIgnoreFormattingCommandTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/commands/SurroundWithIgnoreFormattingCommandTest.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+* Copyright (c) 2026 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.contentmodel.commands;
+
+import static org.eclipse.lemminx.XMLAssert.assertSurroundWith;
+
+import org.eclipse.lemminx.extensions.contentmodel.BaseFileTempTest;
+import org.eclipse.lemminx.extensions.contentmodel.commands.SurroundWithCommand.SurroundWithKind;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests with {@link SurroundWithCommand} command with Ignore Formatting.
+ *
+ */
+public class SurroundWithIgnoreFormattingCommandTest extends BaseFileTempTest {
+
+	// --------------- Surround with Ignore Formatting
+
+	@Test
+	public void surroundInText() throws Exception {
+		String xml = "<foo>\r\n" + //
+				"	s|ome te|xt\r\n" + //
+				"</foo>";
+		String expected = "<foo>\r\n" + //
+				"	s<!-- @formatter:off -->ome te<!-- @formatter:on -->$0xt\r\n" + //
+				"</foo>";
+		assertSurroundWith(xml, SurroundWithKind.ignoreFormatting, true, expected);
+	}
+
+	@Test
+	public void surroundInStartTag() throws Exception {
+		String xml = "<fo|o>\r\n" + //
+				"	som|e text\r\n" + //
+				"</foo>";
+		String expected = "<fo<!-- @formatter:off -->o>\r\n" + //
+				"	som<!-- @formatter:on -->$0e text\r\n" + //
+				"</foo>";
+		assertSurroundWith(xml, SurroundWithKind.ignoreFormatting, true, expected);
+	}
+
+	@Test
+	public void surroundEmptySelectionInText() throws Exception {
+		String xml = "<foo>\r\n" + //
+				"	s|ome text\r\n" + //
+				"</foo>";
+		String expected = "<foo>\r\n" + //
+				"	s<!-- @formatter:off -->$1<!-- @formatter:on -->$0ome text\r\n" + //
+				"</foo>";
+		assertSurroundWith(xml, SurroundWithKind.ignoreFormatting, true, expected);
+	}
+
+	@Test
+	public void surroundEmptySelectionInStartTag() throws Exception {
+		String xml = "<f|oo>\r\n" + //
+				"	some text\r\n" + //
+				"</foo>";
+		String expected = "<!-- @formatter:off -->$1<foo>\r\n" + //
+				"	some text\r\n" + //
+				"</foo><!-- @formatter:on -->$0";
+		assertSurroundWith(xml, SurroundWithKind.ignoreFormatting, true, expected);
+	}
+
+	@Test
+	public void surroundEmptySelectionInEndTag() throws Exception {
+		String xml = "<foo>\r\n" + //
+				"	some text\r\n" + //
+				"</fo|o>";
+		String expected = "<!-- @formatter:off -->$1<foo>\r\n" + //
+				"	some text\r\n" + //
+				"</foo><!-- @formatter:on -->$0";
+		assertSurroundWith(xml, SurroundWithKind.ignoreFormatting, true, expected);
+	}
+
+}


### PR DESCRIPTION
This PR provides the ignore formatting request used with 'Ignore Formatting' menu https://github.com/redhat-developer/vscode-xml/pull/1169

<img width="939" height="489" alt="IgnoreFormatting" src="https://github.com/user-attachments/assets/752d54bb-053c-4665-a890-ea0276f04a6a" />
