### PR TITLE
Fix: hover, completion and type definition for xsi:type-derived children across namespaces

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/model/CMDocument.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/model/CMDocument.java
@@ -100,6 +100,18 @@ public interface CMDocument {
 	}
 
 	/**
+	 * Returns the child element declarations of the xsi:type-derived type
+	 * for the given element. Used when the derived type is defined in this
+	 * schema but the element itself belongs to a different namespace.
+	 *
+	 * @param element the DOM element with xsi:type attribute.
+	 * @return the child element declarations, or empty if not applicable.
+	 */
+	default Collection<CMElementDeclaration> findXsiTypeDerivedElements(DOMElement element) {
+		return Collections.emptyList();
+	}
+
+	/**
 	 * Returns list of declared entities.
 	 *
 	 * @return list of declared entities.

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/ContentModelCompletionParticipant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/ContentModelCompletionParticipant.java
@@ -31,6 +31,7 @@ import org.eclipse.lemminx.extensions.contentmodel.participants.completion.Attri
 import org.eclipse.lemminx.extensions.contentmodel.participants.completion.AttributeValueCompletionResolver;
 import org.eclipse.lemminx.extensions.contentmodel.participants.completion.ContentModelElementCompletionItem;
 import org.eclipse.lemminx.extensions.contentmodel.utils.XMLGenerator;
+import org.eclipse.lemminx.extensions.xsi.XSISchemaModel;
 import org.eclipse.lemminx.services.data.DataEntryField;
 import org.eclipse.lemminx.services.extensions.completion.AttributeCompletionItem;
 import org.eclipse.lemminx.services.extensions.completion.CompletionParticipantAdapter;
@@ -93,6 +94,8 @@ public class ContentModelCompletionParticipant extends CompletionParticipantAdap
 					parentElement.getNamespaceURI());
 
 			String defaultPrefix = null;
+			boolean foundXsiTypeChildren = false;
+			String xsiTypeNs = getXsiTypeNamespace(parentElement);
 			for (CMDocument cmDocument : cmRootDocuments) {
 				CMElementDeclaration cmElement = cmDocument.findCMElement(parentElement,
 						parentElement.getNamespaceURI());
@@ -100,6 +103,35 @@ public class ContentModelCompletionParticipant extends CompletionParticipantAdap
 					defaultPrefix = parentElement.getPrefix();
 					fillWithPossibleElementDeclaration(parentElement, cmElement, defaultPrefix, contentModelManager,
 							request, response);
+					// Check if the regular path already resolved xsi:type
+					// children (happens when the parent's schema imports the
+					// derived type's schema).
+					if (xsiTypeNs != null && !foundXsiTypeChildren) {
+						Collection<CMElementDeclaration> possible = cmElement
+								.getPossibleElements(parentElement, request.getOffset());
+						for (CMElementDeclaration pe : possible) {
+							if (xsiTypeNs.equals(pe.getNamespace())) {
+								foundXsiTypeChildren = true;
+								break;
+							}
+						}
+					}
+				}
+			}
+			// Handle cross-namespace xsi:type only when the regular path
+			// did not already resolve the derived type's children.
+			if (!foundXsiTypeChildren && xsiTypeNs != null
+					&& !xsiTypeNs.equals(parentElement.getNamespaceURI())) {
+				Collection<CMDocument> xsiTypeDocs = contentModelManager.findCMDocument(
+						document, xsiTypeNs);
+				for (CMDocument cmDocument : xsiTypeDocs) {
+					Collection<CMElementDeclaration> derivedElements = cmDocument
+							.findXsiTypeDerivedElements(parentElement);
+					if (!derivedElements.isEmpty()) {
+						String xsiPrefix = parentElement.getPrefix(xsiTypeNs);
+						fillWithChildrenElementDeclaration(parentElement, null, derivedElements,
+								xsiPrefix, true, request, response);
+					}
 				}
 			}
 			if (parentElement.isDocumentElement()) {
@@ -486,5 +518,34 @@ public class ContentModelCompletionParticipant extends CompletionParticipantAdap
 	private static void addResolveData(ICompletionRequest request, CompletionItem item, String participantId) {
 		JsonObject data = DataEntryField.createCompletionData(request, participantId);
 		item.setData(data);
+	}
+
+	/**
+	 * Returns the namespace URI of the type referenced by the xsi:type attribute
+	 * on the given element, or null if there is no cross-namespace xsi:type.
+	 *
+	 * @param element the DOM element to inspect.
+	 * @return the namespace URI of the xsi:type value's prefix, or null.
+	 */
+	private static String getXsiTypeNamespace(DOMElement element) {
+		org.w3c.dom.NamedNodeMap attrs = element.getAttributes();
+		if (attrs == null) {
+			return null;
+		}
+		for (int i = 0; i < attrs.getLength(); i++) {
+			org.w3c.dom.Node attr = attrs.item(i);
+			if ("type".equals(attr.getLocalName())
+					&& XSISchemaModel.XSI_WEBSITE.equals(attr.getNamespaceURI())) {
+				String value = attr.getNodeValue();
+				if (value == null) {
+					return null;
+				}
+				int colonIndex = value.indexOf(':');
+				if (colonIndex != -1) {
+					return element.getNamespaceURI(value.substring(0, colonIndex));
+				}
+			}
+		}
+		return null;
 	}
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/contentmodel/CMXSDDocument.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/contentmodel/CMXSDDocument.java
@@ -179,15 +179,24 @@ public class CMXSDDocument implements CMDocument, XSElementDeclHelper {
 	@Override
 	public CMElementDeclaration findCMElement(DOMElement element, String namespace) {
 		List<DOMElement> paths = new ArrayList<>();
-		while (element != null && (namespace == null || namespace.equals(element.getNamespaceURI()))) {
-			paths.add(0, element);
-			element = element.getParentNode() instanceof DOMElement ? (DOMElement) element.getParentNode() : null;
+		DOMElement excludedParent = element;
+		while (excludedParent != null && (namespace == null || namespace.equals(excludedParent.getNamespaceURI()))) {
+			paths.add(0, excludedParent);
+			excludedParent = excludedParent.getParentNode() instanceof DOMElement
+					? (DOMElement) excludedParent.getParentNode()
+					: null;
 		}
 		CMXSDElementDeclaration declaration = null;
 		for (int i = 0; i < paths.size(); i++) {
 			DOMElement elt = paths.get(i);
 			if (i == 0) {
-				declaration = (CMXSDElementDeclaration) findElementDeclaration(elt.getLocalName(), namespace);
+				// When the parent has xsi:type, prefer resolving through the
+				// derived type's particles — the local element declaration
+				// carries the correct documentation and type information.
+				declaration = findCMElementFromXsiType(excludedParent, elt.getLocalName());
+				if (declaration == null) {
+					declaration = (CMXSDElementDeclaration) findElementDeclaration(elt.getLocalName(), namespace);
+				}
 			} else {
 				declaration = (CMXSDElementDeclaration) declaration.findCMElement(elt.getLocalName(), namespace);
 			}
@@ -210,6 +219,87 @@ public class CMXSDDocument implements CMDocument, XSElementDeclHelper {
 			}
 		}
 		return declaration;
+	}
+
+	/**
+	 * When the element's parent is in a different namespace and has an xsi:type
+	 * attribute, resolve the derived type and find the child element declaration
+	 * within it.
+	 *
+	 * @param xsiTypeParent the parent element with xsi:type (may be null).
+	 * @param childName     the local name of the child element to find.
+	 * @return the element declaration, or null if not found.
+	 */
+	private CMXSDElementDeclaration findCMElementFromXsiType(DOMElement xsiTypeParent, String childName) {
+		if (xsiTypeParent == null) {
+			return null;
+		}
+		XSTypeDefinition xsiType = findXsiType(xsiTypeParent);
+		if (xsiType == null || xsiType.getTypeCategory() != XSTypeDefinition.COMPLEX_TYPE) {
+			return null;
+		}
+		XSParticle particle = ((XSComplexTypeDefinition) xsiType).getParticle();
+		if (particle == null) {
+			return null;
+		}
+		XSElementDeclaration elemDecl = findElementInParticle(particle, childName);
+		if (elemDecl != null) {
+			return (CMXSDElementDeclaration) getXSDElement(elemDecl);
+		}
+		return null;
+	}
+
+	/**
+	 * Returns all child element declarations from the xsi:type-derived complex
+	 * type. Used by completion to propose child elements when the parent element
+	 * uses an xsi:type from a different namespace.
+	 */
+	@Override
+	public Collection<CMElementDeclaration> findXsiTypeDerivedElements(DOMElement element) {
+		XSTypeDefinition xsiType = findXsiType(element);
+		if (xsiType == null || xsiType.getTypeCategory() != XSTypeDefinition.COMPLEX_TYPE) {
+			return Collections.emptyList();
+		}
+		XSParticle particle = ((XSComplexTypeDefinition) xsiType).getParticle();
+		if (particle == null) {
+			return Collections.emptyList();
+		}
+		Collection<CMElementDeclaration> elements = new ArrayList<>();
+		collectElementsFromParticle(particle, elements);
+		return elements;
+	}
+
+	/**
+	 * Recursively collects all element declarations from the given particle tree.
+	 */
+	private void collectElementsFromParticle(XSParticle particle, Collection<CMElementDeclaration> elements) {
+		XSTerm term = particle.getTerm();
+		if (term.getType() == XSConstants.ELEMENT_DECLARATION) {
+			elements.add(getXSDElement((XSElementDeclaration) term));
+		} else if (term.getType() == XSConstants.MODEL_GROUP) {
+			XSObjectList particles = ((XSModelGroup) term).getParticles();
+			for (int i = 0; i < particles.getLength(); i++) {
+				collectElementsFromParticle((XSParticle) particles.item(i), elements);
+			}
+		}
+	}
+
+	private static XSElementDeclaration findElementInParticle(XSParticle particle, String name) {
+		XSTerm term = particle.getTerm();
+		if (term.getType() == XSConstants.ELEMENT_DECLARATION) {
+			if (name.equals(((XSElementDeclaration) term).getName())) {
+				return (XSElementDeclaration) term;
+			}
+		} else if (term.getType() == XSConstants.MODEL_GROUP) {
+			XSObjectList particles = ((XSModelGroup) term).getParticles();
+			for (int i = 0; i < particles.getLength(); i++) {
+				XSElementDeclaration found = findElementInParticle((XSParticle) particles.item(i), name);
+				if (found != null) {
+					return found;
+				}
+			}
+		}
+		return null;
 	}
 
 	private XSTypeDefinition findXsiType(DOMElement element) {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaCompletionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaCompletionExtensionsTest.java
@@ -1684,6 +1684,55 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				c("derivedProp", "<derivedProp></derivedProp>"));
 	}
 
+	/**
+	 * See https://github.com/eclipse-lemminx/lemminx/issues/1787
+	 *
+	 * Test completion inside xsi:type-derived types across namespaces,
+	 * with both a:ADerived and b:BDerived blocks present.
+	 */
+	@Test
+	public void xsiTypeDerivedChildCompletionAcrossNamespaces() throws BadLocationException {
+		XMLLanguageService xmlLanguageService = new XMLLanguageService();
+
+		// Completion inside <m:Data xsi:type="a:ADerived"> should suggest a:Title — with both blocks
+		String xmlA = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + //
+				"<m:Root xmlns:m=\"http://main\"\n" + //
+				"        xmlns:a=\"http://a\"\n" + //
+				"        xmlns:b=\"http://b\"\n" + //
+				"        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" + //
+				"        xsi:schemaLocation=\"http://main main.xsd\">\n" + //
+				"  <m:Data xsi:type=\"a:ADerived\">\n" + //
+				"    <|\n" + //
+				"  </m:Data>\n" + //
+				"  <m:Data xsi:type=\"b:BDerived\">\n" + //
+				"    <b:Title/>\n" + //
+				"  </m:Data>\n" + //
+				"</m:Root>";
+		testCompletionFor(xmlLanguageService, xmlA, null, null,
+				"src/test/resources/xsd/xsi-type-derived/test.xml",
+				1 + 4 /* CDATA and Comments */, true,
+				c("a:Title", "<a:Title></a:Title>"));
+
+		// Completion inside <m:Data xsi:type="b:BDerived"> should suggest b:Title — with both blocks
+		String xmlB = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + //
+				"<m:Root xmlns:m=\"http://main\"\n" + //
+				"        xmlns:a=\"http://a\"\n" + //
+				"        xmlns:b=\"http://b\"\n" + //
+				"        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" + //
+				"        xsi:schemaLocation=\"http://main main.xsd\">\n" + //
+				"  <m:Data xsi:type=\"a:ADerived\">\n" + //
+				"    <a:Title/>\n" + //
+				"  </m:Data>\n" + //
+				"  <m:Data xsi:type=\"b:BDerived\">\n" + //
+				"    <|\n" + //
+				"  </m:Data>\n" + //
+				"</m:Root>";
+		testCompletionFor(xmlLanguageService, xmlB, null, null,
+				"src/test/resources/xsd/xsi-type-derived/test.xml",
+				1 + 4 /* CDATA and Comments */, true,
+				c("b:Title", "<b:Title></b:Title>"));
+	}
+
 	// Tests for https://github.com/redhat-developer/vscode-xml/issues/1079
 
 	@Test

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaHoverExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaHoverExtensionsTest.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.lemminx.extensions.contentmodel;
 
+import static org.eclipse.lemminx.XMLAssert.assertHover;
 import static org.eclipse.lemminx.XMLAssert.r;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -26,7 +27,9 @@ import org.eclipse.lemminx.dom.DOMElement;
 import org.eclipse.lemminx.dom.DOMNode;
 import org.eclipse.lemminx.dom.DOMText;
 import org.eclipse.lemminx.dom.LineIndentInfo;
+import org.eclipse.lemminx.extensions.contentmodel.model.ContentModelManager;
 import org.eclipse.lemminx.extensions.contentmodel.participants.ContentModelHoverParticipant;
+import org.eclipse.lemminx.extensions.contentmodel.settings.ContentModelSettings;
 import org.eclipse.lemminx.extensions.xsi.XSISchemaModel;
 import org.eclipse.lemminx.services.XMLLanguageService;
 import org.eclipse.lemminx.services.extensions.hover.IHoverRequest;
@@ -458,6 +461,66 @@ public class XMLSchemaHoverExtensionsTest extends AbstractCacheBasedTest {
 						System.lineSeparator() + //
 						System.lineSeparator() + "Source: [xsitype-ns.xsd](" + schemaURI + ")", //
 				r(4, 5, 4, 16));
+	}
+
+	/**
+	 * See https://github.com/eclipse-lemminx/lemminx/issues/1787
+	 *
+	 * Test hover on child elements inside xsi:type-derived types across
+	 * namespaces, with both a:ADerived and b:BDerived blocks present
+	 * in the same document.
+	 */
+	@Test
+	public void testHoverXSITypeDerivedChildAcrossNamespaces() throws BadLocationException, MalformedURIException {
+		String aSchemaURI = getXMLSchemaFileURI("xsi-type-derived/a.xsd");
+		String bSchemaURI = getXMLSchemaFileURI("xsi-type-derived/b.xsd");
+
+		XMLLanguageService xmlLanguageService = new XMLLanguageService();
+		ContentModelSettings settings = new ContentModelSettings();
+		settings.setUseCache(true);
+
+		// Hover on <a:Title> inside xsi:type="a:ADerived" — with both Data blocks present
+		// Only main.xsd is in schemaLocation; a.xsd and b.xsd are transitively imported
+		String xmlA = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + //
+				"<m:Root xmlns:m=\"http://main\"\n" + //
+				"        xmlns:a=\"http://a\"\n" + //
+				"        xmlns:b=\"http://b\"\n" + //
+				"        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" + //
+				"        xsi:schemaLocation=\"http://main main.xsd\">\n" + //
+				"  <m:Data xsi:type=\"a:ADerived\">\n" + //
+				"    <a:Tit|le/>\n" + //
+				"  </m:Data>\n" + //
+				"  <m:Data xsi:type=\"b:BDerived\">\n" + //
+				"    <b:Title/>\n" + //
+				"  </m:Data>\n" + //
+				"</m:Root>";
+		XMLAssert.assertHover(xmlLanguageService, xmlA, null,
+				"src/test/resources/xsd/xsi-type-derived/test.xml",
+				"Documentation for Title from namespace a" + //
+						System.lineSeparator() + //
+						System.lineSeparator() + "Source: [a.xsd](" + aSchemaURI + ")",
+				r(7, 5, 7, 12), settings);
+
+		// Hover on <b:Title> inside xsi:type="b:BDerived" — with both Data blocks present
+		String xmlB = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + //
+				"<m:Root xmlns:m=\"http://main\"\n" + //
+				"        xmlns:a=\"http://a\"\n" + //
+				"        xmlns:b=\"http://b\"\n" + //
+				"        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" + //
+				"        xsi:schemaLocation=\"http://main main.xsd\">\n" + //
+				"  <m:Data xsi:type=\"a:ADerived\">\n" + //
+				"    <a:Title/>\n" + //
+				"  </m:Data>\n" + //
+				"  <m:Data xsi:type=\"b:BDerived\">\n" + //
+				"    <b:Tit|le/>\n" + //
+				"  </m:Data>\n" + //
+				"</m:Root>";
+		XMLAssert.assertHover(xmlLanguageService, xmlB, null,
+				"src/test/resources/xsd/xsi-type-derived/test.xml",
+				"Documentation for Title from namespace b" + //
+						System.lineSeparator() + //
+						System.lineSeparator() + "Source: [b.xsd](" + bSchemaURI + ")",
+				r(10, 5, 10, 12), settings);
 	}
 
 	private static void assertHover(String value, String expectedHoverLabel, Range expectedHoverRange)

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaTypeDefinitionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaTypeDefinitionExtensionsTest.java
@@ -211,4 +211,55 @@ public class XMLSchemaTypeDefinitionExtensionsTest extends AbstractCacheBasedTes
 				ll(targetSchemaURI, r(4, 5, 4, 16), r(21, 37, 21, 50)));
 	}
 
