### PR TITLE
Fix: handle Xerces NPE for empty element name in XSD validation

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/participants/diagnostics/XSDValidator.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/participants/diagnostics/XSDValidator.java
@@ -109,6 +109,9 @@ public class XSDValidator {
 			grammarPreparser.preparseGrammar(XMLGrammarDescription.XML_SCHEMA, source);
 		} catch (IOException | CancellationException | XMLParseException exception) {
 			// ignore error
+		} catch (NullPointerException e) {
+			// Xerces can throw NPE for invalid XSD constructs
+			// (ex: empty element name), see issue #437
 		} catch (Exception e) {
 			LOGGER.log(Level.SEVERE, "Unexpected XSDValidator error", e);
 		} finally {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDValidationExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDValidationExtensionsTest.java
@@ -201,6 +201,22 @@ public class XSDValidationExtensionsTest extends AbstractCacheBasedTest {
 	}
 
 	@Test
+	public void emptyElementNameNoNPE() throws BadLocationException {
+		// Test for https://github.com/eclipse-lemminx/lemminx/issues/437
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + //
+				"<xs:schema \r\n" + //
+				"	xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\r\n" + //
+				"	<xs:complexType name=\"testType\">\r\n" + //
+				"		<xs:all>\r\n" + //
+				"			<xs:element name=\"\" minOccurs=\"1\" maxOccurs=\"2\" type=\"xs:string\"/>\r\n" + //
+				"		</xs:all>\r\n" + //
+				"	</xs:complexType>\r\n" + //
+				"</xs:schema>";
+		testDiagnosticsFor(xml, d(5, 20, 5, 22, XSDErrorCode.s4s_att_invalid_value),
+				d(5, 4, 5, 14, XSDErrorCode.src_element_2_1));
+	}
+
+	@Test
 	public void s4s_elt_invalid_content_3WithClosingTag() throws BadLocationException {
 		String xml = "<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" elementFormDefault=\"qualified\">\r\n" + //
 				"	<xs:element name=\"project\" type=\"xs:string\"></xs:element>\r\n" + //


### PR DESCRIPTION
Fix: handle Xerces NPE for empty element name in XSD validation

Fixes #437

Xerces throws NPE in XSDAbstractTraverser.checkOccurrences when an
xs:element has an empty name="" attribute inside xs:all. Catch the
NPE gracefully so diagnostics collected before the crash are still
reported.