### PR TITLE
Fix: improve error range for xsd(src-ct.2.1)

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/participants/XSDErrorCode.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/participants/XSDErrorCode.java
@@ -56,6 +56,7 @@ public enum XSDErrorCode implements IXMLErrorCode {
 	sch_props_correct_2("sch-props-correct.2"), //
 	schema_reference_4("schema_reference.4"), //
 	src_ct_1("src-ct.1"), //
+	src_ct_2_1("src-ct.2.1"), //
 	src_import_1_2("src-import.1.2"), //
 	src_element_3("src-element.3"), //
 	src_resolve_4_2("src-resolve.4.2"), //
@@ -158,6 +159,7 @@ public enum XSDErrorCode implements IXMLErrorCode {
 			return XMLPositionUtility.selectAttributeValueFromGivenValue(attrName, offset, document);
 		}
 		case src_ct_1:
+		case src_ct_2_1:
 			return XMLPositionUtility.selectAttributeValueAt("base", offset, document);
 		case src_resolve_4_2: {
 			String attrValue = getString(arguments[2]);

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDValidationExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDValidationExtensionsTest.java
@@ -270,6 +270,22 @@ public class XSDValidationExtensionsTest extends AbstractCacheBasedTest {
 	}
 
 	@Test
+	public void src_ct_2_1() throws BadLocationException {
+		String xml = "<?xml version=\"1.1\" ?>\r\n" + //
+				"<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\r\n" + //
+				"	<xs:element name=\"childA\">\r\n" + //
+				"		<xs:complexType>\r\n" + //
+				"			<xs:simpleContent>\r\n" + //
+				"				<xs:restriction base=\"xs:string\" />\r\n" + //
+				"			</xs:simpleContent>\r\n" + //
+				"			<xs:attributeGroup ref=\"\" />\r\n" + //
+				"		</xs:complexType>\r\n" + //
+				"	</xs:element>\r\n" + //
+				"</xs:schema>";
+		testDiagnosticsFor(xml, d(5, 25, 5, 36, XSDErrorCode.src_ct_2_1));
+	}
+
+	@Test
 	public void src_resolve() throws BadLocationException {
 		String xml = "<?xml version=\"1.1\"?>\r\n" + //
 				"<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\r\n" + //


### PR DESCRIPTION
Fix: improve error range for xsd(src-ct.2.1)

Fixes #1269

Highlight the base attribute value instead of the default end-of-line range, so the user can immediately see which base type is invalid.

<img width="889" height="324" alt="image" src="https://github.com/user-attachments/assets/32fa6a5d-5394-41de-a985-dd4961d34309" />