+	/**
+	 * See https://github.com/eclipse-lemminx/lemminx/issues/1787
+	 *
+	 * Test type definition on child elements inside xsi:type-derived types
+	 * across namespaces, with both a:ADerived and b:BDerived blocks present.
+	 */
+	@Test
+	public void xsiTypeDerivedChildAcrossNamespacesTypeDefinition() throws BadLocationException, MalformedURIException {
+		String xmlFile = "src/test/resources/xsd/xsi-type-derived/test.xml";
+		String aSchemaURI = XMLEntityManager.expandSystemId("xsd/xsi-type-derived/a.xsd",
+				"src/test/resources/test.xml", true);
+		String bSchemaURI = XMLEntityManager.expandSystemId("xsd/xsi-type-derived/b.xsd",
+				"src/test/resources/test.xml", true);
+
+		XMLLanguageService xmlLanguageService = new XMLLanguageService();
+
+		// Type definition on <a:Title> inside xsi:type="a:ADerived" — with both blocks
+		String xmlA = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + //
+				"<m:Root xmlns:m=\"http://main\"\n" + //
+				"        xmlns:a=\"http://a\"\n" + //
+				"        xmlns:b=\"http://b\"\n" + //
+				"        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" + //
+				"        xsi:schemaLocation=\"http://main main.xsd\">\n" + //
+				"  <m:Data xsi:type=\"a:ADerived\">\n" + //
+				"    <a:Tit|le/>\n" + //
+				"  </m:Data>\n" + //
+				"  <m:Data xsi:type=\"b:BDerived\">\n" + //
+				"    <b:Title/>\n" + //
+				"  </m:Data>\n" + //
+				"</m:Root>";
+		testTypeDefinitionFor(xmlLanguageService, xmlA, xmlFile,
+				ll(aSchemaURI, r(7, 5, 7, 12), r(12, 37, 12, 44)));
+
+		// Type definition on <b:Title> inside xsi:type="b:BDerived" — with both blocks
+		String xmlB = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + //
+				"<m:Root xmlns:m=\"http://main\"\n" + //
+				"        xmlns:a=\"http://a\"\n" + //
+				"        xmlns:b=\"http://b\"\n" + //
+				"        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" + //
+				"        xsi:schemaLocation=\"http://main main.xsd\">\n" + //
+				"  <m:Data xsi:type=\"a:ADerived\">\n" + //
+				"    <a:Title/>\n" + //
+				"  </m:Data>\n" + //
+				"  <m:Data xsi:type=\"b:BDerived\">\n" + //
+				"    <b:Tit|le/>\n" + //
+				"  </m:Data>\n" + //
+				"</m:Root>";
+		testTypeDefinitionFor(xmlLanguageService, xmlB, xmlFile,
+				ll(bSchemaURI, r(10, 5, 10, 12), r(12, 37, 12, 44)));
+	}
+
 }

--- a/org.eclipse.lemminx/src/test/resources/xsd/xsi-type-derived/a.xsd
+++ b/org.eclipse.lemminx/src/test/resources/xsd/xsi-type-derived/a.xsd
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://a"
+           xmlns:base="http://base"
+           elementFormDefault="qualified">
+
+    <xs:import namespace="http://base" schemaLocation="base.xsd"/>
+
+    <xs:complexType name="ADerived">
+        <xs:complexContent>
+            <xs:extension base="base:DataType">
+                <xs:sequence>
+                    <xs:element name="Title">
+                        <xs:annotation>
+                            <xs:documentation>Documentation for Title from namespace a</xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+</xs:schema>

--- a/org.eclipse.lemminx/src/test/resources/xsd/xsi-type-derived/b.xsd
+++ b/org.eclipse.lemminx/src/test/resources/xsd/xsi-type-derived/b.xsd
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://b"
+           xmlns:base="http://base"
+           elementFormDefault="qualified">
+
+    <xs:import namespace="http://base" schemaLocation="base.xsd"/>
+
+    <xs:complexType name="BDerived">
+        <xs:complexContent>
+            <xs:extension base="base:DataType">
+                <xs:sequence>
+                    <xs:element name="Title">
+                        <xs:annotation>
+                            <xs:documentation>Documentation for Title from namespace b</xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+</xs:schema>

--- a/org.eclipse.lemminx/src/test/resources/xsd/xsi-type-derived/base.xsd
+++ b/org.eclipse.lemminx/src/test/resources/xsd/xsi-type-derived/base.xsd
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://base"
+           elementFormDefault="qualified">
+
+    <xs:complexType name="DataType">
+        <xs:annotation>
+            <xs:documentation>Base Data type documentation</xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+</xs:schema>

--- a/org.eclipse.lemminx/src/test/resources/xsd/xsi-type-derived/main.xsd
+++ b/org.eclipse.lemminx/src/test/resources/xsd/xsi-type-derived/main.xsd
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://main"
+           xmlns:tns="http://main"
+           xmlns:base="http://base"
+           elementFormDefault="qualified">
+
+    <xs:import namespace="http://base" schemaLocation="base.xsd"/>
+    <xs:import namespace="http://a" schemaLocation="a.xsd"/>
+    <xs:import namespace="http://b" schemaLocation="b.xsd"/>
+
+    <xs:element name="Root" type="tns:RootType"/>
+
+    <xs:complexType name="RootType">
+        <xs:sequence>
+            <xs:element name="Data" type="base:DataType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+</xs:schema>

--- a/org.eclipse.lemminx/src/test/resources/xsd/xsi-type-derived/test.xml
+++ b/org.eclipse.lemminx/src/test/resources/xsd/xsi-type-derived/test.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<m:Root xmlns:m="http://main"
+        xmlns:a="http://a"
+        xmlns:b="http://b"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://main main.xsd">
+    <m:Data xsi:type="a:ADerived">
+        <a:Title/>
+    </m:Data>
+    <m:Data xsi:type="b:BDerived">
+        <b:Title/>
+    </m:Data>
+</m:Root>


### PR DESCRIPTION
Fix: hover, completion and type definition for xsi:type-derived children across namespaces

Fixes #1787

Here a demo:

<img width="939" height="489" alt="XSDMultiNs" src="https://github.com/user-attachments/assets/b2de47b6-a7d2-4c83-9b96-eac0692d4558" />

